### PR TITLE
Android: the maven repository is always required

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -24,12 +24,10 @@ task copySharedLibraries {
 
 build.dependsOn copySharedLibraries
 
-#if @(Gradle.Repository:IsRequired)
 repositories {
     maven { url 'https://maven.google.com' }
     @(Gradle.Repository:Join('\n'))
 }
-#endif
 
 
 repositories {


### PR DESCRIPTION
Otherwise we'll get these build errors (regression from #57):
   > Could not find com.android.support:appcompat-v7:26.0.2.
     Required by:
         Debug:app:unspecified
   > Could not find com.android.support:design:26.0.2.
     Required by:
         Debug:app:unspecified