### PR TITLE
OpenGL and Uno.Graphics clean-ups

### DIFF
--- a/Library/Core/UnoCore/Source/OpenGL/GL.uno
+++ b/Library/Core/UnoCore/Source/OpenGL/GL.uno
@@ -6,7 +6,6 @@ using Uno.Runtime.InteropServices;
 namespace OpenGL
 {
     [extern(DOTNET) DotNetType]
-    [extern(CPLUSPLUS) Require("Source.Include", "Uno/Support.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "XliPlatform/GL.h")]
     extern(OPENGL) public static class GL
     {

--- a/Library/Core/UnoCore/Source/OpenGL/GL.uno
+++ b/Library/Core/UnoCore/Source/OpenGL/GL.uno
@@ -817,17 +817,11 @@ namespace OpenGL
             if (data != null)
             {
                 GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                try
-                {
-                    TexImage2D(target, level,
-                        internalFormat, width, height, border,
-                        format, type,
-                        pin.AddrOfPinnedObject());
-                }
-                finally
-                {
-                    pin.Free();
-                }
+                TexImage2D(target, level,
+                    internalFormat, width, height, border,
+                    format, type,
+                    pin.AddrOfPinnedObject());
+                pin.Free();
             }
             else
             {
@@ -878,14 +872,8 @@ namespace OpenGL
             if (data != null)
             {
                 GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                try
-                {
-                    TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pin.AddrOfPinnedObject());
-                }
-                finally
-                {
-                    pin.Free();
-                }
+                TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pin.AddrOfPinnedObject());
+                pin.Free();
             }
             else
             {

--- a/Library/Core/UnoCore/Source/OpenGL/GL.uno
+++ b/Library/Core/UnoCore/Source/OpenGL/GL.uno
@@ -437,86 +437,75 @@ namespace OpenGL
                 build_error;
         }
 
+        public static void BufferData(GLBufferTarget target, int sizeInBytes, IntPtr data, GLBufferUsage usage)
+        {
+            if defined(CPLUSPLUS)
+            @{
+                glBufferData($@);
+            @}
+            else if defined(DOTNET)
+            {
+                _gl.BufferData(target, sizeInBytes, data, usage);
+            }
+            else
+                build_error;
+        }
+
+        [DotNetOverride]
+        [Obsolete("Use GL.BufferData(GLBufferTarget,int,IntPtr,GLBufferUsage) instead")]
         public static void BufferData(GLBufferTarget target, int sizeInBytes, GLBufferUsage usage)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glBufferData($0, $1, NULL, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                _gl.BufferData(target, sizeInBytes, IntPtr.Zero, usage);
-            }
-            else
-                build_error;
+            BufferData(target, sizeInBytes, IntPtr.Zero, usage);
         }
 
         [DotNetOverride]
+        [Obsolete("Use GL.BufferData(GLBufferTarget,int,IntPtr,GLBufferUsage) instead")]
         public static void BufferData(GLBufferTarget target, byte[] data, GLBufferUsage usage)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glBufferData($0, $1->Length(), $1->Ptr(), $2);
-            @}
-            else if defined(DOTNET)
-            {
-                GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                _gl.BufferData(target, data.Length, pin.AddrOfPinnedObject(), usage);
-                pin.Free();
-            }
-            else
-                build_error;
+            GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+            BufferData(target, data.Length, pin.AddrOfPinnedObject(), usage);
+            pin.Free();
         }
 
-        [DotNetOverride, Obsolete("Use the byte[] overload instead")]
+        [DotNetOverride]
+        [Obsolete("Use GL.BufferData(GLBufferTarget,int,IntPtr,GLBufferUsage) instead")]
         public static void BufferData(GLBufferTarget target, Buffer data, GLBufferUsage usage)
+        {
+            GCHandle pin;
+            BufferData(target, data.SizeInBytes, data.PinPtr(out pin), usage);
+            pin.Free();
+        }
+
+        public static void BufferSubData(GLBufferTarget target, int offset, int sizeInBytes, IntPtr data)
         {
             if defined(CPLUSPLUS)
             @{
-                glBufferData($0, U_BUFFER_SIZE($1), U_BUFFER_PTR($1), $2);
+                glBufferSubData($@);
             @}
             else if defined(DOTNET)
             {
-                GCHandle pin;
-                _gl.BufferData(target, data.SizeInBytes, data.PinPtr(out pin), usage);
-                pin.Free();
+                _gl.BufferSubData(target, offset, sizeInBytes, data);
             }
             else
                 build_error;
         }
 
         [DotNetOverride]
+        [Obsolete("Use GL.BufferSubData(GLBufferTarget,int,int,IntPtr) instead")]
         public static void BufferSubData(GLBufferTarget target, int offset, byte[] data)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glBufferSubData($0, $1, $2->Length(), $2->Ptr());
-            @}
-            else if defined(DOTNET)
-            {
-                GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                _gl.BufferSubData(target, offset, data.Length, pin.AddrOfPinnedObject());
-                pin.Free();
-            }
-            else
-                build_error;
+            GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+            BufferSubData(target, offset, data.Length, pin.AddrOfPinnedObject());
+            pin.Free();
         }
 
-        [DotNetOverride, Obsolete("Use the byte[] overload instead")]
+        [DotNetOverride]
+        [Obsolete("Use GL.BufferSubData(GLBufferTarget,int,int,IntPtr) instead")]
         public static void BufferSubData(GLBufferTarget target, int offset, Buffer data)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glBufferSubData($0, $1, U_BUFFER_SIZE($2), U_BUFFER_PTR($2));
-            @}
-            else if defined(DOTNET)
-            {
-                GCHandle pin;
-                _gl.BufferSubData(target, offset, data.SizeInBytes, data.PinPtr(out pin));
-                pin.Free();
-            }
-            else
-                build_error;
+            GCHandle pin;
+            BufferSubData(target, offset, data.SizeInBytes, data.PinPtr(out pin));
+            pin.Free();
         }
 
         public static GLBufferHandle CreateBuffer()
@@ -822,67 +811,50 @@ namespace OpenGL
         // IsTexture
 
         [DotNetOverride]
+        [Obsolete("Use GL.TexImage2D(GLTextureTarget,int,GLPixelFormat,int,int,int,GLPixelFormat,GLPixelType,IntPtr) instead")]
         public static void TexImage2D(GLTextureTarget target, int level, GLPixelFormat internalFormat, int width, int height, int border, GLPixelFormat format, GLPixelType type, byte[] data)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glTexImage2D($0, $1, $2, $3, $4, $5, $6, $7, $8 ? $8->Ptr() : NULL);
-            @}
-            else if defined(DOTNET)
+            if (data != null)
             {
-                if (data != null)
+                GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+                try
                 {
-                    GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                    try
-                    {
-                        _gl.TexImage2D(target, level,
-                            internalFormat, width, height, border,
-                            format, type,
-                            pin.AddrOfPinnedObject());
-                    }
-                    finally
-                    {
-                        pin.Free();
-                    }
-                }
-                else
-                {
-                    _gl.TexImage2D(target, level,
-                        internalFormat, width, height, border,
-                        format, type, IntPtr.Zero);
-                }
-            }
-            else
-                build_error;
-        }
-
-        [DotNetOverride, Obsolete("Use the byte[] overload instead")]
-        public static void TexImage2D(GLTextureTarget target, int level, GLPixelFormat internalFormat, int width, int height, int border, GLPixelFormat format, GLPixelType type, Buffer data)
-        {
-            if defined(CPLUSPLUS)
-            @{
-                glTexImage2D($0, $1, $2, $3, $4, $5, $6, $7, $8 ? U_BUFFER_PTR($8) : NULL);
-            @}
-            else if defined(DOTNET)
-            {
-                if (data != null)
-                {
-                    GCHandle pin;
-                    _gl.TexImage2D(target, level,
+                    TexImage2D(target, level,
                         internalFormat, width, height, border,
                         format, type,
-                        data.PinPtr(out pin));
-                    pin.Free();
+                        pin.AddrOfPinnedObject());
                 }
-                else
+                finally
                 {
-                    _gl.TexImage2D(target, level,
-                        internalFormat, width, height, border,
-                        format, type, IntPtr.Zero);
+                    pin.Free();
                 }
             }
             else
-                build_error;
+            {
+                TexImage2D(target, level,
+                    internalFormat, width, height, border,
+                    format, type, IntPtr.Zero);
+            }
+        }
+
+        [DotNetOverride]
+        [Obsolete("Use GL.TexImage2D(GLTextureTarget,int,GLPixelFormat,int,int,int,GLPixelFormat,GLPixelType,IntPtr) instead")]
+        public static void TexImage2D(GLTextureTarget target, int level, GLPixelFormat internalFormat, int width, int height, int border, GLPixelFormat format, GLPixelType type, Buffer data)
+        {
+            if (data != null)
+            {
+                GCHandle pin;
+                TexImage2D(target, level,
+                    internalFormat, width, height, border,
+                    format, type, data.PinPtr(out pin));
+                pin.Free();
+            }
+            else
+            {
+                TexImage2D(target, level,
+                    internalFormat, width, height, border,
+                    format, type, IntPtr.Zero);
+            }
         }
 
         public static void TexImage2D(GLTextureTarget target, int level, GLPixelFormat internalFormat, int width, int height, int border, GLPixelFormat format, GLPixelType type, IntPtr data)
@@ -899,34 +871,27 @@ namespace OpenGL
                 build_error;
         }
 
+        [DotNetOverride]
+        [Obsolete("Use GL.TexSubImage2D(GLTextureTarget,int,int,int,int,int,GLPixelFormat,GLPixelType,IntPtr) instead")]
         public static void TexSubImage2D(GLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, GLPixelFormat format, GLPixelType type, byte[] data)
         {
-            if defined(CPLUSPLUS)
-            @{
-                glTexSubImage2D($0, $1, $2, $3, $4, $5, $6, $7, $8 ? $8->Ptr() : NULL);
-            @}
-            else if defined(DOTNET)
+            if (data != null)
             {
-                if(data != null)
+                GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+                try
                 {
-                    GCHandle pin = GCHandle.Alloc(data, GCHandleType.Pinned);
-                    try
-                    {
-                        _gl.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pin.AddrOfPinnedObject());
-                    }
-                    finally
-                    {
-                        pin.Free();
-                    }
+                    TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pin.AddrOfPinnedObject());
                 }
-                else
+                finally
                 {
-                    // The data pointer for glTexSubImage2D can be zero in case of 'GL_PIXEL_UNPACK_BUFFER'
-                    _gl.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, IntPtr.Zero);
+                    pin.Free();
                 }
             }
             else
-                build_error;
+            {
+                // The data pointer for glTexSubImage2D can be zero in case of 'GL_PIXEL_UNPACK_BUFFER'
+                TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, IntPtr.Zero);
+            }
         }
 
         public static void TexSubImage2D(GLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, GLPixelFormat format, GLPixelType type, IntPtr data)

--- a/Library/Core/UnoCore/Source/Uno/Array.uno
+++ b/Library/Core/UnoCore/Source/Uno/Array.uno
@@ -7,6 +7,11 @@ namespace Uno
     [extern(CPLUSPLUS) Set("TypeName", "uArray*")]
     public class Array
     {
+        public int Length
+        { 
+            get @{ return $$->Length(); @}
+        }
+
         [DotNetOverride]
         public static void Copy<T>(T[] sourceArray, T[] destinationArray, int length)
         {

--- a/Library/Core/UnoCore/Source/Uno/Buffer.uno
+++ b/Library/Core/UnoCore/Source/Uno/Buffer.uno
@@ -471,7 +471,6 @@ namespace Uno
             BufferImpl.SetDouble(_data, _offset + offset, value, littleEndian);
         }
 
-        extern(DOTNET)
         public IntPtr PinPtr(out GCHandle pin)
         {
             pin = GCHandle.Alloc(_data, GCHandleType.Pinned);

--- a/Library/Core/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
+++ b/Library/Core/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
@@ -41,7 +41,6 @@ namespace Uno.Graphics
         {
             GLBufferTarget = target;
             GLBufferHandle = GL.CreateBuffer();
-
             SizeInBytes = sizeInBytes;
 
             GL.BindBuffer(GLBufferTarget, GLBufferHandle);
@@ -53,7 +52,6 @@ namespace Uno.Graphics
         {
             GLBufferTarget = target;
             GLBufferHandle = GL.CreateBuffer();
-
             SizeInBytes = data.Length;
 
             var pin = GCHandle.Alloc(data, GCHandleType.Pinned);
@@ -68,7 +66,6 @@ namespace Uno.Graphics
         {
             GLBufferTarget = target;
             GLBufferHandle = GL.CreateBuffer();
-
             SizeInBytes = data.SizeInBytes;
 
             GCHandle pin;
@@ -92,8 +89,9 @@ namespace Uno.Graphics
         public void Dispose()
         {
             if (IsDisposed)
-                throw new ObjectDisposedException("DeviceBuffer");
-            else if defined(OPENGL)
+                return;
+
+            if defined(OPENGL)
                 GL.DeleteBuffer(GLBufferHandle);
             else
                 build_error;
@@ -103,11 +101,9 @@ namespace Uno.Graphics
 
         public void Update(byte[] data)
         {
-            if (IsDisposed)
-            {
-                throw new ObjectDisposedException("DeviceBuffer");
-            }
-            else if defined(OPENGL)
+            CheckDisposed();
+
+            if defined(OPENGL)
             {
                 var pin = GCHandle.Alloc(data, GCHandleType.Pinned);
                 GL.BindBuffer(GLBufferTarget, GLBufferHandle);
@@ -134,11 +130,9 @@ namespace Uno.Graphics
         [Obsolete("Use the byte[] overload instead")]
         public void Update(Buffer data)
         {
-            if (IsDisposed)
-            {
-                throw new ObjectDisposedException("DeviceBuffer");
-            }
-            else if defined(OPENGL)
+            CheckDisposed();
+
+            if defined(OPENGL)
             {
                 GL.BindBuffer(GLBufferTarget, GLBufferHandle);
 
@@ -158,6 +152,12 @@ namespace Uno.Graphics
             {
                 build_error;
             }
+        }
+
+        protected void CheckDisposed()
+        {
+            if (IsDisposed)
+                throw new ObjectDisposedException(GetType() + " was disposed");
         }
     }
 }

--- a/Library/Core/UnoCore/Source/Uno/Graphics/IndexBuffer.uno
+++ b/Library/Core/UnoCore/Source/Uno/Graphics/IndexBuffer.uno
@@ -15,31 +15,33 @@ namespace Uno.Graphics
         }
 
         public IndexBuffer(int sizeInBytes, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ElementArrayBuffer, sizeInBytes);
-            else
-                build_error;
+            Alloc(sizeInBytes);
         }
 
         public IndexBuffer(byte[] data, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ElementArrayBuffer, data);
-            else
-                build_error;
+            Update(data);
+        }
+
+        public IndexBuffer(ushort[] data, BufferUsage usage)
+            : this(usage)
+        {
+            Update(data);
         }
 
         [Obsolete("Use the byte[] overload instead")]
         public IndexBuffer(Buffer data, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ElementArrayBuffer, data);
-            else
-                build_error;
+            Update(data);
+        }
+
+        public void Update(ushort[] data)
+        {
+            Update(data, sizeof(ushort));
         }
     }
 }

--- a/Library/Core/UnoCore/Source/Uno/Graphics/Support/DotNetTexture.uno
+++ b/Library/Core/UnoCore/Source/Uno/Graphics/Support/DotNetTexture.uno
@@ -5,6 +5,7 @@ using Uno.Native.Textures;
 
 namespace Uno.Graphics.Support
 {
+    [Obsolete]
     extern(DOTNET)
     static class DotNetTexture
     {

--- a/Library/Core/UnoCore/Source/Uno/Graphics/TextureCube.uno
+++ b/Library/Core/UnoCore/Source/Uno/Graphics/TextureCube.uno
@@ -8,16 +8,19 @@ namespace Uno.Graphics
 {
     public sealed intrinsic class TextureCube : IDisposable
     {
+        [Obsolete]
         public static TextureCube Load(BundleFile file)
         {
             return Load(file.Name, file.ReadAllBytes());
         }
 
+        [Obsolete]
         public static TextureCube Load(string filename)
         {
             return Load(filename, File.ReadAllBytes(filename));
         }
 
+        [Obsolete]
         public static TextureCube Load(string filename, byte[] bytes)
         {
             if defined(CPLUSPLUS)

--- a/Library/Core/UnoCore/Source/Uno/Graphics/VertexBuffer.uno
+++ b/Library/Core/UnoCore/Source/Uno/Graphics/VertexBuffer.uno
@@ -15,31 +15,66 @@ namespace Uno.Graphics
         }
 
         public VertexBuffer(int sizeInBytes, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ArrayBuffer, sizeInBytes);
-            else
-                build_error;
+            Alloc(sizeInBytes);
         }
 
         public VertexBuffer(byte[] data, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ArrayBuffer, data);
-            else
-                build_error;
+            Update(data);
+        }
+
+        public VertexBuffer(float[] data, BufferUsage usage)
+            : this(usage)
+        {
+            Update(data);
+        }
+
+        public VertexBuffer(float2[] data, BufferUsage usage)
+            : this(usage)
+        {
+            Update(data);
+        }
+
+        public VertexBuffer(float3[] data, BufferUsage usage)
+            : this(usage)
+        {
+            Update(data);
+        }
+
+        public VertexBuffer(float4[] data, BufferUsage usage)
+            : this(usage)
+        {
+            Update(data);
         }
 
         [Obsolete("Use the byte[] overload instead")]
         public VertexBuffer(Buffer data, BufferUsage usage)
-            : base(usage)
+            : this(usage)
         {
-            if defined(OPENGL)
-                GLInit(GLBufferTarget.ArrayBuffer, data);
-            else
-                build_error;
+            Update(data);
+        }
+
+        public void Update(float[] data)
+        {
+            Update(data, sizeof(float));
+        }
+
+        public void Update(float2[] data)
+        {
+            Update(data, sizeof(float2));
+        }
+
+        public void Update(float3[] data)
+        {
+            Update(data, sizeof(float3));
+        }
+
+        public void Update(float4[] data)
+        {
+            Update(data, sizeof(float4));
         }
     }
 }

--- a/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/Internal/BufferConverters.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/Internal/BufferConverters.uno
@@ -1,5 +1,6 @@
 namespace Uno.Runtime.Implementation.Internal
 {
+    [Obsolete]
     public static class BufferConverters
     {
         public static Buffer ToBuffer(float[] data)

--- a/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLHelpers.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLHelpers.uno
@@ -167,13 +167,6 @@ namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
                 var log = GL.GetProgramInfoLog(handle);
                 throw new GLException("Error linking shader program:\n\n" + log);
             }
-            // try
-            // {
-            //     debug_log "GL.LinkProgram Log: "+GL.GetProgramInfoLog(handle);
-            // } catch (Exception e) {
-            //     debug_log "Threw exception while trying to get ProgramInfoLog. Trying to continue";
-            // }
-
 
             GL.UseProgram(handle);
 

--- a/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLHelpers.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLHelpers.uno
@@ -2,6 +2,7 @@ using OpenGL;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Graphics;
 using Uno.Diagnostics;
+using Uno.Runtime.InteropServices;
 
 namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
 {
@@ -25,68 +26,31 @@ namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
 
         public static void TexImage2DFromBytes(GLTextureTarget target, int w, int h, int mip, Format format, byte[] data)
         {
-            switch (format)
+            var pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            try
             {
-            case Format.L8:
-                GL.TexImage2D(target, mip, GLPixelFormat.Luminance, w, h, 0, GLPixelFormat.Luminance, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.LA88:
-                GL.TexImage2D(target, mip, GLPixelFormat.LuminanceAlpha, w, h, 0, GLPixelFormat.LuminanceAlpha, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.RGBA8888:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.RGBA4444:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedShort4444, data);
-                break;
-
-            case Format.RGBA5551:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedShort5551, data);
-                break;
-
-            case Format.RGB565:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgb, w, h, 0, GLPixelFormat.Rgb, GLPixelType.UnsignedShort565, data);
-                break;
-
-            default:
-                throw new GLException("Unsupported texture format");
+                TexImage2DFromIntPtr(target, w, h, mip, format, pin.AddrOfPinnedObject());
+            }
+            finally
+            {
+                pin.Free();
             }
         }
 
         [Obsolete("Use the byte[] overload instead")]
         public static void TexImage2DFromBuffer(GLTextureTarget target, int w, int h, int mip, Format format, Buffer data)
         {
-            switch (format)
+            GCHandle pin;
+            var addr = data.PinPtr(out pin);
+
+            try
             {
-            case Format.L8:
-                GL.TexImage2D(target, mip, GLPixelFormat.Luminance, w, h, 0, GLPixelFormat.Luminance, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.LA88:
-                GL.TexImage2D(target, mip, GLPixelFormat.LuminanceAlpha, w, h, 0, GLPixelFormat.LuminanceAlpha, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.RGBA8888:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedByte, data);
-                break;
-
-            case Format.RGBA4444:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedShort4444, data);
-                break;
-
-            case Format.RGBA5551:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgba, w, h, 0, GLPixelFormat.Rgba, GLPixelType.UnsignedShort5551, data);
-                break;
-
-            case Format.RGB565:
-                GL.TexImage2D(target, mip, GLPixelFormat.Rgb, w, h, 0, GLPixelFormat.Rgb, GLPixelType.UnsignedShort565, data);
-                break;
-
-            default:
-                throw new GLException("Unsupported texture format");
+                TexImage2DFromIntPtr(target, w, h, mip, format, addr);
+            }
+            finally
+            {
+                pin.Free();
             }
         }
 

--- a/Library/Core/UnoCore/Source/Uno/Runtime/InteropServices/GCHandle.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/InteropServices/GCHandle.uno
@@ -69,6 +69,13 @@ namespace Uno.Runtime.InteropServices
         public static explicit operator GCHandle(IntPtr ptr) { return FromIntPtr(ptr); }
         public static explicit operator IntPtr(GCHandle handle) { return ToIntPtr(handle); }
 
-        extern(DOTNET) public IntPtr AddrOfPinnedObject();
+        public IntPtr AddrOfPinnedObject()
+        {
+            var obj = Target;
+            var arr = obj as Array;
+            return arr != null
+                ? extern<IntPtr>(arr) "$0->Ptr()"
+                : extern<IntPtr>(obj) "$0";
+        }
     }
 }

--- a/src/compiler/Uno.Compiler.Core/Syntax/Generators/ShaderGenerator.VertexAttrib.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Generators/ShaderGenerator.VertexAttrib.cs
@@ -25,15 +25,6 @@ namespace Uno.Compiler.Core.Syntax.Generators
             DetectedVertexCounts.Add(c);
         }
 
-        Expression CreateByteArray(Expression buf)
-        {
-            return ILFactory.CallMethod(
-                    buf.ReturnType.Equals(ILFactory.GetType(buf.Source, "Uno.Buffer")) ?
-                        buf :
-                        ILFactory.CallMethod(buf.Source, "Uno.Runtime.Implementation.Internal.BufferConverters", "ToBuffer", buf), 
-                "GetBytes");
-        }
-
         void ProcessIndexBuffer(Source vaSrc, StageValue indexBuffer, StageValue indexType)
         {
             if (IndexBuffer == null && indexBuffer.Value == null && IndexType == null && indexType.Value == null ||
@@ -93,13 +84,13 @@ namespace Uno.Compiler.Core.Syntax.Generators
 
                 FrameScope.Statements.Add(
                     ILFactory.CallMethod(src, new LoadField(src, new This(src, owner), field), "Update",
-                        CreateByteArray(indexBuffer.Value)));
+                        indexBuffer.Value));
             }
             else
             {
                 InitScope.Statements.Add(
                     new StoreField(src, new This(src, owner), field, ILFactory.NewObject(src, "Uno.Graphics.IndexBuffer",
-                        CreateByteArray(indexBuffer.Value),
+                        indexBuffer.Value,
                         ILFactory.GetExpression(src, "Uno.Graphics.BufferUsage.Immutable"))));
             }
 
@@ -148,14 +139,14 @@ namespace Uno.Compiler.Core.Syntax.Generators
 
                     FrameScope.Statements.Add(
                         ILFactory.CallMethod(src, new LoadField(src, new This(src, owner), field), "Update",
-                            CreateByteArray(vertexBuffer.Value)));
+                            vertexBuffer.Value));
                 }
                 else
                 {
                     InitScope.Statements.Add(
                         new StoreField(src, new This(src, owner), field,
                             ILFactory.NewObject(src, "Uno.Graphics.VertexBuffer",
-                                CreateByteArray(vertexBuffer.Value),
+                                vertexBuffer.Value,
                                 ILFactory.GetExpression(src, "Uno.Graphics.BufferUsage.Immutable"))));
                 }
 

--- a/src/runtime/Uno.Runtime.Core/OpenGL/GL.cs
+++ b/src/runtime/Uno.Runtime.Core/OpenGL/GL.cs
@@ -143,9 +143,14 @@ namespace OpenGL
             GL._gl.BindBuffer(target, buffer);
         }
 
-        public static void BufferData(GLBufferTarget target, int sizeInBytes, GLBufferUsage usage)
+        public static void BufferData(GLBufferTarget target, int sizeInBytes, global::System.IntPtr data, GLBufferUsage usage)
         {
-            GL._gl.BufferData(target, sizeInBytes, global::System.IntPtr.Zero, usage);
+            GL._gl.BufferData(target, sizeInBytes, data, usage);
+        }
+
+        public static void BufferSubData(GLBufferTarget target, int offset, int sizeInBytes, global::System.IntPtr data)
+        {
+            GL._gl.BufferSubData(target, offset, sizeInBytes, data);
         }
 
         public static GLBufferHandle CreateBuffer()
@@ -246,25 +251,6 @@ namespace OpenGL
         public static void TexImage2D(GLTextureTarget target, int level, GLPixelFormat internalFormat, int width, int height, int border, GLPixelFormat format, GLPixelType type, global::System.IntPtr data)
         {
             GL._gl.TexImage2D(target, level, internalFormat, width, height, border, format, type, data);
-        }
-
-        public static void TexSubImage2D(GLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, GLPixelFormat format, GLPixelType type, byte[] data)
-        {
-            if (data != null)
-            {
-                global::System.Runtime.InteropServices.GCHandle pin = global::System.Runtime.InteropServices.GCHandle.Alloc(data, global::System.Runtime.InteropServices.GCHandleType.Pinned);
-
-                try
-                {
-                    GL._gl.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pin.AddrOfPinnedObject());
-                }
-                finally
-                {
-                    pin.Free();
-                }
-            }
-            else
-                GL._gl.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, global::System.IntPtr.Zero);
         }
 
         public static void TexSubImage2D(GLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, GLPixelFormat format, GLPixelType type, global::System.IntPtr data)


### PR DESCRIPTION
Here comes some commits focused on improving our interfacing with OpenGL.

In particular, this will make it really easy to finally deprecate the `Uno.Buffer` class - since it's no longer needed by the compiler, nor the API.

We also avoid extra copy passes on index and vertex arrays from `draw`-statements, and just generally make things nicer.

After this, I plan to follow up by replacing and deprecating `Uno.Buffer`, and make patches for other known repositories ready for when a new Uno release is available.