### PR TITLE
Uno.UX.Markup.*: fix casing of System.Xml

### DIFF
--- a/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
@@ -46,7 +46,7 @@
       <HintPath>..\..\..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Uno.UX.Markup.AST.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />

--- a/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
+++ b/src/ux/Uno.UX.Markup.Common/Uno.UX.Markup.Common.csproj
@@ -33,7 +33,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />


### PR DESCRIPTION
This is not named System.XML, as we used here. This worked without
this patch, because we only build on Windows and case-insensitive
HFS+ currently.

This patch opens the door for case-sensitive HFS+, as well as Linux.