### PR TITLE
Enable Remote Notifications mode on Background Modes in Plist file while enabling push notifications

### DIFF
--- a/Library/Core/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
+++ b/Library/Core/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
@@ -167,19 +167,20 @@
 #endif
 #endif
 
+<key>UIBackgroundModes</key>
+<array>
 #if @(iOS.BackgroundModes:IsRequired)
-	<key>UIBackgroundModes</key>
-	<array>
-        @(iOS.BackgroundModes:Join('\n\t\t', '<string>','</string>'))
-	</array>
+	@(iOS.BackgroundModes:Join('\n\t\t', '<string>','</string>'))
 #endif
-
 #if @(Project.iOS.PList.UIBackgroundModes:IsSet)
-	<key>UIBackgroundModes</key>
-	<array>
-		@(Project.iOS.PList.UIBackgroundModes:SplitAndJoin('\n\t\t', '<string>','</string>'))
-	</array>
+	@(Project.iOS.PList.UIBackgroundModes:SplitAndJoin('\n\t\t', '<string>','</string>'))
 #endif
+#if @(Project.iOS.SystemCapabilities.Push:IsSet)
+	#if @(Project.iOS.SystemCapabilities.Push:Test(1,0))
+		<string>remote-notification</string>
+	#endif
+#endif
+</array>
 
 #if @(Project.iOS.PList.UIFileSharingEnabled:IsSet)
 	<key>UIFileSharingEnabled</key>


### PR DESCRIPTION
By default, UIBackground modes on iOS project doesn't contains any value which will need extra work and time from the developer like below.

![image](https://user-images.githubusercontent.com/7278576/40536118-c75beb48-6013-11e8-9669-87c7ddee9101.png)

Every time he would likes to run the project on his mobile he need t check that option like the image each time.

I have make it added automatically once the `Unoproj` file contains the `Push` capability it directly added to project `.plist` file.

Also, the file contained multiple definitions for the UIBackgroundModes and not listed on the Documentations you have i have wrapped them into one plist `array` to mitigate any conflicts on the proejct files.