### PR TITLE
ILVerifier: check foreign attribute in VerifyExtern()

### DIFF
--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Statement.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Statement.cs
@@ -184,7 +184,7 @@ namespace Uno.Compiler.Core.IL.Validation
         {
             if (Function is ShaderFunction)
                 return;
-            if (Backend.Has(FunctionOptions.Bytecode))
+            if (Backend.Has(FunctionOptions.Bytecode) && !Backend.IsPInvokable(Essentials, Function))
                 Log.Error(e.Source, ErrorCode.E0000, "This backend does not support 'extern' code");
         }
 


### PR DESCRIPTION
This fixes build errors when building fuselibs.