### PR TITLE
Uno.Compiler: report error on unsupported 'extern' code

### DIFF
--- a/Library/Core/UnoCore/Source/OpenGL/GL.uno
+++ b/Library/Core/UnoCore/Source/OpenGL/GL.uno
@@ -764,9 +764,9 @@ namespace OpenGL
                 glBindTexture($@);
             @}
             else if defined(DOTNET)
-            @{
-                _gl.BindTexture($@);
-            @}
+            {
+                _gl.BindTexture(target, texture);
+            }
             else
                 build_error;
         }

--- a/src/compiler/Uno.Compiler.API/Backends/FunctionOptions.cs
+++ b/src/compiler/Uno.Compiler.API/Backends/FunctionOptions.cs
@@ -13,5 +13,6 @@ namespace Uno.Compiler.API.Backends
         MakeNativeCode = 1 << 7,
         Analyze = 1 << 8,
         ClosureConvert = 1 << 9,
+        Bytecode = 1 << 10
     }
 }

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
@@ -21,7 +21,8 @@ namespace Uno.Compiler.Backends.CIL
                 FunctionOptions.DecodeEnumOps |
                 FunctionOptions.DecodeDelegateOps |
                 FunctionOptions.DecodeSwizzles |
-                FunctionOptions.ClosureConvert;
+                FunctionOptions.ClosureConvert |
+                FunctionOptions.Bytecode;
             Options =
                 BackendOptions.ExportFiles |
                 BackendOptions.ExportMergedBlob;

--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Expression.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Expression.cs
@@ -591,6 +591,11 @@ namespace Uno.Compiler.Core.IL.Validation
                     _lambdas.Push((Lambda) e);
                     break;
                 }
+                case ExpressionType.ExternOp:
+                {
+                    VerifyExtern(e);
+                    break;
+                }
             }
         }
 

--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Statement.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Statement.cs
@@ -1,4 +1,6 @@
-﻿using Uno.Compiler.API.Domain.IL;
+﻿using Uno.Compiler.API.Backends;
+using Uno.Compiler.API.Domain.Graphics;
+using Uno.Compiler.API.Domain.IL;
 using Uno.Compiler.API.Domain.IL.Expressions;
 using Uno.Compiler.API.Domain.IL.Statements;
 using Uno.Compiler.API.Domain.IL.Types;
@@ -170,7 +172,20 @@ namespace Uno.Compiler.Core.IL.Validation
 
                     break;
                 }
+                case StatementType.ExternScope:
+                {
+                    VerifyExtern(e);
+                    break;
+                }
             }
+        }
+
+        void VerifyExtern(Statement e)
+        {
+            if (Function is ShaderFunction)
+                return;
+            if (Backend.Has(FunctionOptions.Bytecode))
+                Log.Error(e.Source, ErrorCode.E0000, "This backend does not support 'extern' code");
         }
 
         void VerifySwitchCaseValue(Constant a, Constant b)


### PR DESCRIPTION
If we try to compile 'extern' code on .NET we'll get exceptions in `CilBackend`, i.e.:
```
void foo()
@{
    // code here
@}
```
These errors are hard to fix because the compiler doesn't give us any source information.

After this fix, we get a more helpful error message that tells us where to fix the problem.