### PR TITLE
UxlProcessor cleanup

### DIFF
--- a/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 using System.IO;
 using System.Linq;

--- a/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
@@ -623,9 +623,9 @@ namespace Uno.Compiler.Core.Syntax
                     if (_env.IsDefined("iOS") && Image.IsAlphaPixelFormat(originalImg.PixelFormat) )
                     {
                         var source = new Source(src);
-                        Log.Warning(source, ErrorCode.E0000, "iOS App Store doesn't accept Images with transparency.");
+                        Log.Warning(source, ErrorCode.W0000, "iOS App Store doesn't accept Images with transparency.");
                     }
-                  
+
                     int width = f.TargetWidth ?? f.TargetHeight ?? originalImg.Width;
                     int height = f.TargetHeight ?? f.TargetWidth ?? originalImg.Height;
 


### PR DESCRIPTION
Warning messages should use a warning-code (instead of an error-code), and fix some formatting.