### PR TITLE
Fix App Store issue while uploading the app to App Store because of App Icons are invalid format 

### DIFF
--- a/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 using System.IO;
 using System.Linq;
@@ -619,10 +620,16 @@ namespace Uno.Compiler.Core.Syntax
 
                 using (var originalImg = Image.FromFile(src))
                 {
+                    if (_env.IsDefined("iOS") && Image.IsAlphaPixelFormat(originalImg.PixelFormat) )
+                    {
+                        var source = new Source(src);
+                        Log.Warning(source, ErrorCode.E0000, "iOS App Store doesn't accept Images with transparency.");
+                    }
+                  
                     int width = f.TargetWidth ?? f.TargetHeight ?? originalImg.Width;
                     int height = f.TargetHeight ?? f.TargetWidth ?? originalImg.Height;
 
-                    using (var resizedImg = new Bitmap(width, height))
+                    using (var resizedImg = new Bitmap(width, height, originalImg.PixelFormat))
                     {
                         using (var graphics = Graphics.FromImage(resizedImg))
                         {


### PR DESCRIPTION
Fix App Store issue while uploading the app to App Store because of App Icon has invalid format and they have to be stripped from alpha channel.

The previous image was generated using default settings of .NET graphics. I have fixed it and adding additional app icon sizes by simply setting `CompositingMode` attribute for .NET graphics to `CompositingMode.SourceOver`

for further information see this example of XCode error message after archiving the App

<img width="663" alt="Xcode error screen" src="https://user-images.githubusercontent.com/7278576/40520327-faac7b20-5fcd-11e8-8b65-639b54feb15c.png">

Also it's listed here in Apple's guidelines for [Human Interface Guidelines ](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/):

> Keep the background simple and avoid transparency. Make sure your icon is opaque, and don’t clutter the background. Give it a simple background so it doesn’t overpower other app icons nearby. You don’t need to fill the entire icon with content.