### PR TITLE
README: update travis-link to travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uno Core Platform
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/0loj5orsrrb1bn8e/branch/master?svg=true)](https://ci.appveyor.com/project/fusetools/uno/branch/master)
-[![Travis CI Build Status](https://travis-ci.com/fuse-open/uno.svg?token=eE9qUU9YXyokaZsAsV2P&branch=master)](https://travis-ci.com/fuse-open/uno)
+[![Tracis CI Build Status](https://travis-ci.org/fuse-open/uno.svg?branch=master)](https://travis-ci.org/fuse-open/uno)
 
 Welcome to Uno.
 


### PR DESCRIPTION
We also don't need any token anymore.