### PR TITLE
Fix android permissions crash while _currentRequest is null

### DIFF
--- a/Library/Core/Uno.Permissions/Permissions.java
+++ b/Library/Core/Uno.Permissions/Permissions.java
@@ -76,7 +76,11 @@ public final class Permissions {
             _currentRequest.requestID);
     }
 
-    public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) 
+    {
+        if( _currentRequest == null) 
+            return;
+
         if (_currentRequest.requestID == requestCode && _currentRequest.promise != null && grantResults.length > 0) 
         {
             boolean ok = true;


### PR DESCRIPTION
I have reformated the braces and fixed the `NullPointerException` crash by copying the condition used on `nextRequest()` method.

I figured it out by using `Firabase Crashlytics` and it says that there is a crash with the following information: 

```
Caused by java.lang.NullPointerException
Attempt to read from field 'int com.fuse.PermissionsRequest.requestID' on a null object reference
```
```
com.fuse.Permissions.onRequestPermissionsResult (Permissions.java:80)
```
Best Regards.