### PR TITLE
appveyor: build using VS2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+image: Visual Studio 2017
 
 environment:
   matrix:
@@ -11,6 +12,7 @@ install:
         Invoke-WebRequest https://files.fusetools.com/tooling/iyVp8kwQ0vLn-mesa-17.2.3.500.zip -OutFile mesa.zip
         Expand-Archive mesa.zip mesa
       }
+  - choco install vswhere
 
 build_script:
   - nuget restore uno-win32.sln


### PR DESCRIPTION
Visual Studio 2017 is the latest and greatest, and it'd be nice if we used the same version for all Fuse-projects. So let's build with VS2017 in AppVeyor as well.