### PR TITLE
Upgrade FuseOpen.Xamarin.Mac package to 3.4.0.2

### DIFF
--- a/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
+++ b/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition=" ('$(OS)' == 'Unix') And Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props') " Project="..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props" />
+  <Import Project="..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props" Condition="Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,8 +43,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Condition=" '$(OS)' == 'Unix' " Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\lib\net45\Xamarin.Mac.dll</HintPath>
+    <Reference Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\lib\net45\Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -147,6 +147,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props'))" />
   </Target>
 </Project>

--- a/src/engine/Uno.Build.Targets/packages.config
+++ b/src/engine/Uno.Build.Targets/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FuseOpen.Xamarin.Mac" version="3.4.0" targetFramework="net45" />
+  <package id="FuseOpen.Xamarin.Mac" version="3.4.0.2" targetFramework="net45" />
 </packages>

--- a/src/runtime/Uno.AppLoader-MonoMac/Uno.AppLoader-MonoMac.csproj
+++ b/src/runtime/Uno.AppLoader-MonoMac/Uno.AppLoader-MonoMac.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props" Condition="Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props')" />
+  <Import Project="..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props" Condition="Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -43,13 +43,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\lib\net45\OpenTK.dll</HintPath>
+      <HintPath>..\..\..\packages\FuseOpen.Xamarin.OpenTK.3.4.0.2\lib\net45\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\lib\net45\Xamarin.Mac.dll</HintPath>
+      <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\lib\net45\Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -117,6 +117,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0\build\net45\FuseOpen.Xamarin.Mac.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\build\net45\FuseOpen.Xamarin.Mac.props'))" />
   </Target>
 </Project>

--- a/src/runtime/Uno.AppLoader-MonoMac/packages.config
+++ b/src/runtime/Uno.AppLoader-MonoMac/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FuseOpen.Xamarin.Mac" version="3.4.0" targetFramework="net45" />
+  <package id="FuseOpen.Xamarin.Mac" version="3.4.0.2" targetFramework="net45" />
+  <package id="FuseOpen.Xamarin.OpenTK" version="3.4.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is to avoid getting a reference to `OpenTK.dll` distributed with `Xamarin.Mac` from `Uno.Build.Targets`, since it could possibly overwrite the other `OpenTK.dll` from the OpenTK 2.0 package.