### PR TITLE
Uno.Compiler.Frontend: early-out in TryParseCondition()

### DIFF
--- a/src/compiler/Uno.Compiler.Frontend/Preprocessor/Preprocessor.cs
+++ b/src/compiler/Uno.Compiler.Frontend/Preprocessor/Preprocessor.cs
@@ -129,6 +129,12 @@ namespace Uno.Compiler.Frontend.Preprocessor
 
         public static bool TryParseCondition(string value, out bool result)
         {
+            if (string.IsNullOrEmpty(value))
+            {
+                result = false;
+                return false;
+            }
+
             var log = new Log(TextWriter.Null);
             var e = Parser.ParseExpression(log, Source.Unknown, value.ToLower());
 


### PR DESCRIPTION
This avoids false calls to `Log.Error()`, which is a convenient place to set
breakpoints. So, let's make life a little bit easier when debugging the
compiler..