### PR TITLE
Android: remove self-comparison in GLHelper.cpp

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/Uno/Base/JNI.uno
+++ b/Library/Core/UnoCore/Targets/Android/Uno/Base/JNI.uno
@@ -228,7 +228,7 @@ namespace Android.Base
             extern "free(cMethodName)";
             extern "free(cMethodSig)";
             JNI.CheckException();
-            if (extern<bool>(mid)"($0==0)")
+            if (extern<bool>(mid)"$0==0")
                 throw new Exception("Java method id for " + methodName + " is null");
             return mid;
         }

--- a/Library/Core/UnoCore/Targets/Android/Uno/Base/JNI.uno
+++ b/Library/Core/UnoCore/Targets/Android/Uno/Base/JNI.uno
@@ -228,7 +228,7 @@ namespace Android.Base
             extern "free(cMethodName)";
             extern "free(cMethodSig)";
             JNI.CheckException();
-            if (extern<bool>(mid)"$0==0")
+            if (extern<bool>(mid) "$0 == 0")
                 throw new Exception("Java method id for " + methodName + " is null");
             return mid;
         }

--- a/Library/Core/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
+++ b/Library/Core/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
@@ -240,7 +240,7 @@ void GLHelper::_setEGLConfig(bool forPBuffer)
         eglGetConfigAttrib(_eglDisplay, configs[i], EGL_SAMPLES, &samples);
 
         if (samples >= cs && depth >= cd && buffer >= cb &&
-            samples <= samples && r <= colorBits.R && g <= colorBits.G && b <= colorBits.B && a <= colorBits.A)
+            r <= colorBits.R && g <= colorBits.G && b <= colorBits.B && a <= colorBits.A)
         {
             cs = samples;
             cd = depth;

--- a/Library/Core/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
+++ b/Library/Core/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
@@ -226,7 +226,7 @@ void GLHelper::_setEGLConfig(bool forPBuffer)
     int cc = 0;
 
     const uBase::Vector4i& colorBits = uBase::Vector4i(8, 8, 8, 8);
-    int samples = 4;
+
     for (int i = 0; i < numConfigs; i++)
     {
         EGLint samples, depth, stencil, buffer, r, g, b, a, render;


### PR DESCRIPTION
This expression will always be true, so remove it to avoid compile-time warning on new build-tools.