### PR TITLE
Add elements insisted upon by VS to test .csprojs

### DIFF
--- a/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
@@ -55,6 +55,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/ux/Uno.UX.Markup.UXIL/Tests/Uno.UX.Markup.UXIL.Tests.csproj
+++ b/src/ux/Uno.UX.Markup.UXIL/Tests/Uno.UX.Markup.UXIL.Tests.csproj
@@ -83,6 +83,9 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
VS 2017 writes some entries to two of the `.csproj` files every time I open the solution. I can't see any harm in just committing it once and for all to avoid the annoyance of having to exclude it every time I commit. :)