### PR TITLE
Uno.Compiler: fix C++ regression after #48

### DIFF
--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppWriter.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppWriter.cs
@@ -613,6 +613,11 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 WriteExpression(s);
                 Write(")->" + member);
             }
+            else if (s.ReturnType.IsValueType && declType != null && declType.IsReferenceType)
+            {
+                WriteBox(s.Source, declType, s.ActualValue, true, ExpressionUsage.Object);
+                Write("->" + member);
+            }
             else
             {
                 WriteExpression(s, ExpressionUsage.Object);

--- a/tests/src/UnoTest/General/ValueTypes.uno
+++ b/tests/src/UnoTest/General/ValueTypes.uno
@@ -1,4 +1,5 @@
 using Uno;
+using Uno.Compiler.ExportTargetInterop;
 using Uno.Testing;
 
 namespace UnoTest.General
@@ -31,6 +32,36 @@ namespace UnoTest.General
         {
             var a = (object) new Value(1, 2);
             var b = (object) new Value(1, 2);
+            Assert.IsTrue(a.Equals(b));
+            Assert.IsTrue(a.GetHashCode() == b.GetHashCode());
+        }
+    }
+
+    [Set("TypeName", "int")]
+    extern(CPLUSPLUS) struct CppValueHandle
+    {
+    }
+
+    extern(CPLUSPLUS) class CppValue
+    {
+        readonly CppValueHandle _value;
+
+        public override bool Equals(object o)
+        {
+            var that = o as CppValue;
+            return that != null && _value.Equals(that._value);
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        [Test]
+        public static void Test()
+        {
+            var a = new CppValue();
+            var b = new CppValue();
             Assert.IsTrue(a.Equals(b));
             Assert.IsTrue(a.GetHashCode() == b.GetHashCode());
         }


### PR DESCRIPTION
This adds a new test based on a fail-case from fuselibs, and add stack-boxing
when emitting virtual calls on value types in CppWriter.WriteMemberBase().

Before this patch, we got C++ compile errors when building fuselibs.