### PR TITLE
Setup nuget packaging

### DIFF
--- a/Library/Core/UnoCore/Targets/DotNet/Executable.uxl
+++ b/Library/Core/UnoCore/Targets/DotNet/Executable.uxl
@@ -32,7 +32,7 @@
 
     <!-- macOS bundle -->
     <ProcessFile Name="@(AppDirectory)/Contents/Info.plist" Condition="HOST_MAC" />    
-    <CopyFile Name="@(PrebuiltDirectory)/monostub" TargetName="@(AppDirectory)/Contents/MacOS/@(Project.Name)" Condition="HOST_MAC" />
+    <CopyFile Name="@(PrebuiltDirectory)/monostub" TargetName="@(AppDirectory)/Contents/MacOS/@(Project.Name)" IsExecutable=true Condition="HOST_MAC" />
     <CopyFile Name="@//Assets/Icon.icns" TargetName="@(AppDirectory)/Contents/Resources/Icon.icns" Condition="HOST_MAC" />
 
 </Extensions>

--- a/scripts/FuseOpen.Uno.Tool.nuspec
+++ b/scripts/FuseOpen.Uno.Tool.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.Uno.Tool</id>
+        <version>$version$</version>
+        <title>Uno compiler tool package</title>
+        <authors>FuseOpen</authors>
+        <owners>FuseOpen</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Uno compiler tool package</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+    <files>
+        <file src="..\release\bin\**\*" target="tools" />
+    </files>
+</package>

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -79,6 +79,14 @@ p cp -rf src/runtime/Uno.AppLoader-WinForms/bin/Release/x64 $BIN/apploader-win
 p cp config/pack.unoconfig $BIN/.unoconfig
 cat config/common.unoconfig >> $BIN/.unoconfig
 
+echo "Making NuGet packages"
+
+for i in `find src -iname "*.nuspec" | sed -e 's/.nuspec$/.csproj/'`; do
+    p nuget pack -OutputDirectory "$OUT" -Properties Configuration=Release -IncludeReferencedProjects "$i"
+done
+
+p nuget pack -OutputDirectory "$OUT" -Version "$VERSION" "`dirname "$SELF"`/FuseOpen.Uno.Tool.nuspec"
+
 # Generate launcher
 p cp prebuilt/uno prebuilt/uno.exe $DST
 echo "Packages.InstallDirectory: lib" > $DST/.unoconfig

--- a/src/common/Uno.Common/Uno.Common.csproj
+++ b/src/common/Uno.Common/Uno.Common.csproj
@@ -83,7 +83,9 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="Diagnostics\UnoVersion.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Uno.Common.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/common/Uno.Common/Uno.Common.nuspec
+++ b/src/common/Uno.Common/Uno.Common.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.API/Uno.Compiler.API.csproj
+++ b/src/compiler/Uno.Compiler.API/Uno.Compiler.API.csproj
@@ -445,6 +445,9 @@
       <Name>Uno.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.API.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.API/Uno.Compiler.API.nuspec
+++ b/src/compiler/Uno.Compiler.API/Uno.Compiler.API.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.csproj
@@ -87,6 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Uno.Compiler.Backends.CIL.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.CIL/Uno.Compiler.Backends.CIL.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.csproj
@@ -79,7 +79,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Uno.Compiler.Backends.CPlusPlus.nuspec" />
+  </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>
       <Properties>

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/Uno.Compiler.Backends.CPlusPlus.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.csproj
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.csproj
@@ -56,6 +56,9 @@
       <Name>Uno.Compiler.Backends.OpenGL</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.Backends.CSharp.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.csproj
+++ b/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.csproj
@@ -55,6 +55,9 @@
       <Name>Uno.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.Backends.JavaScript.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.JavaScript/Uno.Compiler.Backends.JavaScript.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.csproj
+++ b/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.csproj
@@ -51,6 +51,9 @@
       <Name>Uno.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.Backends.OpenGL.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.OpenGL/Uno.Compiler.Backends.OpenGL.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
+++ b/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
@@ -53,5 +53,8 @@
       <Name>Uno.ProjectFormat</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.Backends.PInvoke.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
@@ -162,5 +162,6 @@
   -->
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Uno.Compiler.Backends.UnoDoc.nuspec" />
   </ItemGroup>
 </Project>

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.nuspec
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.csproj
+++ b/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.csproj
@@ -244,6 +244,9 @@
   <ItemGroup>
     <Compile Include="IL\Validation\ILVerifier.Name.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Compiler.Core.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.nuspec
+++ b/src/compiler/Uno.Compiler.Core/Uno.Compiler.Core.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
+++ b/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Uno.Compiler.Extensions.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.nuspec
+++ b/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.csproj
+++ b/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.csproj
@@ -71,7 +71,9 @@
       <Name>Uno.Common</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Uno.Compiler.Frontend.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.nuspec
+++ b/src/compiler/Uno.Compiler.Frontend/Uno.Compiler.Frontend.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
+++ b/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
@@ -139,6 +139,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Uno.Build.Targets.nuspec" />
   </ItemGroup>
   <ItemGroup />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/engine/Uno.Build.Targets/Uno.Build.Targets.nuspec
+++ b/src/engine/Uno.Build.Targets/Uno.Build.Targets.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/engine/Uno.Build/Uno.Build.csproj
+++ b/src/engine/Uno.Build/Uno.Build.csproj
@@ -136,6 +136,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Uno.Build.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/engine/Uno.Build/Uno.Build.nuspec
+++ b/src/engine/Uno.Build/Uno.Build.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/engine/Uno.Configuration/Uno.Configuration.csproj
+++ b/src/engine/Uno.Configuration/Uno.Configuration.csproj
@@ -50,6 +50,9 @@
       <Name>Uno.Stuff</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Configuration.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/engine/Uno.Configuration/Uno.Configuration.nuspec
+++ b/src/engine/Uno.Configuration/Uno.Configuration.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
+++ b/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Uno.ProjectFormat.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.nuspec
+++ b/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/engine/Uno.Stuff/Uno.Stuff.csproj
+++ b/src/engine/Uno.Stuff/Uno.Stuff.csproj
@@ -87,6 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Uno.Stuff.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/engine/Uno.Stuff/Uno.Stuff.nuspec
+++ b/src/engine/Uno.Stuff/Uno.Stuff.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/main/Uno.CLI/Uno.CLI.csproj
+++ b/src/main/Uno.CLI/Uno.CLI.csproj
@@ -106,6 +106,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Uno.CLI.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/main/Uno.CLI/Uno.CLI.nuspec
+++ b/src/main/Uno.CLI/Uno.CLI.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
+++ b/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
@@ -152,5 +152,8 @@
     <Compile Include="Uno\UX\UXParameterAttribute.cs" />
     <Compile Include="Uno\UX\UXPrimaryAttribute.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.Runtime.Core.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.nuspec
+++ b/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
@@ -57,6 +57,9 @@
       <Name>Uno.UX.Markup.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.AST.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.nuspec
+++ b/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
+++ b/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
@@ -81,6 +81,9 @@
       <Name>Uno.UX.Markup.CompilerReflection</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.CodeGeneration.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.nuspec
+++ b/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
+++ b/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
@@ -64,6 +64,9 @@
       <Name>Uno.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.Common.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.nuspec
+++ b/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
+++ b/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
@@ -75,6 +75,9 @@
       <Name>Uno.UX.Markup.Reflection</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.CompilerReflection.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.nuspec
+++ b/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.csproj
+++ b/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.csproj
@@ -43,6 +43,9 @@
       <Name>Uno.UX.Markup.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.Reflection.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.nuspec
+++ b/src/ux/Uno.UX.Markup.Reflection/Uno.UX.Markup.Reflection.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>

--- a/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.csproj
+++ b/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.csproj
@@ -79,6 +79,9 @@
       <Name>Uno.UX.Markup.Reflection</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Uno.UX.Markup.UXIL.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.nuspec
+++ b/src/ux/Uno.UX.Markup.UXIL/Uno.UX.Markup.UXIL.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FuseOpen.$id$</id>
+        <version>$version$</version>
+        <title>$title$</title>
+        <authors>$author$</authors>
+        <owners>$author$</owners>
+        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/fuse-open/uno</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>$description$</description>
+        <copyright>Copyright FuseOpen 2018</copyright>
+        <tags>uno fuse ux</tags>
+    </metadata>
+</package>


### PR DESCRIPTION
The pack.sh script now generates a bunch of nuget packages. One for every dll, for referencing from projects and using as a library, and one called FuseOpen.Uno.Tool.

This is a replacement PR for https://github.com/fuse-open/uno/pull/10