### PR TITLE
Uno.Compiler: fix stack underflow in BytecodeCompiler

### DIFF
--- a/src/compiler/Uno.Compiler.Core/IL/Bytecode/BytecodeCompiler.Expression.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Bytecode/BytecodeCompiler.Expression.cs
@@ -344,11 +344,12 @@ namespace Uno.Compiler.Core.IL.Bytecode
                         var s = e as StoreThis;
 
                         Emit(Opcodes.This);
-                        CompileExpression(s.Value);
-                        Emit(Opcodes.StoreObj, s.Value.ReturnType);
 
                         if (!pop & addressMode)
-                            CreateIndirection(s.ReturnType);
+                            Emit(Opcodes.Dup);
+
+                        CompileExpression(s.Value);
+                        Emit(Opcodes.StoreObj, s.Value.ReturnType);
                     }
                     break;
 

--- a/tests/src/UnoTest/Mono/_ignore.txt
+++ b/tests/src/UnoTest/Mono/_ignore.txt
@@ -18,7 +18,6 @@ test-379.uno
 test-421.uno
 test-453.uno
 test-485.uno
-test-487.uno
 test-630.uno
 test-639.uno
 test-68.uno

--- a/tests/src/UnoTest/Mono/test-487.uno
+++ b/tests/src/UnoTest/Mono/test-487.uno
@@ -19,7 +19,7 @@ namespace Mono.test_487
             
             pass = (n == 2);
         }
-        [Uno.Testing.Ignore, Uno.Testing.Test] public static void test_487() { Uno.Testing.Assert.AreEqual(0, Main()); }
+        [Uno.Testing.Test] public static void test_487() { Uno.Testing.Assert.AreEqual(0, Main()); }
         public static int Main()
         {
             new X (null);


### PR DESCRIPTION
We now correctly compile expressions such as '&(this = x)' (pseudo code).

This avoids getting Assertion Failed from IKVM.Reflection during compilation
of UnoTest.

Minimal repro:

    struct X
    {
        int i;

        int f()
        {
            return (this = default(X)).i;
        }
    }