### PR TITLE
Three additional `Unoproj` Properties to help the Foreign code developers for iOS

### DIFF
--- a/Library/Core/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/Library/Core/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -458,10 +458,31 @@
 #if @(LIBRARY:Defined)
                 MACH_O_TYPE = mh_dylib;
 #endif
+
+#if @(Project.iOS.SpecialCapabilities.CPPImport:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.CPPImport:Test(1,0))
+                OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fmodules",
+					"-fcxx-modules",
+				);
+    #endif
+#endif
+#if @(Project.iOS.SpecialCapabilities.AllowSwiftModules:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.AllowSwiftModules:Test(1,0))
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+    #endif
+#endif
+#if @(Project.iOS.SpecialCapabilities.AllowNonModularModules:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.AllowNonModularModules:Test(1,0))
+                CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+    #endif
+#endif
                 OTHER_LDFLAGS = (
                     "$(inherited)",
                     "@(Pbxproj.LinkLibraries)"
                 );
+
                 PRODUCT_NAME = "$(TARGET_NAME)";
                 SWIFT_VERSION = @(Project.iOS.SwiftVersion || "3.0");
             };
@@ -505,6 +526,26 @@
                 LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 #if @(LIBRARY:Defined)
                 MACH_O_TYPE = mh_dylib;
+#endif
+
+#if @(Project.iOS.SpecialCapabilities.CPPImport:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.CPPImport:Test(1,0))
+                OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fmodules",
+					"-fcxx-modules",
+				);
+    #endif
+#endif
+#if @(Project.iOS.SpecialCapabilities.AllowSwiftModules:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.AllowSwiftModules:Test(1,0))
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+    #endif
+#endif
+#if @(Project.iOS.SpecialCapabilities.AllowNonModularModules:IsSet)
+    #if @(Project.iOS.SpecialCapabilities.AllowNonModularModules:Test(1,0))
+                CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+    #endif
 #endif
                 OTHER_LDFLAGS = (
                     "$(inherited)",


### PR DESCRIPTION
I feel sick while everytime building the iOS app because i have to add some changed manually to the project. Those properties i used to integration with `PhotoEditorSDK` library and it requires the following actions each time:

1- Allow Embed Swift Standard Libraries. 
2- Allow non-modular includes in Frameworks Modules.
3- Adding two flags to Apple's LLVM Compiler to fix the following compiler error `Use of '@import' when C++ modules are disabled, consider using -fmodules and -fcxx-modules`, So i added `-fmodules` and `-fcxx-modules` flags to it.

Those suggested attributes are nessesary for anyone need to connect with Swift SDK and Swift-NDK modules.

And the attributes are :
1- AllowSwiftModules
2- AllowNonModularModules
3- CPPImport

And can be used for example :
```
 "iOS": {
    "SpecialCapabilities": {
      "AllowSwiftModules": true,
      "AllowNonModularModules": true,
      "CPPImport": true
    },
```

That's all ;)
Thanks