### PR TITLE
Fixup UnoCore generation

### DIFF
--- a/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/Internal/Bootstrapper.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/Internal/Bootstrapper.uno
@@ -22,7 +22,7 @@ namespace Uno.Runtime.Implementation.Internal
 
         static bool IsPrimaryFinger(PlatformWindowHandle handle, int fingerId)
         {
-            return _lastPrimaryFingerId == fingerId && (defined(Android) || defined(iOS) || defined(FirefoxOS));
+            return _lastPrimaryFingerId == fingerId && (defined(Android) || defined(iOS));
         }
 
         static EventModifiers GetEventModifiers(PlatformWindowHandle handle)

--- a/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
@@ -53,10 +53,8 @@ namespace Uno.Compiler.Backends.CSharp
                 w.WriteLine(@"    <Reference Include=""System.Core"" />");
                 w.WriteLine(@"    <Reference Include=""Microsoft.CSharp"" />");
                 w.WriteLine(@"  </ItemGroup>");
+                w.WriteLine(@"  <Import Project=""..\..\GlobalAssemblyInfo.targets"" Condition=""Exists('..\..\GlobalAssemblyInfo.targets')"" />");
                 w.WriteLine(@"  <ItemGroup>");
-                w.WriteLine( "    <Compile Include=\"..\\..\\GlobalAssemblyInfo.cs\">");
-                w.WriteLine(@"      <Link>Properties\GlobalAssemblyInfo.cs</Link>");
-                w.WriteLine( "    </Compile>");
 
                 var sourceFiles = SourceFiles.Select(x => x.Replace('/', '\\')).ToList();
                 sourceFiles.Sort(StringComparer.InvariantCulture);
@@ -91,11 +89,6 @@ namespace Uno.Compiler.Backends.CSharp
                 w.WriteLine("        HideSolutionNode = FALSE");
                 w.WriteLine("    EndGlobalSection");
                 w.WriteLine("EndGlobal");
-            }
-
-            using (var w = Disk.CreateBufferedText(Environment.Combine("..", "..", "GlobalAssemblyInfo.cs"), NewLine.Lf))
-            {
-                w.WriteLine("// Dummy file");
             }
         }
     }

--- a/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
@@ -13,6 +13,7 @@ namespace Uno.Compiler.Backends.CSharp
         {
             var projFilename = "Uno.Runtime.Core.csproj";
             var slnFilename = "Uno.Runtime.Core.sln";
+            var nuspecFilename = "Uno.Runtime.Core.nuspec";
 
             using (var w = Disk.CreateBufferedText(Environment.Combine(projFilename), NewLine.CrLf))
             {
@@ -63,6 +64,9 @@ namespace Uno.Compiler.Backends.CSharp
                     w.WriteLine("    <Compile Include=\"" + f + "\" />");
 
                 w.WriteLine(@"  </ItemGroup>");
+                w.WriteLine(@"  <ItemGroup>");
+                w.WriteLine(@"    <None Include=""Uno.Runtime.Core.nuspec"" />");
+                w.WriteLine(@"  </ItemGroup>");
                 w.WriteLine("  <Import Project=\"$(MSBuildToolsPath)\\Microsoft.CSharp.targets\" />");
                 w.Write("</Project>");
             }
@@ -89,6 +93,26 @@ namespace Uno.Compiler.Backends.CSharp
                 w.WriteLine("        HideSolutionNode = FALSE");
                 w.WriteLine("    EndGlobalSection");
                 w.WriteLine("EndGlobal");
+            }
+
+            using (var w = Disk.CreateBufferedText(Environment.Combine(nuspecFilename), NewLine.CrLf))
+            {
+                w.WriteLine(@"<?xml version=""1.0"" encoding=""utf-8""?>");
+                w.WriteLine(@"<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">");
+                w.WriteLine(@"    <metadata>");
+                w.WriteLine(@"        <id>FuseOpen.$id$</id>");
+                w.WriteLine(@"        <version>$version$</version>");
+                w.WriteLine(@"        <title>$title$</title>");
+                w.WriteLine(@"        <authors>$author$</authors>");
+                w.WriteLine(@"        <owners>$author$</owners>");
+                w.WriteLine(@"        <licenseUrl>https://github.com/fuse-open/uno/blob/master/LICENSE.txt</licenseUrl>");
+                w.WriteLine(@"        <projectUrl>https://github.com/fuse-open/uno</projectUrl>");
+                w.WriteLine(@"        <requireLicenseAcceptance>false</requireLicenseAcceptance>");
+                w.WriteLine(@"        <description>$description$</description>");
+                w.WriteLine(@"        <copyright>Copyright FuseOpen 2018</copyright>");
+                w.WriteLine(@"        <tags>uno fuse ux</tags>");
+                w.WriteLine(@"    </metadata>");
+                w.Write(@"</package>");
             }
         }
     }

--- a/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/CsBackend.GenerateProject.cs
@@ -17,7 +17,7 @@ namespace Uno.Compiler.Backends.CSharp
 
             using (var w = Disk.CreateBufferedText(Environment.Combine(projFilename), NewLine.CrLf))
             {
-                w.WriteLine(@"<?xml version=""1.0"" encoding=""utf-8""?>");
+                w.WriteLine("\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?>");
                 w.WriteLine(@"<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">");
                 w.WriteLine(@"  <PropertyGroup>");
                 w.WriteLine(@"    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>");

--- a/src/compiler/Uno.Compiler.Backends.CSharp/CsWriter.cs
+++ b/src/compiler/Uno.Compiler.Backends.CSharp/CsWriter.cs
@@ -66,6 +66,8 @@ namespace Uno.Compiler.Backends.CSharp
                 Write("abstract ");
             if (tm.HasFlag(Modifiers.Sealed))
                 Write("sealed ");
+            if (tm.HasFlag(Modifiers.New))
+                Write("new ");
         }
 
         public void WriteFieldModifiers(FieldModifiers tm)

--- a/src/runtime/Uno.Runtime.Core/OpenGL/GL.cs
+++ b/src/runtime/Uno.Runtime.Core/OpenGL/GL.cs
@@ -225,7 +225,7 @@ namespace OpenGL
 
         public static void BindTexture(GLTextureTarget target, GLTextureHandle texture)
         {
-            _gl.BindTexture(target, texture);
+            GL._gl.BindTexture(target, texture);
         }
 
         public static GLTextureHandle CreateTexture()

--- a/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
+++ b/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
@@ -6,8 +6,7 @@
     <ProjectGuid>{BE6FB7C9-4F00-4A1B-BEBD-59869A4AF387}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>
-    </RootNamespace>
+    <RootNamespace></RootNamespace>
     <AssemblyName>Uno.Runtime.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
+++ b/src/runtime/Uno.Runtime.Core/Uno.Runtime.Core.csproj
@@ -35,7 +35,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <Import Project="..\..\GlobalAssemblyInfo.targets" />
+  <Import Project="..\..\GlobalAssemblyInfo.targets" Condition="Exists('..\..\GlobalAssemblyInfo.targets')" />
   <ItemGroup>
     <Compile Include="OpenGL\GL.cs" />
     <Compile Include="OpenGL\GLBlendEquation.cs" />

--- a/src/runtime/Uno.Runtime.Core/Uno/Application.cs
+++ b/src/runtime/Uno.Runtime.Core/Uno/Application.cs
@@ -20,7 +20,7 @@ namespace Uno
         {
         }
 
-        public static Application Current
+        public static new Application Current
         {
             get { return (Application)Platform.CoreApp.Current; }
         }


### PR DESCRIPTION
Re-generating UnoCore is not currently possible, due to a few mismatches between the current sources and the generator. This isn't ideal, as it means people will have to carefully stage only the changes they want.

This series have two small fixes "tacked on", but they are all kinda related:
- The FirefoxOS-define is never defined any more, so checking for it is kinda pointless.
- The C# writer now emits `new`-keywords for definitions that previously missed them. This eliminates a compile-time warning.