### PR TITLE
Android: upgrade support libraries to 27.1.1

### DIFF
--- a/Library/Core/UnoCore/Targets/Android/Dependencies.uxl
+++ b/Library/Core/UnoCore/Targets/Android/Dependencies.uxl
@@ -8,8 +8,8 @@
     <Require Gradle.Repository="maven { url 'https://maven.google.com' }" />
 
     <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:3.1.3" />
-    <Require Gradle.Dependency.Implementation="com.android.support:appcompat-v7:26.0.2" />
-    <Require Gradle.Dependency.Implementation="com.android.support:design:26.0.2" />
-    <Require Gradle.Dependency.Implementation="com.android.support:support-v4:23.4.0" />
+    <Require Gradle.Dependency.Implementation="com.android.support:appcompat-v7:27.1.1" />
+    <Require Gradle.Dependency.Implementation="com.android.support:design:27.1.1" />
+    <Require Gradle.Dependency.Implementation="com.android.support:support-v4:27.1.1" />
 
 </Extensions>


### PR DESCRIPTION
Support libraries should match the major version of build-tools used.

So, now they do.