### PR TITLE
Add .csproj rule to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_style = space
 indent_size = 4
 
-[*.{json,unoproj}]
+[*.{json,unoproj,csproj}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
This is the default whitespace style used in VS