### PR TITLE
Android build system cleanup

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/Dependencies.uxl
+++ b/Library/Core/UnoCore/Targets/Android/Dependencies.uxl
@@ -1,0 +1,15 @@
+<Extensions Backend="CPlusPlus" Condition="ANDROID">
+
+    <Require Gradle.AllProjects.Repository="jcenter()" />
+    <Require Gradle.AllProjects.Repository="mavenCentral()" />
+    <Require Gradle.BuildScript.Repository="google()" />
+    <Require Gradle.BuildScript.Repository="jcenter()" />
+    <Require Gradle.BuildScript.Repository="mavenCentral()" />
+    <Require Gradle.Repository="maven { url 'https://maven.google.com' }" />
+
+    <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:3.1.3" />
+    <Require Gradle.Dependency.Implementation="com.android.support:appcompat-v7:26.0.2" />
+    <Require Gradle.Dependency.Implementation="com.android.support:design:26.0.2" />
+    <Require Gradle.Dependency.Implementation="com.android.support:support-v4:23.4.0" />
+
+</Extensions>

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -40,17 +40,6 @@ tasks.whenTaskAdded {
 
 repositories {
     @(Gradle.Repository:Join('\n    '))
-
-#if @(JNI.SystemLibrary:IsSet || JNI.SharedLibrary:IsSet)
-    libs(PrebuiltLibraries) {
-        prebuilt {
-            binaries.withType(SharedLibraryBinary) {
-                @(JNI.SystemLibrary:Join('\n                    ', 'sharedLibraryFile = file(\'', '\')'))
-                @(JNI.SharedLibrary:Join('\n                    ', 'sharedLibraryFile = file(\'', '\')'))
-            }
-        }
-    }
-#endif
 }
 
 android {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'com.android.@(LIBRARY:Defined:Test('library', 'application'))'
 
-// A configuration to mark AARs to extract native libraries from
-#if @(Gradle.Dependency.NativeImplementation:IsRequired)
 configurations { native_implementation }
-#endif
 
 dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
@@ -16,11 +13,8 @@ task copySharedLibraries {
     @(JNI.SharedLibrary:Join('\n    ', 'copy {\n        from \'', '\'\n        into file('src/main/jniLibs/armeabi-v7a')\n    }'))
 }
 
-build.dependsOn copySharedLibraries
-
 // Extracts native libraries from AARs in the native_implementation configuration.
 // This is done so that the NDK can access these libraries.
-#if @(Gradle.Dependency.NativeImplementation:IsRequired)
 task extractNativeLibraries() {
     doFirst {
         configurations.native_implementation.files.each { f ->
@@ -35,10 +29,14 @@ task extractNativeLibraries() {
 
 tasks.whenTaskAdded {
     task-> if (task.name.contains('external') && !task.name.contains('Clean')) {
+#if @(JNI.SharedLibrary:IsRequired)
+        task.dependsOn(copySharedLibraries)
+#endif
+#if @(Gradle.Dependency.NativeImplementation:IsRequired)
         task.dependsOn(extractNativeLibraries)
+#endif
     }
 }
-#endif
 
 repositories {
     @(Gradle.Repository:Join('\n'))

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -1,8 +1,4 @@
-#if @(LIBRARY:Defined)
-apply plugin: 'com.android.library'
-#else
-apply plugin: 'com.android.application'
-#endif
+apply plugin: 'com.android.@(LIBRARY:Defined:Test('library', 'application'))'
 
 // A configuration to mark AARs to extract native libraries from
 #if @(Gradle.Dependency.NativeImplementation:IsRequired)

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -11,9 +11,6 @@ configurations { native_implementation }
 
 dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
-    implementation 'com.android.support:support-v4:23.4.0'
-    implementation 'com.android.support:appcompat-v7:26.0.2'
-    implementation 'com.android.support:design:26.0.2'
     @(Gradle.Dependency.Implementation:Join('\n', 'implementation \'', '\''))
     @(Gradle.Dependency.NativeImplementation:Join('\n', 'native_implementation \'', '\''))
     @(Gradle.Dependency:Join('\n'))
@@ -48,7 +45,6 @@ tasks.whenTaskAdded {
 #endif
 
 repositories {
-    maven { url 'https://maven.google.com' }
     @(Gradle.Repository:Join('\n'))
 
 #if @(JNI.SystemLibrary:IsSet || JNI.SharedLibrary:IsSet)

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -55,8 +55,7 @@ android {
         versionCode = @(Project.Android.VersionCode)
         versionName = '@(Project.Android.VersionName)'
         ndk {
-            abiFilters = []
-            abiFilters.add('armeabi-v7a')
+            abiFilters = ['armeabi-v7a']
         }
 
         externalNativeBuild {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -61,8 +61,8 @@ android {
 #if !@(LIBRARY:Defined)
         applicationId = '@(Activity.Package)'
 #endif
-        minSdkVersion = @(SDK.MinVersion)
-        targetSdkVersion = @(SDK.TargetVersion)
+        minSdkVersion @(SDK.MinVersion)
+        targetSdkVersion @(SDK.TargetVersion)
         versionCode = @(Project.Android.VersionCode)
         versionName = '@(Project.Android.VersionName)'
         ndk {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -53,10 +53,6 @@ repositories {
 #endif
 }
 
-android.lintOptions {
-    checkReleaseBuilds = false
-}
-
 android {
     compileSdkVersion = @(SDK.CompileVersion)
     buildToolsVersion = '@(SDK.BuildToolsVersion)'
@@ -122,6 +118,10 @@ android {
 
     aaptOptions {
         cruncherEnabled = false
+    }
+
+    lintOptions {
+        checkReleaseBuilds = false
     }
 
     packagingOptions {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -4,9 +4,9 @@ configurations { native_implementation }
 
 dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
-    @(Gradle.Dependency.Implementation:Join('\n', 'implementation \'', '\''))
-    @(Gradle.Dependency.NativeImplementation:Join('\n', 'native_implementation \'', '\''))
-    @(Gradle.Dependency:Join('\n'))
+    @(Gradle.Dependency.Implementation:Join('\n    ', 'implementation \'', '\''))
+    @(Gradle.Dependency.NativeImplementation:Join('\n    ', 'native_implementation \'', '\''))
+    @(Gradle.Dependency:Join('\n    '))
 }
 
 task copySharedLibraries {
@@ -39,7 +39,7 @@ tasks.whenTaskAdded {
 }
 
 repositories {
-    @(Gradle.Repository:Join('\n'))
+    @(Gradle.Repository:Join('\n    '))
 
 #if @(JNI.SystemLibrary:IsSet || JNI.SharedLibrary:IsSet)
     libs(PrebuiltLibraries) {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -55,7 +55,7 @@ android {
         versionCode = @(Project.Android.VersionCode)
         versionName = '@(Project.Android.VersionName)'
         ndk {
-            abiFilters = ['armeabi-v7a']
+            abiFilters = ['@(ABI)']
         }
 
         externalNativeBuild {

--- a/Library/Core/UnoCore/Targets/Android/app/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/app/build.gradle
@@ -30,15 +30,15 @@ task extractNativeLibraries() {
         configurations.native_implementation.files.each { f ->
             copy {
                 from zipTree(f)
-                into "${buildDir}/native"
-                include "jni/**/*"
+                into '${buildDir}/native'
+                include 'jni/**/*'
             }
         }
     }
 }
 
 tasks.whenTaskAdded {
-    task-> if (task.name.contains("external") && !task.name.contains("Clean")) {
+    task-> if (task.name.contains('external') && !task.name.contains('Clean')) {
         task.dependsOn(extractNativeLibraries)
     }
 }
@@ -69,15 +69,15 @@ android {
 
     defaultConfig {
 #if !@(LIBRARY:Defined)
-        applicationId = "@(Activity.Package)"
+        applicationId = '@(Activity.Package)'
 #endif
         minSdkVersion = @(SDK.MinVersion)
         targetSdkVersion = @(SDK.TargetVersion)
         versionCode = @(Project.Android.VersionCode)
-        versionName = "@(Project.Android.VersionName)"
+        versionName = '@(Project.Android.VersionName)'
         ndk {
             abiFilters = []
-            abiFilters.add("armeabi-v7a")
+            abiFilters.add('armeabi-v7a')
         }
 
         externalNativeBuild {
@@ -88,28 +88,28 @@ android {
                 // default means we are giving users a bad experience by default. Native debug
                 // binaries are only really useful when actually debugging generated C++ code.
                 // Running 'uno build android --debug' will produce debuggable C++ code.
-                arguments "-DCMAKE_BUILD_TYPE=@(Native.Configuration)",
-                    "-DANDROID_STL=@(STL)",
-                    "-DANDROID_PLATFORM=android-@(NDK.PlatformVersion)",
-                    "-DANDROID_TOOLCHAIN=clang",
-                    "-DANDROID_NDK=@(NDK.Directory)"
+                arguments '-DCMAKE_BUILD_TYPE=@(Native.Configuration)',
+                    '-DANDROID_STL=@(STL)',
+                    '-DANDROID_PLATFORM=android-@(NDK.PlatformVersion)',
+                    '-DANDROID_TOOLCHAIN=clang',
+                    '-DANDROID_NDK=@(NDK.Directory)'
             }
         }
     }
 
     externalNativeBuild {
         cmake {
-            path "src/main/CMakeLists.txt"
+            path 'src/main/CMakeLists.txt'
         }
     }
 
 #if @(Project.Android.Key.Store:IsSet)
     signingConfigs {
         release {
-            keyAlias "@(Project.Android.Key.Alias)"
-            keyPassword "@(Project.Android.Key.AliasPassword)"
-            storeFile file("@(Project.Android.Key.Store:Path)")
-            storePassword "@(Project.Android.Key.StorePassword)"
+            keyAlias '@(Project.Android.Key.Alias)'
+            keyPassword '@(Project.Android.Key.AliasPassword)'
+            storeFile file('@(Project.Android.Key.Store:Path)')
+            storePassword '@(Project.Android.Key.StorePassword)'
         }
     }
 #endif

--- a/Library/Core/UnoCore/Targets/Android/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/build.gradle
@@ -1,21 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        google()
-        jcenter()
-        mavenCentral()
         @(Gradle.BuildScript.Repository:Join('\n'))
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
         @(Gradle.Dependency.ClassPath:Join('\n', 'classpath \'', '\''))
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
-        mavenCentral()
         @(Gradle.AllProjects.Repository:Join('\n'))
     }
 }

--- a/Library/Core/UnoCore/Targets/Android/build.gradle
+++ b/Library/Core/UnoCore/Targets/Android/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        @(Gradle.BuildScript.Repository:Join('\n'))
+        @(Gradle.BuildScript.Repository:Join('\n        '))
     }
     dependencies {
-        @(Gradle.Dependency.ClassPath:Join('\n', 'classpath \'', '\''))
+        @(Gradle.Dependency.ClassPath:Join('\n        ', 'classpath \'', '\''))
     }
 }
 
 allprojects {
     repositories {
-        @(Gradle.AllProjects.Repository:Join('\n'))
+        @(Gradle.AllProjects.Repository:Join('\n        '))
     }
 }
 

--- a/Library/Core/UnoCore/UnoCore.unoproj
+++ b/Library/Core/UnoCore/UnoCore.unoproj
@@ -459,6 +459,7 @@
     "Targets/Android/build.bat:File",
     "Targets/Android/build.gradle:File",
     "Targets/Android/build.sh:File",
+    "Targets/Android/Dependencies.uxl:Extensions",
     "Targets/Android/gradle/wrapper/gradle-wrapper.jar:File",
     "Targets/Android/gradle/wrapper/gradle-wrapper.properties:File",
     "Targets/Android/gradlew:File",


### PR DESCRIPTION
When already "deep in Android-land" I got a compelling feeling to clean up our build system even more.

Testing: I've tried various apps from our examples-repo (cards-menu, inbox and weather-app), and they all still work.

After this PR I want to follow-up by upgrading the three android-support libraries to `27.1.1`, and that should make us good for a while I think, Android-wise (because support-libs should match the build-tools version).