### PR TITLE
UnoDoc: handle arrays of arrays

### DIFF
--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/EntityTypes/MemberBuilder.cs
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/EntityTypes/MemberBuilder.cs
@@ -194,6 +194,23 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.EntityTypes
             return member.DeclaringType.GetUri() == dataType.GetUri() ? member.GetUri() : null;
         }
 
+        ParameterViewModel GetParameterViewModelForParameter(Parameter param)
+        {
+            var suffix = "";
+            var elementType = param.Type;
+            while (elementType.IsArray)
+            {
+                elementType = elementType.ElementType;
+                suffix += "[]";
+            }
+
+            return new ParameterViewModel(param.Name,
+                                    GetDataTypeUri(elementType),
+                                    elementType.IsVirtualType(),
+                                    Naming.GetIndexTitle(elementType) + suffix,
+                                    Naming.GetFullIndexTitle(elementType) + suffix);
+        }
+
         private ParametersViewModel GetParameters(Member member)
         {
             var parameters = member.GetParametersOrNull();
@@ -217,18 +234,7 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.EntityTypes
                 throw new Exception($"Found {invisibleParams.Count} parameters for member {member.FullName} that have non-exportable types: {string.Join(", ", names)}");
             }
 
-            var list = parameters.Select(param => param.Type.IsArray
-                                                          ? new ParameterViewModel(param.Name,
-                                                                                   GetDataTypeUri(param.Type.ElementType),
-                                                                                   param.Type.ElementType.IsVirtualType(),
-                                                                                   Naming.GetIndexTitle(param.Type.ElementType) + "[]",
-                                                                                   Naming.GetFullIndexTitle(param.Type.ElementType) + "[]")
-                                                          : new ParameterViewModel(param.Name,
-                                                                                   GetDataTypeUri(param.Type),
-                                                                                   param.Type.IsVirtualType(),
-                                                                                   Naming.GetIndexTitle(param.Type),
-                                                                                   Naming.GetFullIndexTitle(param.Type)))
-                                 .ToList();
+            var list = parameters.Select(param => GetParameterViewModelForParameter(param)).ToList();
             return new ParametersViewModel(list);
         }
 

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/Naming/Naming.cs
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/Naming/Naming.cs
@@ -18,10 +18,10 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.Naming
             var typeNames = parameterTypes.Select(type =>
             {
                 var suffix = "";
-                if (type.IsArray)
+                while (type.IsArray)
                 {
                     type = type.ElementType;
-                    suffix = "[]";
+                    suffix += "[]";
                 }
                 var name = fullyQualified
                                    ? new EntityNaming().GetFullIndexTitle(type)

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/Syntax/SyntaxGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Builders/Syntax/SyntaxGenerator.cs
@@ -104,6 +104,21 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.Syntax
             return "<" + string.Join(", ", parameterNames) + ">";
         }
 
+        string GetDataTypeString(DataType dataType)
+        {
+            var suffix = "";
+            while (dataType.IsArray)
+            {
+                dataType = dataType.ElementType;
+                suffix += "[]";
+            }
+
+            if (dataType.IsGenericParameter)
+                return dataType.Name + suffix;
+            else
+                return new EntityNaming().GetFullIndexTitle(dataType) + suffix;
+        }
+
         protected string BuildParameters(List<Parameter> parameters, DataType context, bool useSquareBrackets = false)
         {
             if (parameters == null) return null;
@@ -115,25 +130,7 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.Syntax
                 var sb = new StringBuilder();
                 sb.Append(string.Join(" ", param.GetModifierNames()));
                 sb.Append(" ");
-
-                if (param.Type.IsArray)
-                {
-                    if (param.Type.IsGenericParameter)
-                    {
-                        sb.Append(param.Type.Name + "[]");
-                    }
-                    else
-                    {
-                        sb.Append(new EntityNaming().GetFullIndexTitle(param.Type.ElementType) + "[]");
-                    }
-                }
-                else
-                {
-                    sb.Append(param.Type.IsGenericParameter
-                                      ? param.Type.Name
-                                      : new EntityNaming().GetFullIndexTitle(param.Type));
-                }
-
+                sb.Append(GetDataTypeString(param.Type));
                 sb.Append(" " + param.Name);
 
                 if (param.OptionalDefault != null)


### PR DESCRIPTION
It seems this generator is written without concern for arrays of
arrays, which we use in our API.

According to the docs-team, this was ad-hoc hacked around when
outputting the API in the past. But let's instead do this correctly,
by peeling away multiple arrays rather than just a single one.

This prevents an error about missing namespace for `byte[]` when
updating API docs.