### PR TITLE
Fix pack script versioning

### DIFF
--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -33,6 +33,15 @@ if [ -n "$SUFFIX" ]; then
     VERSION="$VERSION-$SUFFIX"
 fi
 
+# Extract the X.Y.Z part of version, removing the suffix if any
+VERSION_TRIPLET=`echo $VERSION | sed -n -e 's/\([^-]*\).*/\1/p'`
+
+# Start with updating the local GlobalAssemblyInfo.Override.cs
+sed -e 's/\(AssemblyVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET'\2/' \
+      -e 's/\(AssemblyFileVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET'\2/' \
+      -e 's/\(AssemblyInformationalVersion("\)[^"]*\(")\)/\1'$VERSION'\2/' \
+      src/GlobalAssemblyInfo.cs > src/GlobalAssemblyInfo.Override.cs
+
 # Build
 if [ "$1" != --no-build ]; then
     bash scripts/build.sh --release; echo ""
@@ -95,3 +104,6 @@ for f in Library/Core/*; do
             $SUFFIX_OPT
     fi
 done
+
+# Remove GlobalAssemblyInfo Override
+rm -f src/GlobalAssemblyInfo.Override.cs

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -100,6 +100,7 @@ for f in Library/Core/*; do
     PROJECT=$f/$NAME.unoproj
     if [ -f "$PROJECT" ]; then
         uno pack $PROJECT \
+            --version $VERSION_TRIPLET \
             --out-dir $OUT \
             $SUFFIX_OPT
     fi

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+GlobalAssemblyInfo.Override.cs

--- a/src/GlobalAssemblyInfo.targets
+++ b/src/GlobalAssemblyInfo.targets
@@ -1,0 +1,10 @@
+<Project ToolsVersion="14.0" DefaultTargets="Compile" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Condition="!Exists('$(MSBuildThisFileDirectory)\GlobalAssemblyInfo.Override.cs')" Include="$(MSBuildThisFileDirectory)\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Condition="Exists('$(MSBuildThisFileDirectory)\GlobalAssemblyInfo.Override.cs')" Include="$(MSBuildThisFileDirectory)\GlobalAssemblyInfo.Override.cs">
+      <Link>Properties\GlobalAssemblyInfo.Override.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/src/common/Uno.Common/Uno.Common.csproj
+++ b/src/common/Uno.Common/Uno.Common.csproj
@@ -36,10 +36,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="CLI\Arguments.cs" />
     <Compile Include="CLI\Command.cs" />
     <Compile Include="CLI\DotNetCommand.cs" />

--- a/src/compiler/Uno.Compiler.API/Uno.Compiler.API.csproj
+++ b/src/compiler/Uno.Compiler.API/Uno.Compiler.API.csproj
@@ -35,10 +35,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Backends\BackendExtension.cs" />
     <Compile Include="Backends\Shaders\ShaderPass.cs" />
     <Compile Include="CompilerFactory.cs" />

--- a/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.csproj
@@ -48,10 +48,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AppLoader.cs" />
     <Compile Include="CilBackend.cs" />
     <Compile Include="CilGenerator.Generate.cs" />

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.csproj
@@ -38,10 +38,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="CallFlags.cs" />
     <Compile Include="CppBackend.cs" />
     <Compile Include="CppFinallyTransform.cs" />

--- a/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.csproj
@@ -35,10 +35,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="CsBackend.cs" />
     <Compile Include="CsWriter.cs" />
     <Compile Include="CsBackend.GenerateProject.cs" />

--- a/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.csproj
+++ b/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.csproj
@@ -37,10 +37,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="JsBackend.cs" />
     <Compile Include="JsHelper.cs" />
     <Compile Include="JsObfuscator.cs" />

--- a/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.csproj
+++ b/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.csproj
@@ -35,10 +35,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="GlslWriter.cs" />
     <Compile Include="GLBackend.cs" />
     <Compile Include="GLGenerator.cs" />

--- a/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
+++ b/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
@@ -29,10 +29,8 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="PInvokeDecompiler.cs" />
     <Compile Include="PInvokeBackend.cs" />
     <Compile Include="PInvokeWriter.cs" />

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
@@ -43,10 +43,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Builders\AttachedMemberCache.cs" />
     <Compile Include="Builders\AttachedUxEvent.cs" />
     <Compile Include="Builders\AttachedUxEventEqualityComparer.cs" />

--- a/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.csproj
+++ b/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.csproj
@@ -41,10 +41,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Compiler.cs" />
     <Compile Include="BuildEnvironment.cs" />
     <Compile Include="CompilerOptions.cs" />

--- a/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
+++ b/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
@@ -37,10 +37,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="CppExtension.cs" />
     <Compile Include="Foreign\ForeignCPlusPlusPass.cs" />
     <Compile Include="Foreign\ForeignFilePass.cs" />

--- a/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.csproj
+++ b/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.csproj
@@ -36,10 +36,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Analysis\Associativity.cs" />
     <Compile Include="Analysis\MessageType.cs" />
     <Compile Include="Analysis\Precedence.cs" />

--- a/src/disasm/Uno.Disasm-WPF/Uno.Disasm-WPF.csproj
+++ b/src/disasm/Uno.Disasm-WPF/Uno.Disasm-WPF.csproj
@@ -65,10 +65,8 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="TreeState.cs" />
     <Page Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/disasm/Uno.Disasm/Uno.Disasm.csproj
+++ b/src/disasm/Uno.Disasm/Uno.Disasm.csproj
@@ -34,10 +34,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Disassemblers\BytecodeDisassembler.cs" />
     <Compile Include="Disassembler.cs" />
     <Compile Include="Disassemblers\UnoDisassembler.cs" />

--- a/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
+++ b/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
@@ -47,10 +47,8 @@
       <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\lib\net45\Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Android\AndroidBuild.cs" />
     <Compile Include="Android\AndroidGenerator.cs" />
     <Compile Include="Browser\WebServer.cs" />

--- a/src/engine/Uno.Build/Uno.Build.csproj
+++ b/src/engine/Uno.Build/Uno.Build.csproj
@@ -67,10 +67,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="BuildConfiguration.cs" />
     <Compile Include="BuildDriver.cs" />
     <Compile Include="BuildFile.cs" />

--- a/src/engine/Uno.Configuration/Uno.Configuration.csproj
+++ b/src/engine/Uno.Configuration/Uno.Configuration.csproj
@@ -34,10 +34,8 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="UnoConfigFile.cs" />
     <Compile Include="UnoConfig.cs" />
     <Compile Include="UnoConfigString.cs" />

--- a/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
+++ b/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
@@ -47,10 +47,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="GlobList.cs" />
     <Compile Include="IncludeGlobber.cs" />
     <Compile Include="IncludeItem.cs" />

--- a/src/engine/Uno.Stuff/Uno.Stuff.csproj
+++ b/src/engine/Uno.Stuff/Uno.Stuff.csproj
@@ -44,10 +44,8 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Arguments.cs" />
     <Compile Include="Commands\Clean.cs" />
     <Compile Include="Commands\GC.cs" />

--- a/src/main/Uno.CLI.Loader/Uno.CLI.Loader.csproj
+++ b/src/main/Uno.CLI.Loader/Uno.CLI.Loader.csproj
@@ -34,10 +34,8 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/main/Uno.CLI.Main/Uno.CLI.Main.csproj
+++ b/src/main/Uno.CLI.Main/Uno.CLI.Main.csproj
@@ -38,10 +38,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/main/Uno.CLI/Uno.CLI.csproj
+++ b/src/main/Uno.CLI/Uno.CLI.csproj
@@ -39,10 +39,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Android\AdbDevice.cs" />
     <Compile Include="Android\Android.cs" />
     <Compile Include="Android\Adb.cs" />

--- a/src/runtime/Uno.AppLoader-Console/Uno.Apploader-Console.csproj
+++ b/src/runtime/Uno.AppLoader-Console/Uno.Apploader-Console.csproj
@@ -37,10 +37,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/runtime/Uno.AppLoader-MonoMac/Uno.AppLoader-MonoMac.csproj
+++ b/src/runtime/Uno.AppLoader-MonoMac/Uno.AppLoader-MonoMac.csproj
@@ -52,10 +52,8 @@
       <HintPath>..\..\..\packages\FuseOpen.Xamarin.Mac.3.4.0.2\lib\net45\Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="DummyUnoApp.cs" />
     <Compile Include="Program.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/src/runtime/Uno.AppLoader-WinForms/Uno.AppLoader-WinForms.csproj
+++ b/src/runtime/Uno.AppLoader-WinForms/Uno.AppLoader-WinForms.csproj
@@ -51,10 +51,8 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="Microsoft.Ink" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="DpiAwareness.cs" />
     <Compile Include="DummyApp.cs" />
     <Compile Include="MainForm.cs">

--- a/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
+++ b/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
@@ -36,10 +36,8 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="OpenGL\GL.cs" />
     <Compile Include="OpenGL\GLBlendEquation.cs" />
     <Compile Include="OpenGL\GLBlendingFactor.cs" />

--- a/src/runtime/Uno.Support.OpenTK/Uno.Support.OpenTK.csproj
+++ b/src/runtime/Uno.Support.OpenTK/Uno.Support.OpenTK.csproj
@@ -40,10 +40,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="BufferDisposable.cs" />
     <Compile Include="TextureDisposable.cs" />
     <Compile Include="FramebufferDisposable.cs" />

--- a/src/testing/Uno.CompilerTestRunner/Uno.CompilerTestRunner.csproj
+++ b/src/testing/Uno.CompilerTestRunner/Uno.CompilerTestRunner.csproj
@@ -40,10 +40,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="ErrorItem.cs" />
     <Compile Include="ErrorItemComparer.cs" />
     <Compile Include="ErrorType.cs" />

--- a/src/testing/Uno.TestGenerator/Uno.TestGenerator.csproj
+++ b/src/testing/Uno.TestGenerator/Uno.TestGenerator.csproj
@@ -40,10 +40,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/src/testing/Uno.TestRunner.BasicTypes/Uno.TestRunner.BasicTypes.csproj
+++ b/src/testing/Uno.TestRunner.BasicTypes/Uno.TestRunner.BasicTypes.csproj
@@ -38,10 +38,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Assertion.cs" />
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="Test.cs" />

--- a/src/testing/Uno.TestRunner.CLI/Uno.TestRunner.CLI.csproj
+++ b/src/testing/Uno.TestRunner.CLI/Uno.TestRunner.CLI.csproj
@@ -35,10 +35,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="UnoTestClient.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/testing/Uno.TestRunner.Loggers/Uno.TestRunner.Loggers.csproj
+++ b/src/testing/Uno.TestRunner.Loggers/Uno.TestRunner.Loggers.csproj
@@ -33,10 +33,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AbstractLogger.cs" />
     <Compile Include="ColorHelper.cs" />
     <Compile Include="ConsoleLogger.cs" />

--- a/src/testing/Uno.TestRunner.Tests/Uno.TestRunner.Tests.csproj
+++ b/src/testing/Uno.TestRunner.Tests/Uno.TestRunner.Tests.csproj
@@ -34,10 +34,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="TestRunTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/testing/Uno.TestRunner/Uno.TestRunner.csproj
+++ b/src/testing/Uno.TestRunner/Uno.TestRunner.csproj
@@ -34,10 +34,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="HttpHelpers.cs" />
     <Compile Include="ProjectDiscoverer.cs" />
     <Compile Include="HTTPTestCommunicator.cs" />

--- a/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
@@ -37,10 +37,8 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Generator.cs" />
     <Compile Include="Node.cs" />
     <Compile Include="Parser.cs" />

--- a/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
+++ b/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
@@ -33,10 +33,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="CodeGenerator.cs" />
     <Compile Include="UXProcessor.cs" />
     <Compile Include="Scope.cs" />

--- a/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
+++ b/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
@@ -36,10 +36,8 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AtomicValue.cs" />
     <Compile Include="AtomicValueParser.cs" />
     <Compile Include="Attributes.cs" />

--- a/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
+++ b/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
@@ -36,10 +36,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AttachedPropertyRegistry.cs" />
     <Compile Include="CompilerReflection.cs" />
     <Compile Include="Helpers.cs" />

--- a/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.csproj
+++ b/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.csproj
@@ -33,10 +33,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Reflection.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.csproj
+++ b/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.csproj
@@ -35,10 +35,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
-    <Compile Include="..\..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Expressions\Lexer\Lexer.cs" />
     <Compile Include="Expressions\Lexer\LexerBuilder.cs" />
     <Compile Include="Expressions\Lexer\Token.cs" />


### PR DESCRIPTION
This makes sure the assembly attributes has the correct version numbers for a build, and also fixes the issue with `.upk` packages having version 0.0.0.