### PR TITLE
Android: add Gradle.Dependency.NativeImplementation

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/Android.uxl
+++ b/Library/Core/UnoCore/Targets/Android/Android.uxl
@@ -46,6 +46,7 @@
     <Declare Element="Gradle.Dependency" />
     <Declare Element="Gradle.Dependency.ClassPath" />
     <Declare Element="Gradle.Dependency.Implementation" />
+    <Declare Element="Gradle.Dependency.NativeImplementation" />
     <Declare Element="Gradle.BuildFile.End" />
     <Declare Element="Gradle.Repository" />
     <Declare Element="Gradle.BuildScript.Repository" />

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -4,21 +4,48 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.android.application'
 #endif
 
+// A configuration to mark AARs to extract native libraries from
+#if @(Gradle.Dependency.NativeImplementation:IsRequired)
+configurations { native_implementation }
+#endif
+
 dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
     implementation 'com.android.support:support-v4:23.4.0'
     implementation 'com.android.support:appcompat-v7:26.0.2'
     implementation 'com.android.support:design:26.0.2'
     @(Gradle.Dependency.Implementation:Join('\n', 'implementation \'', '\''))
+    @(Gradle.Dependency.NativeImplementation:Join('\n', 'native_implementation \'', '\''))
     @(Gradle.Dependency:Join('\n'))
 }
-
 
 task copySharedLibraries {
     @(JNI.SharedLibrary:Join('\n    ', 'copy {\n        from \'', '\'\n        into file('src/main/jniLibs/armeabi-v7a')\n    }'))
 }
 
 build.dependsOn copySharedLibraries
+
+// Extracts native libraries from AARs in the native_implementation configuration.
+// This is done so that the NDK can access these libraries.
+#if @(Gradle.Dependency.NativeImplementation:IsRequired)
+task extractNativeLibraries() {
+    doFirst {
+        configurations.native_implementation.files.each { f ->
+            copy {
+                from zipTree(f)
+                into "${buildDir}/native"
+                include "jni/**/*"
+            }
+        }
+    }
+}
+
+tasks.whenTaskAdded {
+    task-> if (task.name.contains("external") && !task.name.contains("Clean")) {
+        task.dependsOn(extractNativeLibraries)
+    }
+}
+#endif
 
 repositories {
     maven { url 'https://maven.google.com' }

--- a/Library/Core/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
+++ b/Library/Core/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
@@ -14,6 +14,11 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -s")
 endif()
 
+# Find libraries extracted from AARs, if applicable.
+#if @(Gradle.Dependency.NativeImplementation:IsRequired)
+link_directories(@(OutputDirectory:Path)/app/build/native/jni/@(ABI))
+#endif
+
 add_library(@(Activity.Name) SHARED
     @(HeaderFile:Join('\n    ', '"include/', '"'))
     @(SourceFile:Join('\n    ', '"jni/', '"')))

--- a/tests/src/AndroidNativeDependency/AndroidNativeDependency.unoproj
+++ b/tests/src/AndroidNativeDependency/AndroidNativeDependency.unoproj
@@ -1,0 +1,5 @@
+{
+  "Includes": [
+    "App.uno:Source"
+  ]
+}

--- a/tests/src/AndroidNativeDependency/App.uno
+++ b/tests/src/AndroidNativeDependency/App.uno
@@ -1,0 +1,17 @@
+using Uno;
+using Uno.Compiler.ExportTargetInterop;
+
+namespace AndroidNativeDependency
+{
+    public partial class App : Application
+    {
+    }
+
+    [Require("Gradle.Dependency.NativeImplementation", "com.google.ar:core:1.3.0")]
+    [Require("LinkLibrary", "arcore_sdk_c")]
+    [Require("LinkLibrary", "arcore_sdk_jni")]
+    extern(ANDROID) partial class App
+    {
+        // If this app builds, it means our feature is working!
+    }
+}


### PR DESCRIPTION
This feature will extract native libraries from downloaded AARs, so that we can
use them in our Uno/C++ code and make the NDK able to link them.

The extracted libraries are also added to search-paths in CMakeLists.txt, so we
can simply link them without worrying about actual paths.

I'm currently using this feature to build an app using the ARCore SDK, and it
would be cool if I could test the next version of Fuse Studio on my app...