### PR TITLE
Update android app gradle dependency Libraries

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -7,8 +7,8 @@ apply plugin: 'com.android.application'
 dependencies {
     compile fileTree(dir: 'src/main/libs', include: ['*.jar'])
     compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
+    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:design:26.0.2'
 #if @(Gradle.Dependency.Compile:IsRequired)
     @(Gradle.Dependency.Compile:Join('\n', 'compile \'', '\''))
 #endif
@@ -26,6 +26,7 @@ build.dependsOn copySharedLibraries
 
 #if @(Gradle.Repository:IsRequired)
 repositories {
+    maven { url 'https://maven.google.com' }
     @(Gradle.Repository:Join('\n'))
 }
 #endif


### PR DESCRIPTION
Hello!

Android O is here and dependencies versions must be updated in order to be able to utilize API 26 new features 

This is a simple pull requests that made the change of support libraries to `26.0.2` and added google maven repository in order to be able to fetch the new support libraries

That's all,
Thanks