### PR TITLE
Android: upgrade Gradle versions

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/Android.uxl
+++ b/Library/Core/UnoCore/Targets/Android/Android.uxl
@@ -18,7 +18,7 @@
     <Set JDK.Directory="@(Config.Java.JDK.Directory:Path || JAVA_HOME:Env)" />
     <Set NDK.Directory="@(Config.Android.NDK.Directory:Path || ANDROID_NDK:Env)" />
     <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '9')" />
-    <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '26.0.2')" />
+    <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '27.0.3')" />
     <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '26')" />
     <Set SDK.Directory="@(Config.Android.SDK.Directory:Path || ANDROID_SDK:Env)" />
     <Set SDK.MinVersion="@(Project.Android.SDK.MinVersion || Config.Android.SDK.MinVersion || '16')" />

--- a/Library/Core/UnoCore/Targets/Android/Android.uxl
+++ b/Library/Core/UnoCore/Targets/Android/Android.uxl
@@ -64,7 +64,7 @@
 
     <Set Activity.Name="@(Project.Android.Activity || Project.Name:Identifier)" />
     <Set Activity.Package="@(Project.Android.Package || 'com.apps.@(Project.Name:QIdentifier:ToLower)')" />
-    <Set APK.BuildName="app/build/outputs/apk/app-@(APK.Configuration:ToLower).apk" />
+    <Set APK.BuildName="app/build/outputs/apk/@(APK.Configuration:ToLower)/app-@(APK.Configuration:ToLower).apk" />
     <Set APK.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
     <Set Gradle.Task="assemble@(APK.Configuration)" />
     <Set Runtime.CatchCppExceptions=2 />

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -116,6 +116,10 @@ android {
     aaptOptions {
         cruncherEnabled = false
     }
+
+    packagingOptions {
+        pickFirst 'lib/armeabi-v7a/libgnustl_shared.so'
+    }
 }
 
 @(Gradle.BuildFile.End:Join('\n'))

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'com.android.application'
 #endif
 
 dependencies {
-    compile fileTree(dir: 'src/main/libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile 'com.android.support:design:26.0.2'
+    implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
+    implementation 'com.android.support:support-v4:23.4.0'
+    implementation 'com.android.support:appcompat-v7:26.0.2'
+    implementation 'com.android.support:design:26.0.2'
 #if @(Gradle.Dependency.Compile:IsRequired)
-    @(Gradle.Dependency.Compile:Join('\n', 'compile \'', '\''))
+    @(Gradle.Dependency.Compile:Join('\n', 'implementation \'', '\''))
 #endif
 #if @(Gradle.Dependency:IsRequired)
     @(Gradle.Dependency:Join('\n'))

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -52,7 +52,7 @@ android.lintOptions {
 
 android {
     compileSdkVersion = @(SDK.CompileVersion)
-    buildToolsVersion = "@(SDK.BuildToolsVersion)"
+    buildToolsVersion = '@(SDK.BuildToolsVersion)'
 
     defaultConfig {
 #if !@(LIBRARY:Defined)

--- a/Library/Core/UnoCore/Targets/Android/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-       jcenter()
-       mavenCentral()
-       @(Gradle.BuildScript.Repository:Join('\n'))
+        jcenter()
+        mavenCentral()
+        @(Gradle.BuildScript.Repository:Join('\n'))
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'

--- a/Library/Core/UnoCore/Targets/Android/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/build.gradle
@@ -1,12 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenCentral()
         @(Gradle.BuildScript.Repository:Join('\n'))
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         @(Gradle.Dependency.ClassPath:Join('\n', 'classpath \'', '\''))
     }
 }

--- a/Library/Core/UnoCore/Targets/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Library/Core/UnoCore/Targets/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 13 15:42:37 CEST 2016
+#Fri Jun 29 18:21:17 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This upgrades to Gradle 4.4, and Gradle-plugin 3.1.3.

This gives access to a new feature called "Instant Run", and we avoid being asked if we want to upgrade every time we open a generated project in Android Studio.