### PR TITLE
Add push notification to iOS Xcode project entitlements file while building Release version

### DIFF
--- a/Library/Core/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name).entitlements
+++ b/Library/Core/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name).entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-#if @('@(DEBUG:Defined) && @(Project.iOS.SystemCapabilities.Push:IsSet)':Test(@(Project.iOS.SystemCapabilities.Push),0))
+#if @(@(Project.iOS.SystemCapabilities.Push:IsSet):Test(@(Project.iOS.SystemCapabilities.Push),0))
 	<key>aps-environment</key>
 	<string>development</string>
 #endif


### PR DESCRIPTION
There was an issue after building release version of the App like the screenshot below :
![image](https://user-images.githubusercontent.com/7278576/40534774-ce4f94ee-600f-11e8-92d0-d1c600c6b322.png).

We have fixed it easily by changing the If statement condition it was wrong and the Xcode changing the `APS Environment` from `development` => `production` during app uploading using Xcode.