### PR TITLE
Replace Buffer class

### DIFF
--- a/Library/Core/UnoCore/Backends/CPlusPlus/Uno/Support.h
+++ b/Library/Core/UnoCore/Backends/CPlusPlus/Uno/Support.h
@@ -70,14 +70,14 @@ unsigned int uCreateGLTexture(uImage::Texture* texData, bool generateMipmap = tr
 #define U_BUFFER_PTR(buffer) ((uint8_t*)(buffer)->_data->_ptr + (buffer)->_offset)
 #define U_BUFFER_SIZE(buffer) (buffer)->_sizeInBytes
 
-void uReverseBytes(uint8_t* ptr, size_t size);
+void DEPRECATED("This method will be removed in a future version") uReverseBytes(uint8_t* ptr, size_t size);
 
 template<class T>
-void uReverseBytes(T& ref) {
+void DEPRECATED("This method will be removed in a future version") uReverseBytes(T& ref) {
     uReverseBytes((uint8_t*)&ref, sizeof(T));
 }
 template<class T>
-T uLoadBytes(uint8_t* ptr, bool littleEndian) {
+T DEPRECATED("This method will be removed in a future version") uLoadBytes(uint8_t* ptr, bool littleEndian) {
     T result;
     memcpy(&result, ptr, sizeof(T));
 
@@ -87,7 +87,7 @@ T uLoadBytes(uint8_t* ptr, bool littleEndian) {
     return result;
 }
 template<class T>
-void uStoreBytes(uint8_t* ptr, T value, bool littleEndian) {
+void DEPRECATED("This method will be removed in a future version") uStoreBytes(uint8_t* ptr, T value, bool littleEndian) {
     if (!littleEndian)
         uReverseBytes(value);
 

--- a/Library/Core/UnoCore/Source/Uno/Buffer.uno
+++ b/Library/Core/UnoCore/Source/Uno/Buffer.uno
@@ -1,10 +1,10 @@
 using Uno.Compiler.ExportTargetInterop;
-using Uno.Runtime.Implementation;
 using Uno.Runtime.InteropServices;
 using Uno.IO;
 
 namespace Uno
 {
+    [Obsolete("Use extension methods on Uno.ByteArrayExtensions instead")]
     public sealed class Buffer
     {
         public static Buffer Load(BundleFile file)
@@ -89,386 +89,268 @@ namespace Uno
 
         public byte this[int offset]
         {
-            get { return GetByte(offset); }
-            set { Set(offset, value); }
+            get { return _data.GetByte(_offset + offset); }
+            set { _data.Set(_offset + offset, value); }
         }
 
         public sbyte GetSByte(int offset)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(sbyte))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return (sbyte)_data[_offset + offset];
+            return _data.GetSByte(_offset + offset);
         }
 
         public void Set(int offset, sbyte value)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(sbyte))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            _data[_offset + offset] = (byte)value;
+            _data.Set(_offset + offset, value);
         }
 
         public sbyte2 GetSByte2(int offset)
         {
-            return sbyte2(GetSByte(offset + 0), GetSByte(offset + 1));
+            return _data.GetSByte2(_offset + offset);
         }
 
         public void Set(int offset, sbyte2 value)
         {
-            Set(offset + 0, value.X);
-            Set(offset + 1, value.Y);
+            _data.Set(_offset + offset, value);
         }
 
         public sbyte4 GetSByte4(int offset)
         {
-            return sbyte4(GetSByte(offset + 0), GetSByte(offset + 1), GetSByte(offset + 2), GetSByte(offset + 3));
+            return _data.GetSByte4(_offset + offset);
         }
 
         public void Set(int offset, sbyte4 value)
         {
-            Set(offset + 0, value.X);
-            Set(offset + 1, value.Y);
-            Set(offset + 2, value.Z);
-            Set(offset + 3, value.W);
+            _data.Set(_offset + offset, value);
         }
 
         public byte GetByte(int offset)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(byte))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return _data[_offset + offset];
+            return _data.GetByte(_offset + offset);
         }
 
         public void Set(int offset, byte value)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(byte))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            _data[_offset + offset] = value;
+            _data.Set(_offset + offset, value);
         }
 
         public byte2 GetByte2(int offset)
         {
-            return byte2(GetByte(offset + 0), GetByte(offset + 1));
+            return _data.GetByte2(_offset + offset);
         }
 
         public void Set(int offset, byte2 value)
         {
-            Set(offset + 0, value.X);
-            Set(offset + 1, value.Y);
+            _data.Set(_offset + offset, value);
         }
 
         public byte4 GetByte4(int offset)
         {
-            return byte4(GetByte(offset + 0), GetByte(offset + 1), GetByte(offset + 2), GetByte(offset + 3));
+            return _data.GetByte4(_offset + offset);
         }
 
         public void Set(int offset, byte4 value)
         {
-            Set(offset + 0, value.X);
-            Set(offset + 1, value.Y);
-            Set(offset + 2, value.Z);
-            Set(offset + 3, value.W);
+            _data.Set(_offset + offset, value);
         }
 
         public short GetShort(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(short))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetShort(_data, _offset + offset, littleEndian);
+            return _data.GetShort(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, short value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(short))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetShort(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public short2 GetShort2(int offset, bool littleEndian = true)
         {
-            return short2(GetShort(offset + 0, littleEndian), GetShort(offset + 2, littleEndian));
+            return _data.GetShort2(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, short2 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 2, value.Y, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public short4 GetShort4(int offset, bool littleEndian = true)
         {
-            return short4(GetShort(offset + 0, littleEndian), GetShort(offset + 2, littleEndian), GetShort(offset + 4, littleEndian), GetShort(offset + 6, littleEndian));
+            return _data.GetShort4(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, short4 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 2, value.Y, littleEndian);
-            Set(offset + 4, value.Z, littleEndian);
-            Set(offset + 6, value.W, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public ushort GetUShort(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(ushort))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetUShort(_data, _offset + offset, littleEndian);
+            return _data.GetUShort(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, ushort value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(ushort))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetUShort(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public ushort2 GetUShort2(int offset, bool littleEndian = true)
         {
-            return ushort2(GetUShort(offset + 0, littleEndian), GetUShort(offset + 2, littleEndian));
+            return _data.GetUShort2(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, ushort2 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 2, value.Y, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public ushort4 GetUShort4(int offset, bool littleEndian = true)
         {
-            return ushort4(GetUShort(offset + 0, littleEndian), GetUShort(offset + 2, littleEndian), GetUShort(offset + 4, littleEndian), GetUShort(offset + 6, littleEndian));
+            return _data.GetUShort4(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, ushort4 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 2, value.Y, littleEndian);
-            Set(offset + 4, value.Z, littleEndian);
-            Set(offset + 6, value.W, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public int GetInt(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(int))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetInt(_data, _offset + offset, littleEndian);
+            return _data.GetInt(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, int value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(int))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetInt(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public int2 GetInt2(int offset, bool littleEndian = true)
         {
-            return int2(GetInt(offset + 0, littleEndian), GetInt(offset + 4, littleEndian));
+            return _data.GetInt2(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, int2 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 4, value.Y, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public int3 GetInt3(int offset, bool littleEndian = true)
         {
-            return int3(GetInt(offset + 0, littleEndian), GetInt(offset + 4, littleEndian), GetInt(offset + 8, littleEndian));
+            return _data.GetInt3(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, int3 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 4, value.Y, littleEndian);
-            Set(offset + 8, value.Z, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public int4 GetInt4(int offset, bool littleEndian = true)
         {
-            return int4(GetInt(offset + 0, littleEndian), GetInt(offset + 4, littleEndian), GetInt(offset + 8, littleEndian), GetInt(offset + 12, littleEndian));
+            return _data.GetInt4(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, int4 value, bool littleEndian = true)
         {
-            Set(offset + 00, value.X, littleEndian);
-            Set(offset + 04, value.Y, littleEndian);
-            Set(offset + 08, value.Z, littleEndian);
-            Set(offset + 12, value.W, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public uint GetUInt(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(uint))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetUInt(_data, _offset + offset, littleEndian);
+            return _data.GetUInt(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, uint value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(uint))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetUInt(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public long GetLong(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(long))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetLong(_data, _offset + offset, littleEndian);
+            return _data.GetLong(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, long value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(long))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetLong(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public ulong GetULong(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(ulong))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetULong(_data, _offset + offset, littleEndian);
+            return _data.GetULong(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, ulong value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(ulong))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetULong(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float GetFloat(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(float))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetFloat(_data, _offset + offset, littleEndian);
+            return _data.GetFloat(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(float))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetFloat(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float2 GetFloat2(int offset, bool littleEndian = true)
         {
-            return float2(GetFloat(offset + 0, littleEndian), GetFloat(offset + 4, littleEndian));
+            return _data.GetFloat2(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float2 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 4, value.Y, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float3 GetFloat3(int offset, bool littleEndian = true)
         {
-            return float3(GetFloat(offset + 0, littleEndian), GetFloat(offset + 4, littleEndian), GetFloat(offset + 8, littleEndian));
+            return _data.GetFloat3(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float3 value, bool littleEndian = true)
         {
-            Set(offset + 0, value.X, littleEndian);
-            Set(offset + 4, value.Y, littleEndian);
-            Set(offset + 8, value.Z, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float4 GetFloat4(int offset, bool littleEndian = true)
         {
-            return float4(GetFloat(offset + 0, littleEndian), GetFloat(offset + 4, littleEndian), GetFloat(offset + 8, littleEndian), GetFloat(offset + 12, littleEndian));
+            return _data.GetFloat4(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float4 value, bool littleEndian = true)
         {
-            Set(offset + 00, value.X, littleEndian);
-            Set(offset + 04, value.Y, littleEndian);
-            Set(offset + 08, value.Z, littleEndian);
-            Set(offset + 12, value.W, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float3x3 GetFloat3x3(int offset, bool littleEndian = true)
         {
-            return float3x3(
-                GetFloat(offset + 00, littleEndian), GetFloat(offset + 04, littleEndian), GetFloat(offset + 08, littleEndian),
-                GetFloat(offset + 12, littleEndian), GetFloat(offset + 16, littleEndian), GetFloat(offset + 20, littleEndian),
-                GetFloat(offset + 24, littleEndian), GetFloat(offset + 28, littleEndian), GetFloat(offset + 32, littleEndian));
+            return _data.GetFloat3x3(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float3x3 value, bool littleEndian = true)
         {
-            Set(offset + 00, value.M11, littleEndian);
-            Set(offset + 04, value.M12, littleEndian);
-            Set(offset + 08, value.M13, littleEndian);
-            Set(offset + 12, value.M21, littleEndian);
-            Set(offset + 16, value.M22, littleEndian);
-            Set(offset + 20, value.M23, littleEndian);
-            Set(offset + 24, value.M31, littleEndian);
-            Set(offset + 28, value.M32, littleEndian);
-            Set(offset + 32, value.M33, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public float4x4 GetFloat4x4(int offset, bool littleEndian = true)
         {
-            return float4x4(
-                GetFloat(offset + 00, littleEndian), GetFloat(offset + 04, littleEndian), GetFloat(offset + 08, littleEndian), GetFloat(offset + 12, littleEndian),
-                GetFloat(offset + 16, littleEndian), GetFloat(offset + 20, littleEndian), GetFloat(offset + 24, littleEndian), GetFloat(offset + 28, littleEndian),
-                GetFloat(offset + 32, littleEndian), GetFloat(offset + 36, littleEndian), GetFloat(offset + 40, littleEndian), GetFloat(offset + 44, littleEndian),
-                GetFloat(offset + 48, littleEndian), GetFloat(offset + 52, littleEndian), GetFloat(offset + 56, littleEndian), GetFloat(offset + 60, littleEndian));
+            return _data.GetFloat4x4(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, float4x4 value, bool littleEndian = true)
         {
-            Set(offset + 00, value.M11, littleEndian);
-            Set(offset + 04, value.M12, littleEndian);
-            Set(offset + 08, value.M13, littleEndian);
-            Set(offset + 12, value.M14, littleEndian);
-            Set(offset + 16, value.M21, littleEndian);
-            Set(offset + 20, value.M22, littleEndian);
-            Set(offset + 24, value.M23, littleEndian);
-            Set(offset + 28, value.M24, littleEndian);
-            Set(offset + 32, value.M31, littleEndian);
-            Set(offset + 36, value.M32, littleEndian);
-            Set(offset + 40, value.M33, littleEndian);
-            Set(offset + 44, value.M34, littleEndian);
-            Set(offset + 48, value.M41, littleEndian);
-            Set(offset + 52, value.M42, littleEndian);
-            Set(offset + 56, value.M43, littleEndian);
-            Set(offset + 60, value.M44, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public double GetDouble(int offset, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(double))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            return BufferImpl.GetDouble(_data, _offset + offset, littleEndian);
+            return _data.GetDouble(_offset + offset, littleEndian);
         }
 
         public void Set(int offset, double value, bool littleEndian = true)
         {
-            if (offset < 0 || _sizeInBytes < offset + sizeof(double))
-                throw new ArgumentOutOfRangeException(nameof(offset));
-
-            BufferImpl.SetDouble(_data, _offset + offset, value, littleEndian);
+            _data.Set(_offset + offset, value, littleEndian);
         }
 
         public IntPtr PinPtr(out GCHandle pin)

--- a/Library/Core/UnoCore/Source/Uno/ByteArrayExtensions.uno
+++ b/Library/Core/UnoCore/Source/Uno/ByteArrayExtensions.uno
@@ -1,0 +1,721 @@
+using Uno.Compiler.ExportTargetInterop;
+
+namespace Uno
+{
+    public static class ByteArrayExtensions
+    {
+        public static sbyte GetSByte(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return (sbyte)bytes[offset];
+        }
+
+        public static void Set(this byte[] bytes, int offset, sbyte value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset] = (byte)value;
+        }
+
+        public static byte GetByte(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return bytes[offset];
+        }
+
+        public static void Set(this byte[] bytes, int offset, byte value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset] = value;
+        }
+
+        public static short GetShort(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(short))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{short} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToInt16(bytes.GetBytes(offset, 2, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, short value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(short))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static ushort GetUShort(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(ushort))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{ushort} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToUInt16(bytes.GetBytes(offset, 2, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, ushort value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(ushort))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static int GetInt(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(int))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{int} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToInt32(bytes.GetBytes(offset, 4, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, int value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(int))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static uint GetUInt(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(uint))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{uint} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToUInt32(bytes.GetBytes(offset, 4, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, uint value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(uint))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static long GetLong(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(long))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{long} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToInt64(bytes.GetBytes(offset, 8, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, long value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(long))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static ulong GetULong(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(ulong))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{ulong} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToUInt64(bytes.GetBytes(offset, 8, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, ulong value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(ulong))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static float GetFloat(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(float))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{float} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToSingle(bytes.GetBytes(offset, 4, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, float value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(float))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        public static double GetDouble(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(double))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                @{double} result;
+                memcpy(&result, (uint8_t*)$0->_ptr + $1, sizeof(result));
+                if (!$2)
+                    @{ReverseBytes(IntPtr, ulong):Call(&result, sizeof(result))};
+                return result;
+            @}
+            else if defined(DOTNET)
+            {
+                return System.BitConverter.ToDouble(bytes.GetBytes(offset, 8, littleEndian), 0);
+            }
+            else
+                build_error;
+        }
+
+        public static void Set(this byte[] bytes, int offset, double value, bool littleEndian = true)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(double))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if defined(CPLUSPLUS)
+            @{
+                if (!$3)
+                    @{ReverseBytes(IntPtr, ulong):Call(&$2, sizeof($2))};
+                memcpy((uint8_t*)$0->_ptr + $1, &$2, sizeof($2));
+            @}
+            else if defined(DOTNET)
+            {
+                bytes.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
+            }
+            else
+                build_error;
+        }
+
+        // Vector types
+
+        public static sbyte2 GetSByte2(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(sbyte2))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return sbyte2(
+                (sbyte) bytes[offset    ], 
+                (sbyte) bytes[offset + 1]);
+        }
+
+        public static void Set(this byte[] bytes, int offset, sbyte2 value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(sbyte2))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset    ] = (byte) value.X;
+            bytes[offset + 1] = (byte) value.Y;
+        }
+
+        public static sbyte4 GetSByte4(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(sbyte4))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return sbyte4(
+                (sbyte) bytes[offset    ], 
+                (sbyte) bytes[offset + 1], 
+                (sbyte) bytes[offset + 2], 
+                (sbyte) bytes[offset + 3]);
+        }
+
+        public static void Set(this byte[] bytes, int offset, sbyte4 value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(sbyte4))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset    ] = (byte) value.X;
+            bytes[offset + 1] = (byte) value.Y;
+            bytes[offset + 2] = (byte) value.Z;
+            bytes[offset + 3] = (byte) value.W;
+        }
+
+        public static byte2 GetByte2(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte2))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return byte2(bytes[offset], bytes[offset + 1]);
+        }
+
+        public static void Set(this byte[] bytes, int offset, byte2 value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte2))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset    ] = value.X;
+            bytes[offset + 1] = value.Y;
+        }
+
+        public static byte4 GetByte4(this byte[] bytes, int offset)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte4))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            return byte4(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]);
+        }
+
+        public static void Set(this byte[] bytes, int offset, byte4 value)
+        {
+            if (offset < 0 || bytes.Length < offset + sizeof(byte4))
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            bytes[offset    ] = value.X;
+            bytes[offset + 1] = value.Y;
+            bytes[offset + 2] = value.Z;
+            bytes[offset + 3] = value.W;
+        }
+
+        public static short2 GetShort2(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return short2(bytes.GetShort(offset, littleEndian), bytes.GetShort(offset + 2, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, short2 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 2, value.Y, littleEndian);
+        }
+
+        public static short4 GetShort4(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return short4(
+                bytes.GetShort(offset    , littleEndian), 
+                bytes.GetShort(offset + 2, littleEndian), 
+                bytes.GetShort(offset + 4, littleEndian), 
+                bytes.GetShort(offset + 6, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, short4 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 2, value.Y, littleEndian);
+            bytes.Set(offset + 4, value.Z, littleEndian);
+            bytes.Set(offset + 6, value.W, littleEndian);
+        }
+
+        public static ushort2 GetUShort2(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return ushort2(bytes.GetUShort(offset    , littleEndian), bytes.GetUShort(offset + 2, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, ushort2 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 2, value.Y, littleEndian);
+        }
+
+        public static ushort4 GetUShort4(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return ushort4(
+                bytes.GetUShort(offset    , littleEndian), 
+                bytes.GetUShort(offset + 2, littleEndian), 
+                bytes.GetUShort(offset + 4, littleEndian), 
+                bytes.GetUShort(offset + 6, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, ushort4 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 2, value.Y, littleEndian);
+            bytes.Set(offset + 4, value.Z, littleEndian);
+            bytes.Set(offset + 6, value.W, littleEndian);
+        }
+
+        public static int2 GetInt2(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return int2(bytes.GetInt(offset    , littleEndian), bytes.GetInt(offset + 4, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, int2 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 4, value.Y, littleEndian);
+        }
+
+        public static int3 GetInt3(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return int3(
+                bytes.GetInt(offset    , littleEndian), 
+                bytes.GetInt(offset + 4, littleEndian), 
+                bytes.GetInt(offset + 8, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, int3 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 4, value.Y, littleEndian);
+            bytes.Set(offset + 8, value.Z, littleEndian);
+        }
+
+        public static int4 GetInt4(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return int4(
+                bytes.GetInt(offset     , littleEndian), 
+                bytes.GetInt(offset +  4, littleEndian), 
+                bytes.GetInt(offset +  8, littleEndian), 
+                bytes.GetInt(offset + 12, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, int4 value, bool littleEndian = true)
+        {
+            bytes.Set(offset     , value.X, littleEndian);
+            bytes.Set(offset +  4, value.Y, littleEndian);
+            bytes.Set(offset +  8, value.Z, littleEndian);
+            bytes.Set(offset + 12, value.W, littleEndian);
+        }
+
+        public static float2 GetFloat2(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return float2(bytes.GetFloat(offset    , littleEndian), bytes.GetFloat(offset + 4, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, float2 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 4, value.Y, littleEndian);
+        }
+
+        public static float3 GetFloat3(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return float3(
+                bytes.GetFloat(offset    , littleEndian), 
+                bytes.GetFloat(offset + 4, littleEndian), 
+                bytes.GetFloat(offset + 8, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, float3 value, bool littleEndian = true)
+        {
+            bytes.Set(offset    , value.X, littleEndian);
+            bytes.Set(offset + 4, value.Y, littleEndian);
+            bytes.Set(offset + 8, value.Z, littleEndian);
+        }
+
+        public static float4 GetFloat4(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return float4(
+                bytes.GetFloat(offset     , littleEndian), 
+                bytes.GetFloat(offset +  4, littleEndian), 
+                bytes.GetFloat(offset +  8, littleEndian), 
+                bytes.GetFloat(offset + 12, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, float4 value, bool littleEndian = true)
+        {
+            bytes.Set(offset     , value.X, littleEndian);
+            bytes.Set(offset +  4, value.Y, littleEndian);
+            bytes.Set(offset +  8, value.Z, littleEndian);
+            bytes.Set(offset + 12, value.W, littleEndian);
+        }
+
+        // Matrix types
+
+        public static float3x3 GetFloat3x3(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return float3x3(
+                bytes.GetFloat(offset     , littleEndian), bytes.GetFloat(offset +  4, littleEndian), bytes.GetFloat(offset +  8, littleEndian),
+                bytes.GetFloat(offset + 12, littleEndian), bytes.GetFloat(offset + 16, littleEndian), bytes.GetFloat(offset + 20, littleEndian),
+                bytes.GetFloat(offset + 24, littleEndian), bytes.GetFloat(offset + 28, littleEndian), bytes.GetFloat(offset + 32, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, float3x3 value, bool littleEndian = true)
+        {
+            bytes.Set(offset     , value.M11, littleEndian);
+            bytes.Set(offset +  4, value.M12, littleEndian);
+            bytes.Set(offset +  8, value.M13, littleEndian);
+            bytes.Set(offset + 12, value.M21, littleEndian);
+            bytes.Set(offset + 16, value.M22, littleEndian);
+            bytes.Set(offset + 20, value.M23, littleEndian);
+            bytes.Set(offset + 24, value.M31, littleEndian);
+            bytes.Set(offset + 28, value.M32, littleEndian);
+            bytes.Set(offset + 32, value.M33, littleEndian);
+        }
+
+        public static float4x4 GetFloat4x4(this byte[] bytes, int offset, bool littleEndian = true)
+        {
+            return float4x4(
+                bytes.GetFloat(offset     , littleEndian), bytes.GetFloat(offset +  4, littleEndian), bytes.GetFloat(offset +  8, littleEndian), bytes.GetFloat(offset + 12, littleEndian),
+                bytes.GetFloat(offset + 16, littleEndian), bytes.GetFloat(offset + 20, littleEndian), bytes.GetFloat(offset + 24, littleEndian), bytes.GetFloat(offset + 28, littleEndian),
+                bytes.GetFloat(offset + 32, littleEndian), bytes.GetFloat(offset + 36, littleEndian), bytes.GetFloat(offset + 40, littleEndian), bytes.GetFloat(offset + 44, littleEndian),
+                bytes.GetFloat(offset + 48, littleEndian), bytes.GetFloat(offset + 52, littleEndian), bytes.GetFloat(offset + 56, littleEndian), bytes.GetFloat(offset + 60, littleEndian));
+        }
+
+        public static void Set(this byte[] bytes, int offset, float4x4 value, bool littleEndian = true)
+        {
+            bytes.Set(offset     , value.M11, littleEndian);
+            bytes.Set(offset +  4, value.M12, littleEndian);
+            bytes.Set(offset +  8, value.M13, littleEndian);
+            bytes.Set(offset + 12, value.M14, littleEndian);
+            bytes.Set(offset + 16, value.M21, littleEndian);
+            bytes.Set(offset + 20, value.M22, littleEndian);
+            bytes.Set(offset + 24, value.M23, littleEndian);
+            bytes.Set(offset + 28, value.M24, littleEndian);
+            bytes.Set(offset + 32, value.M31, littleEndian);
+            bytes.Set(offset + 36, value.M32, littleEndian);
+            bytes.Set(offset + 40, value.M33, littleEndian);
+            bytes.Set(offset + 44, value.M34, littleEndian);
+            bytes.Set(offset + 48, value.M41, littleEndian);
+            bytes.Set(offset + 52, value.M42, littleEndian);
+            bytes.Set(offset + 56, value.M43, littleEndian);
+            bytes.Set(offset + 60, value.M44, littleEndian);
+        }
+
+        // .NET utilities
+
+        extern(DOTNET)
+        static byte[] GetBytes(this byte[] bytes, int offset, int count, bool littleEndian = true)
+        {
+            var result = new byte[count];
+            Array.Copy((Array) bytes, offset, result, 0, count);
+
+            if (!littleEndian)
+                Array.Reverse(result);
+
+            return result;
+        }
+
+        extern(DOTNET)
+        static void SetBytes(this byte[] bytes, int offset, byte[] value, bool littleEndian = true)
+        {
+            Array.Copy((Array) value, 0, bytes, offset, value.Length);
+
+            if (!littleEndian)
+                Array.Reverse(bytes, offset, value.Length);
+        }
+
+        // C++ utilities
+
+        extern(CPLUSPLUS)
+        static void ReverseBytes(IntPtr ptr, ulong size)
+        @{
+            uint64_t tmp;
+            uint8_t* dst = (uint8_t*)$0;
+            uint8_t* src = (uint8_t*)&tmp;
+
+            switch ($1)
+            {
+            case 2:
+                memcpy(src, dst, 2);
+                dst[0] = src[1];
+                dst[1] = src[0];
+                break;
+            case 4:
+                memcpy(src, dst, 4);
+                dst[0] = src[3];
+                dst[1] = src[2];
+                dst[2] = src[1];
+                dst[3] = src[0];
+                break;
+            case 8:
+                memcpy(src, dst, 8);
+                dst[0] = src[7];
+                dst[1] = src[6];
+                dst[2] = src[5];
+                dst[3] = src[4];
+                dst[4] = src[3];
+                dst[5] = src[2];
+                dst[6] = src[1];
+                dst[7] = src[0];
+                break;
+            default:
+                U_FATAL();
+            }
+        @}
+    }
+}
+
+namespace System
+{
+    [DotNetType]
+    extern(DOTNET)
+    class BitConverter
+    {
+        public static extern byte[] GetBytes(short value);
+        public static extern byte[] GetBytes(ushort value);
+        public static extern byte[] GetBytes(int value);
+        public static extern byte[] GetBytes(uint value);
+        public static extern byte[] GetBytes(long value);
+        public static extern byte[] GetBytes(ulong value);
+        public static extern byte[] GetBytes(float value);
+        public static extern byte[] GetBytes(double value);
+
+        public static extern short ToInt16(byte[] value, int startIndex);
+        public static extern ushort ToUInt16(byte[] value, int startIndex);
+        public static extern int ToInt32(byte[] value, int startIndex);
+        public static extern uint ToUInt32(byte[] value, int startIndex);
+        public static extern long ToInt64(byte[] value, int startIndex);
+        public static extern ulong ToUInt64(byte[] value, int startIndex);
+        public static extern float ToSingle(byte[] value, int startIndex);
+        public static extern double ToDouble(byte[] value, int startIndex);
+    }
+}

--- a/Library/Core/UnoCore/Source/Uno/Content/Fonts/CppFontFace.uno
+++ b/Library/Core/UnoCore/Source/Uno/Content/Fonts/CppFontFace.uno
@@ -1,4 +1,5 @@
 using Uno.Compiler.ExportTargetInterop;
+using Uno.Graphics;
 using Uno.IO;
 
 namespace Uno.Content.Fonts
@@ -78,23 +79,21 @@ namespace Uno.Content.Fonts
             return @{$$._handle}->ContainsGlyph($0, $1);
         @}
 
-        [Require("Source.Include", "@{int2:Include}")]
-        [Require("Source.Include", "@{float2:Include}")]
-        [Require("Source.Include", "@{Uno.Content.Images.Bitmap:Include}")]
-        [Require("Source.Include", "@{Uno.Content.Fonts.RenderedGlyph:Include}")]
         [Require("Source.Include", "uImage/Bitmap.h")]
         public override RenderedGlyph RenderGlyph(float size, char glyph)
         @{
             uBase::Vector2 advance, bearing;
             uBase::Auto<uImage::Bitmap> bitmap = @{$$._handle}->RenderGlyph($0, $1, uImage::FontRenderModeNormal, &advance, &bearing);
+            uArray* bytes = uArray::New(@{byte[]:TypeOf}, bitmap->GetSizeInBytes(), bitmap->GetPtr());
 
-            @{Uno.Buffer} resultBuffer = uBufferFromXliDataAccessor(bitmap);
-            @{Uno.Content.Images.Bitmap} resultBitmap = @{Uno.Content.Images.Bitmap(int2,Uno.Graphics.Format,Uno.Buffer):New(@{int2(int,int):New(bitmap->GetWidth(), bitmap->GetHeight())}, @{Uno.Graphics.Format.L8}, resultBuffer)};
-
-            return @{Uno.Content.Fonts.RenderedGlyph(float2,float2,Uno.Content.Images.Bitmap):New(@{float2(float,float):New(advance.X, advance.Y)}, @{float2(float,float):New(bearing.X, bearing.Y)}, resultBitmap)};
+            return @{Uno.Content.Fonts.RenderedGlyph(float2,float2,int2,Format,byte[]):New(
+                @{float2(float,float):New(advance.X, advance.Y)},
+                @{float2(float,float):New(bearing.X, bearing.Y)},
+                @{int2(int,int):New(bitmap->GetWidth(), bitmap->GetHeight())},
+                @{Uno.Graphics.Format.L8},
+                bytes)};
         @}
 
-        [Require("Source.Include", "@{float2:Include}")]
         public override bool TryGetKerning(float size, char left, char right, out float2 result)
         @{
             uBase::Vector2 kerning;

--- a/Library/Core/UnoCore/Source/Uno/Content/Fonts/DotNetFontFace.uno
+++ b/Library/Core/UnoCore/Source/Uno/Content/Fonts/DotNetFontFace.uno
@@ -47,11 +47,13 @@ namespace Uno.Content.Fonts
 
             // TODO: Format is hardcoded
 
-            return new RenderedGlyph()
+            return new RenderedGlyph
             {
                 Advance = new Float2(g.AdvanceX, g.AdvanceY),
                 Bearing = new Float2(g.BearingX, g.BearingY),
-                Bitmap = new Bitmap(new Int2(g.Width, g.Height), Format.L8, new Buffer(g.Bitmap)),
+                Size = new Int2(g.Width, g.Height),
+                Format = Format.L8,
+                Data = g.Bitmap
             };
         }
 

--- a/Library/Core/UnoCore/Source/Uno/Content/Fonts/RenderedGlyph.uno
+++ b/Library/Core/UnoCore/Source/Uno/Content/Fonts/RenderedGlyph.uno
@@ -1,5 +1,6 @@
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Content.Images;
+using Uno.Graphics;
 
 namespace Uno.Content.Fonts
 {
@@ -7,13 +8,33 @@ namespace Uno.Content.Fonts
     {
         public float2 Advance;
         public float2 Bearing;
-        public Bitmap Bitmap;
+        public int2 Size;
+        public Format Format;
+        public byte[] Data;
 
+        public RenderedGlyph(float2 advance, float2 bearing, int2 size, Format format, byte[] data)
+        {
+            Advance = advance;
+            Bearing = bearing;
+            Size = size;
+            Format = format;
+            Data = data;
+        }
+
+        [Obsolete]
         public RenderedGlyph(float2 advance, float2 bearing, Bitmap bitmap)
         {
             Advance = advance;
             Bearing = bearing;
-            Bitmap = bitmap;
+            Size = bitmap.Size;
+            Format = bitmap.Format;
+            Data = bitmap.Buffer.GetBytes();
+        }
+
+        [Obsolete]
+        public Bitmap Bitmap
+        {
+            get { return new Bitmap(Size, Format, new Buffer(Data)); }
         }
     }
 }

--- a/Library/Core/UnoCore/Source/Uno/Content/Images/Bitmap.uno
+++ b/Library/Core/UnoCore/Source/Uno/Content/Images/Bitmap.uno
@@ -3,6 +3,7 @@ using Uno.Graphics;
 
 namespace Uno.Content.Images
 {
+    [Obsolete]
     public class Bitmap
     {
         public int2 Size

--- a/Library/Core/UnoCore/Source/Uno/IO/BinaryReader.uno
+++ b/Library/Core/UnoCore/Source/Uno/IO/BinaryReader.uno
@@ -1,5 +1,4 @@
 using Uno.Collections;
-using Uno.Runtime.Implementation;
 using Uno.Text;
 
 namespace Uno.IO
@@ -121,49 +120,49 @@ namespace Uno.IO
         public short ReadShort()
         {
             FillBuffer(2);
-            return BufferImpl.GetShort(_buffer, 0, LittleEndian);
+            return _buffer.GetShort(0, LittleEndian);
         }
 
         public ushort ReadUShort()
         {
             FillBuffer(2);
-            return BufferImpl.GetUShort(_buffer, 0, LittleEndian);
+            return _buffer.GetUShort(0, LittleEndian);
         }
 
         public int ReadInt()
         {
             FillBuffer(4);
-            return BufferImpl.GetInt(_buffer, 0, LittleEndian);
+            return _buffer.GetInt(0, LittleEndian);
         }
 
         public uint ReadUInt()
         {
             FillBuffer(4);
-            return BufferImpl.GetUInt(_buffer, 0, LittleEndian);
+            return _buffer.GetUInt(0, LittleEndian);
         }
 
         public long ReadLong()
         {
             FillBuffer(8);
-            return BufferImpl.GetLong(_buffer, 0, LittleEndian);
+            return _buffer.GetLong(0, LittleEndian);
         }
 
         public ulong ReadULong()
         {
             FillBuffer(8);
-            return BufferImpl.GetULong(_buffer, 0, LittleEndian);
+            return _buffer.GetULong(0, LittleEndian);
         }
 
         public float ReadFloat()
         {
             FillBuffer(4);
-            return BufferImpl.GetFloat(_buffer, 0, LittleEndian);
+            return _buffer.GetFloat(0, LittleEndian);
         }
 
         public double ReadDouble()
         {
             FillBuffer(8);
-            return BufferImpl.GetDouble(_buffer, 0, LittleEndian);
+            return _buffer.GetDouble(0, LittleEndian);
         }
 
         public sbyte2 ReadSByte2()
@@ -206,127 +205,127 @@ namespace Uno.IO
         {
             FillBuffer(4);
             return short2(
-                BufferImpl.GetShort(_buffer, 0, LittleEndian),
-                BufferImpl.GetShort(_buffer, 2, LittleEndian));
+                _buffer.GetShort(0, LittleEndian),
+                _buffer.GetShort(2, LittleEndian));
         }
 
         public short4 ReadShort4()
         {
             FillBuffer(8);
             return short4(
-                BufferImpl.GetShort(_buffer, 0, LittleEndian),
-                BufferImpl.GetShort(_buffer, 2, LittleEndian),
-                BufferImpl.GetShort(_buffer, 4, LittleEndian),
-                BufferImpl.GetShort(_buffer, 6, LittleEndian));
+                _buffer.GetShort(0, LittleEndian),
+                _buffer.GetShort(2, LittleEndian),
+                _buffer.GetShort(4, LittleEndian),
+                _buffer.GetShort(6, LittleEndian));
         }
 
         public ushort2 ReadUShort2()
         {
             FillBuffer(4);
             return ushort2(
-                BufferImpl.GetUShort(_buffer, 0, LittleEndian),
-                BufferImpl.GetUShort(_buffer, 2, LittleEndian));
+                _buffer.GetUShort(0, LittleEndian),
+                _buffer.GetUShort(2, LittleEndian));
         }
 
         public ushort4 ReadUShort4()
         {
             FillBuffer(8);
             return ushort4(
-                BufferImpl.GetUShort(_buffer, 0, LittleEndian),
-                BufferImpl.GetUShort(_buffer, 2, LittleEndian),
-                BufferImpl.GetUShort(_buffer, 4, LittleEndian),
-                BufferImpl.GetUShort(_buffer, 6, LittleEndian));
+                _buffer.GetUShort(0, LittleEndian),
+                _buffer.GetUShort(2, LittleEndian),
+                _buffer.GetUShort(4, LittleEndian),
+                _buffer.GetUShort(6, LittleEndian));
         }
 
         public int2 ReadInt2()
         {
             FillBuffer(8);
             return int2(
-                BufferImpl.GetInt(_buffer, 0, LittleEndian),
-                BufferImpl.GetInt(_buffer, 4, LittleEndian));
+                _buffer.GetInt(0, LittleEndian),
+                _buffer.GetInt(4, LittleEndian));
         }
 
         public int3 ReadInt3()
         {
             FillBuffer(12);
             return int3(
-                BufferImpl.GetInt(_buffer, 00, LittleEndian),
-                BufferImpl.GetInt(_buffer, 04, LittleEndian),
-                BufferImpl.GetInt(_buffer, 08, LittleEndian));
+                _buffer.GetInt(00, LittleEndian),
+                _buffer.GetInt(04, LittleEndian),
+                _buffer.GetInt(08, LittleEndian));
         }
 
         public int4 ReadInt4()
         {
             FillBuffer(16);
             return int4(
-                BufferImpl.GetInt(_buffer, 00, LittleEndian),
-                BufferImpl.GetInt(_buffer, 04, LittleEndian),
-                BufferImpl.GetInt(_buffer, 08, LittleEndian),
-                BufferImpl.GetInt(_buffer, 12, LittleEndian));
+                _buffer.GetInt(00, LittleEndian),
+                _buffer.GetInt(04, LittleEndian),
+                _buffer.GetInt(08, LittleEndian),
+                _buffer.GetInt(12, LittleEndian));
         }
 
         public float2 ReadFloat2()
         {
             FillBuffer(8);
             return float2(
-                BufferImpl.GetFloat(_buffer, 0, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 4, LittleEndian));
+                _buffer.GetFloat(0, LittleEndian),
+                _buffer.GetFloat(4, LittleEndian));
         }
 
         public float3 ReadFloat3()
         {
             FillBuffer(12);
             return float3(
-                BufferImpl.GetFloat(_buffer, 0, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 4, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 8, LittleEndian));
+                _buffer.GetFloat(0, LittleEndian),
+                _buffer.GetFloat(4, LittleEndian),
+                _buffer.GetFloat(8, LittleEndian));
         }
 
         public float4 ReadFloat4()
         {
             FillBuffer(16);
             return float4(
-                BufferImpl.GetFloat(_buffer, 00, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 04, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 08, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 12, LittleEndian));
+                _buffer.GetFloat(00, LittleEndian),
+                _buffer.GetFloat(04, LittleEndian),
+                _buffer.GetFloat(08, LittleEndian),
+                _buffer.GetFloat(12, LittleEndian));
         }
 
         public float3x3 ReadFloat3x3()
         {
             FillBuffer(36);
             return float3x3(
-                BufferImpl.GetFloat(_buffer, 00, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 04, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 08, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 12, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 16, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 20, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 24, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 28, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 32, LittleEndian));
+                _buffer.GetFloat(00, LittleEndian),
+                _buffer.GetFloat(04, LittleEndian),
+                _buffer.GetFloat(08, LittleEndian),
+                _buffer.GetFloat(12, LittleEndian),
+                _buffer.GetFloat(16, LittleEndian),
+                _buffer.GetFloat(20, LittleEndian),
+                _buffer.GetFloat(24, LittleEndian),
+                _buffer.GetFloat(28, LittleEndian),
+                _buffer.GetFloat(32, LittleEndian));
         }
 
         public float4x4 ReadFloat4x4()
         {
             FillBuffer(64);
             return float4x4(
-                BufferImpl.GetFloat(_buffer, 00, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 04, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 08, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 12, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 16, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 20, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 24, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 28, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 32, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 36, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 40, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 44, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 48, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 52, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 56, LittleEndian),
-                BufferImpl.GetFloat(_buffer, 60, LittleEndian));
+                _buffer.GetFloat(00, LittleEndian),
+                _buffer.GetFloat(04, LittleEndian),
+                _buffer.GetFloat(08, LittleEndian),
+                _buffer.GetFloat(12, LittleEndian),
+                _buffer.GetFloat(16, LittleEndian),
+                _buffer.GetFloat(20, LittleEndian),
+                _buffer.GetFloat(24, LittleEndian),
+                _buffer.GetFloat(28, LittleEndian),
+                _buffer.GetFloat(32, LittleEndian),
+                _buffer.GetFloat(36, LittleEndian),
+                _buffer.GetFloat(40, LittleEndian),
+                _buffer.GetFloat(44, LittleEndian),
+                _buffer.GetFloat(48, LittleEndian),
+                _buffer.GetFloat(52, LittleEndian),
+                _buffer.GetFloat(56, LittleEndian),
+                _buffer.GetFloat(60, LittleEndian));
         }
 
         protected internal int Read7BitEncodedInt()

--- a/Library/Core/UnoCore/Source/Uno/IO/BinaryWriter.uno
+++ b/Library/Core/UnoCore/Source/Uno/IO/BinaryWriter.uno
@@ -1,4 +1,3 @@
-using Uno.Runtime.Implementation;
 using Uno.Text;
 
 namespace Uno.IO
@@ -63,49 +62,49 @@ namespace Uno.IO
 
         public void Write(short value)
         {
-            BufferImpl.SetShort(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 2);
         }
 
         public void Write(ushort value)
         {
-            BufferImpl.SetUShort(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 2);
         }
 
         public void Write(int value)
         {
-            BufferImpl.SetInt(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 4);
         }
 
         public void Write(uint value)
         {
-            BufferImpl.SetUInt(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 4);
         }
 
         public void Write(long value)
         {
-            BufferImpl.SetLong(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(ulong value)
         {
-            BufferImpl.SetULong(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(float value)
         {
-            BufferImpl.SetFloat(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 4);
         }
 
         public void Write(double value)
         {
-            BufferImpl.SetDouble(_buffer, 0, value, LittleEndian);
+            _buffer.Set(0, value, LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
@@ -140,70 +139,70 @@ namespace Uno.IO
         public void Write(short2 value)
         {
             for (int i = 0; i < 2; ++i)
-                BufferImpl.SetShort(_buffer, i*2, value[i], LittleEndian);
+                _buffer.Set(i*2, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 4);
         }
 
         public void Write(short4 value)
         {
             for (int i = 0; i < 4; ++i)
-                BufferImpl.SetShort(_buffer, i*2, value[i], LittleEndian);
+                _buffer.Set(i*2, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(ushort2 value)
         {
             for (int i = 0; i < 2; ++i)
-                BufferImpl.SetUShort(_buffer, i*2, value[i], LittleEndian);
+                _buffer.Set(i*2, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 4);
         }
 
         public void Write(ushort4 value)
         {
             for (int i = 0; i < 4; ++i)
-                BufferImpl.SetUShort(_buffer, i*2, value[i], LittleEndian);
+                _buffer.Set(i*2, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(int2 value)
         {
             for (int i = 0; i < 2; ++i)
-                BufferImpl.SetInt(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(int3 value)
         {
             for (int i = 0; i < 3; ++i)
-                BufferImpl.SetInt(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 12);
         }
 
         public void Write(int4 value)
         {
             for (int i = 0; i < 4; ++i)
-                BufferImpl.SetInt(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 16);
         }
 
         public void Write(float2 value)
         {
             for (int i = 0; i < 2; ++i)
-                BufferImpl.SetFloat(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 8);
         }
 
         public void Write(float3 value)
         {
             for (int i = 0; i < 3; ++i)
-                BufferImpl.SetFloat(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 12);
         }
 
         public void Write(float4 value)
         {
             for (int i = 0; i < 4; ++i)
-                BufferImpl.SetFloat(_buffer, i*4, value[i], LittleEndian);
+                _buffer.Set(i*4, value[i], LittleEndian);
             _stream.Write(_buffer, 0, 16);
         }
 

--- a/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/BufferImpl.uno
+++ b/Library/Core/UnoCore/Source/Uno/Runtime/Implementation/BufferImpl.uno
@@ -2,278 +2,87 @@ using Uno.Compiler.ExportTargetInterop;
 
 namespace Uno.Runtime.Implementation
 {
-    [extern(CPLUSPLUS) Require("Source.Include", "Uno/Support.h")]
+    [Obsolete("Use extension methods on Uno.ByteArrayExtensions instead")]
     public static class BufferImpl
     {
-        public static short GetShort(this byte[] buffer, int offset, bool littleEndian)
+        public static short GetShort(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<int16_t>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToInt16(buffer.GetBytes(offset, 2, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetShort(buffer, offset, littleEndian);
         }
 
-        public static void SetShort(this byte[] buffer, int offset, short value, bool littleEndian)
+        public static void SetShort(byte[] buffer, int offset, short value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static ushort GetUShort(this byte[] buffer, int offset, bool littleEndian)
+        public static ushort GetUShort(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<uint16_t>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToUInt16(buffer.GetBytes(offset, 2, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetUShort(buffer, offset, littleEndian);
         }
 
-        public static void SetUShort(this byte[] buffer, int offset, ushort value, bool littleEndian)
+        public static void SetUShort(byte[] buffer, int offset, ushort value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static int GetInt(this byte[] buffer, int offset, bool littleEndian)
+        public static int GetInt(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<int>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToInt32(buffer.GetBytes(offset, 4, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetInt(buffer, offset, littleEndian);
         }
 
-        public static void SetInt(this byte[] buffer, int offset, int value, bool littleEndian)
+        public static void SetInt(byte[] buffer, int offset, int value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static uint GetUInt(this byte[] buffer, int offset, bool littleEndian)
+        public static uint GetUInt(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<uint32_t>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToUInt32(buffer.GetBytes(offset, 4, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetUInt(buffer, offset, littleEndian);
         }
 
-        public static void SetUInt(this byte[] buffer, int offset, uint value, bool littleEndian)
+        public static void SetUInt(byte[] buffer, int offset, uint value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static long GetLong(this byte[] buffer, int offset, bool littleEndian)
+        public static long GetLong(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<int64_t>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToInt64(buffer.GetBytes(offset, 8, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetLong(buffer, offset, littleEndian);
         }
 
-        public static void SetLong(this byte[] buffer, int offset, long value, bool littleEndian)
+        public static void SetLong(byte[] buffer, int offset, long value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static ulong GetULong(this byte[] buffer, int offset, bool littleEndian)
+        public static ulong GetULong(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<uint64_t>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToUInt64(buffer.GetBytes(offset, 8, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetULong(buffer, offset, littleEndian);
         }
 
-        public static void SetULong(this byte[] buffer, int offset, ulong value, bool littleEndian)
+        public static void SetULong(byte[] buffer, int offset, ulong value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static float GetFloat(this byte[] buffer, int offset, bool littleEndian)
+        public static float GetFloat(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<float>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToSingle(buffer.GetBytes(offset, 4, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetFloat(buffer, offset, littleEndian);
         }
 
-        public static void SetFloat(this byte[] buffer, int offset, float value, bool littleEndian)
+        public static void SetFloat(byte[] buffer, int offset, float value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
 
-        public static double GetDouble(this byte[] buffer, int offset, bool littleEndian)
+        public static double GetDouble(byte[] buffer, int offset, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                return uLoadBytes<double>((uint8_t*)$0->_ptr + $1, $2);
-            @}
-            else if defined(DOTNET)
-            {
-                return System.BitConverter.ToDouble(buffer.GetBytes(offset, 8, littleEndian), 0);
-            }
-            else
-                build_error;
+            return ByteArrayExtensions.GetDouble(buffer, offset, littleEndian);
         }
 
-        public static void SetDouble(this byte[] buffer, int offset, double value, bool littleEndian)
+        public static void SetDouble(byte[] buffer, int offset, double value, bool littleEndian)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uStoreBytes((uint8_t*)$0->_ptr + $1, $2, $3);
-            @}
-            else if defined(DOTNET)
-            {
-                buffer.SetBytes(offset, System.BitConverter.GetBytes(value), littleEndian);
-            }
-            else
-                build_error;
+            ByteArrayExtensions.Set(buffer, offset, value, littleEndian);
         }
-
-        extern(DOTNET)
-        static byte[] GetBytes(this byte[] buffer, int offset, int count, bool littleEndian)
-        {
-            var result = new byte[count];
-            Array.Copy((Array) buffer, offset, result, 0, count);
-
-            if (!littleEndian)
-                Array.Reverse(result);
-
-            return result;
-        }
-
-        extern(DOTNET)
-        static void SetBytes(this byte[] buffer, int offset, byte[] value, bool littleEndian)
-        {
-            Array.Copy((Array) value, 0, buffer, offset, value.Length);
-
-            if (!littleEndian)
-                Array.Reverse(buffer, offset, value.Length);
-        }
-    }
-}
-
-namespace System
-{
-    [DotNetType]
-    extern(DOTNET)
-    class BitConverter
-    {
-        public static extern byte[] GetBytes(short value);
-        public static extern byte[] GetBytes(ushort value);
-        public static extern byte[] GetBytes(int value);
-        public static extern byte[] GetBytes(uint value);
-        public static extern byte[] GetBytes(long value);
-        public static extern byte[] GetBytes(ulong value);
-        public static extern byte[] GetBytes(float value);
-        public static extern byte[] GetBytes(double value);
-
-        public static extern short ToInt16(byte[] value, int startIndex);
-        public static extern ushort ToUInt16(byte[] value, int startIndex);
-        public static extern int ToInt32(byte[] value, int startIndex);
-        public static extern uint ToUInt32(byte[] value, int startIndex);
-        public static extern long ToInt64(byte[] value, int startIndex);
-        public static extern ulong ToUInt64(byte[] value, int startIndex);
-        public static extern float ToSingle(byte[] value, int startIndex);
-        public static extern double ToDouble(byte[] value, int startIndex);
     }
 }

--- a/Library/Core/UnoCore/Tests/Buffer.Test.uno
+++ b/Library/Core/UnoCore/Tests/Buffer.Test.uno
@@ -6,6 +6,7 @@ using Uno.Testing.Assert;
 
 namespace Uno.Test
 {
+    [Obsolete]
     public class BufferTest
     {
         static byte[] GetRandomTestData(int bytes)

--- a/Library/Core/UnoCore/Tests/ByteArrayExtensions.Test.uno
+++ b/Library/Core/UnoCore/Tests/ByteArrayExtensions.Test.uno
@@ -1,0 +1,1080 @@
+using Uno;
+using Uno.Collections;
+using Uno.Graphics;
+using Uno.Testing;
+using Uno.Testing.Assert;
+
+namespace Uno.Test
+{
+    public class ByteArrayExtensionsTest
+    {
+        ///========================================================
+        ///    sbyte
+        ///========================================================
+
+        [Test]
+        public void SetSignedByteOutOfBounds()
+        {
+            var bytes = new byte[4];
+            bytes.Set(0, (sbyte)-1);
+            bytes.Set(3, (sbyte)-1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, (sbyte)-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (sbyte)-1));
+        }
+
+        [Test]
+        public void SetSignedByte2OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, sbyte2((sbyte)-1, (sbyte)1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, sbyte2((sbyte)-1, (sbyte)1)));
+        }
+
+        [Test]
+        public void SetSignedByte4OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, sbyte4((sbyte)-1, (sbyte)1, (sbyte)-2, (sbyte)2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, sbyte4((sbyte)-1, (sbyte)1, (sbyte)-2, (sbyte)2)));
+        }
+
+        [Test]
+        public void GetSignedByte1OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.AreEqual(0, bytes.GetSByte(0));
+            Assert.AreEqual(0, bytes.GetSByte(3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte(-1));
+        }
+
+        [Test]
+        public void GetSignedByte2OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte2(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte2(-1));
+        }
+
+        [Test]
+        public void GetSignedByte4OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte4(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetSByte4(-1));
+        }
+
+        ///========================================================
+        ///    byte
+        ///========================================================
+
+        [Test]
+        public void SetByte1OutOfBounds()
+        {
+            var bytes = new byte[4];
+            bytes.Set(0, (byte)1);
+            bytes.Set(3, (byte)1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, (byte)1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (byte)1));
+        }
+
+        [Test]
+        public void SetByte2OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, byte2((byte)1, (byte)1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, byte2((byte)1, (byte)1)));
+        }
+
+        [Test]
+        public void SetByte4OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(4, byte4((byte)1, (byte)1, (byte)2, (byte)2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, byte4((byte)1, (byte)1, (byte)2, (byte)2)));
+        }
+
+        [Test]
+        public void GetByte1OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.AreEqual(0, bytes.GetByte(0));
+            Assert.AreEqual(0, bytes.GetByte(3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte(-1));
+        }
+
+        [Test]
+        public void GetByte2OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte2(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte2(-1));
+        }
+
+        [Test]
+        public void GetByte4OutOfBounds()
+        {
+            var bytes = new byte[4];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte4(4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetByte4(1));
+        }
+
+        ///========================================================
+        ///    short
+        ///========================================================
+
+        [Test]
+        public void GetShort1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetShort(0));
+            Assert.AreEqual(0, bytes.GetShort(10 - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort(10 - 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort(-1));
+        }
+
+        [Test]
+        public void GetShort2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort2(-1));
+        }
+
+        [Test]
+        public void GetShort4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort4(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetShort4(-1));
+        }
+
+        [Test]
+        public void SetShort1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, (short)1);
+            bytes.Set(10 - 2, (short)1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 1, (short)1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (short)1));
+        }
+
+        [Test]
+        public void SetShort2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, short2((short)1, (short)1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, short2((short)1, (short)1)));
+        }
+
+        [Test]
+        public void SetShort4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, short4((short)1, (short)1, (short)2, (short)2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, short4((short)1, (short)1, (short)2, (short)2)));
+        }
+
+        ///========================================================
+        ///    ushort
+        ///========================================================
+
+        [Test]
+        public void GetUShort1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetUShort(0));
+            Assert.AreEqual(0, bytes.GetUShort(10 - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort(-1));
+        }
+
+        [Test]
+        public void GetUShort2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort2(-1));
+        }
+
+        [Test]
+        public void GetUShort4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort4(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUShort4(-1));
+        }
+
+        [Test]
+        public void SetUShort1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, (ushort)1);
+            bytes.Set(10 - 2, (ushort)1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 1, (ushort)1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (ushort)1));
+        }
+
+        [Test]
+        public void SetUShort2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, ushort2((ushort)1, (ushort)1)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, ushort2((ushort)1, (ushort)1)));
+        }
+
+        [Test]
+        public void SetUShort4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, ushort4((ushort)1, (ushort)1, (ushort)2, (ushort)2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, ushort4((ushort)1, (ushort)1, (ushort)2, (ushort)2)));
+        }
+
+        ///========================================================
+        ///    int
+        ///========================================================
+
+        [Test]
+        public void GetInt1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetInt(0));
+            Assert.AreEqual(0, bytes.GetInt(10 - 4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt(10 - 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt(-1));
+        }
+
+        [Test]
+        public void GetInt2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt2(-1));
+        }
+
+        [Test]
+        public void GetInt3OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt3(-1));
+        }
+
+        [Test]
+        public void GetInt4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetInt4(-1));
+        }
+
+        [Test]
+        public void SetInt1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, (int)1);
+            bytes.Set(10 - 4, (int)1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 3, (int)1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (int)1));
+        }
+
+        [Test]
+        public void SetInt2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, int2(1, 2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, int2(1, 2)));
+        }
+
+        [Test]
+        public void SetInt3OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, int3(1, 2, 3)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, int3(1, 2, 3)));
+        }
+
+        [Test]
+        public void SetInt4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, int4(1, 1, 2, 2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, int4(1, 1, 2, 2)));
+        }
+
+        ///========================================================
+        ///    uint
+        ///========================================================
+
+        [Test]
+        public void SetUIntOutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, (uint)10);
+            bytes.Set(10 - 4, (uint)10);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 3, (uint)10));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (uint)10));
+        }
+
+        [Test]
+        public void GetUIntOutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetUInt(0));
+            Assert.AreEqual(0, bytes.GetUInt(10 - 4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUInt(10 - 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetUInt(-1));
+        }
+
+        ///========================================================
+        ///    ulong
+        ///========================================================
+
+        [Test]
+        public void SetULongOutOfBounds()
+        {
+            var bytes = new byte[20];
+            bytes.Set(0, (ulong)10);
+            bytes.Set(20 - 8, (ulong)10);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(20 - 7, (ulong)10));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, (ulong)10));
+        }
+
+        [Test]
+        public void GetULongOutOfBounds()
+        {
+            var bytes = new byte[20];
+            Assert.AreEqual(0, bytes.GetULong(0));
+            Assert.AreEqual(0, bytes.GetULong(20 - 8));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetULong(20 - 7));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetULong(-1));
+        }
+
+        ///========================================================
+        ///    float
+        ///========================================================
+
+
+        [Test]
+        public void GetFloat1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetFloat(0));
+            Assert.AreEqual(0, bytes.GetFloat(10 - 4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat(10 - 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat(-1));
+        }
+
+        [Test]
+        public void GetFloat2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat2(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat2(-1));
+        }
+
+        [Test]
+        public void GetFloat3OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat3(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat3(-1));
+        }
+
+        [Test]
+        public void GetFloat4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat4(9));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat4(-1));
+        }
+
+        [Test]
+        public void SetFloat1OutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, 1.0f);
+            bytes.Set(10 - 4, 1.0f);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 3, 1.0f));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, 1.0f));
+        }
+
+        [Test]
+        public void SetFloat2OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, float2(2.0f, 2.0f)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, float2(2.0f, 2.0f)));
+        }
+
+        [Test]
+        public void SetFloat3OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, float3(1.0f, 2.0f, 3.0f)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, float3(1.0f, 2.0f, 3.0f)));
+        }
+
+        [Test]
+        public void SetFloat4OutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(9, float4(1.0f, 2.0f, 3.0f, 4.0f)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, float4(1.0f, 2.0f, 3.0f, 4.0f)));
+        }
+
+        [Test]
+        public void GetFloat3x3OutOfBounds()
+        {
+            var bytes = new byte[100];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat3x3(80));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat3x3(-1));
+        }
+
+        [Test]
+        public void SetFloat3x3OutOfBounds()
+        {
+            var bytes = new byte[100];
+            var m = float3x3(
+                float3(1.0f),
+                float3(2.0f),
+                float3(3.0f));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(80, m));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, m));
+        }
+
+        [Test]
+        public void GetFloat4x4OutOfBounds()
+        {
+            var bytes = new byte[200];
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat4x4(150));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetFloat4x4(-1));
+        }
+
+        ///========================================================
+        ///    double
+        ///========================================================
+
+        [Test]
+        public void GetDoubleOutOfBounds()
+        {
+            var bytes = new byte[10];
+            Assert.AreEqual(0, bytes.GetDouble(0));
+            Assert.AreEqual(0, bytes.GetDouble(10 - 8));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetDouble(10 - 7));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.GetDouble(-1));
+        }
+
+        [Test]
+        public void SetDoubleOutOfBounds()
+        {
+            var bytes = new byte[10];
+            bytes.Set(0, 1000.0);
+            bytes.Set(10 - 8, 1000.0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(10 - 7, 1000.0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.Set(-1, 1000.0));
+        }
+
+
+        //===========================================================================================
+        // read write tests
+        //===========================================================================================
+
+
+        ///========================================================
+        ///    sbyte
+        ///========================================================
+
+        [Test]
+        public void GetSignedByte()
+        {
+            var bytes = new byte[] { 0x00, 0xFF, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 };
+            Assert.AreEqual((sbyte)0, bytes.GetSByte(0));
+            Assert.AreEqual((sbyte)-1, bytes.GetSByte(1));
+            Assert.AreEqual((sbyte)-103, bytes.GetSByte(9));
+        }
+
+        [Test]
+        public void SetSignedByte()
+        {
+            var bytes = new byte[10];
+            var data = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 };
+
+            for (int i = 0; i < data.Length; ++i)
+            {
+                bytes.Set(i, data[i]);
+            }
+
+            Assert.AreEqual((sbyte)0, bytes.GetSByte(0));
+            Assert.AreEqual((sbyte)-103, bytes.GetSByte(9));
+
+            bytes.Set(0, (sbyte)-1);
+            bytes.Set(9, (sbyte)-127);
+
+            Assert.AreEqual((sbyte)-1, bytes.GetSByte(0));
+            Assert.AreEqual((sbyte)-127, bytes.GetSByte(9));
+
+        }
+
+        [Test]
+        public void GetSignedByte2()
+        {
+            var bytes = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+
+            Assert.AreEqual(sbyte2((sbyte)0x00, (sbyte)0x11), bytes.GetSByte2(0));
+            Assert.AreEqual(sbyte2((sbyte)0x22, (sbyte)0x33), bytes.GetSByte2(2));
+            Assert.AreEqual(sbyte2((sbyte)0x44, (sbyte)0x55), bytes.GetSByte2(4));
+            Assert.AreEqual(sbyte2((sbyte)0x66, (sbyte)0x77), bytes.GetSByte2(6));
+
+        }
+
+        [Test]
+        public void SetSignedByte2()
+        {
+            var bytes = new byte[4];
+
+            var a = sbyte2((sbyte)0x77, (sbyte)0x66);
+            var b = sbyte2((sbyte)0x33, (sbyte)0x55);
+
+            bytes.Set(0, a);
+            bytes.Set(2, b);
+
+            Assert.AreEqual(a, bytes.GetSByte2(0));
+            Assert.AreEqual(b, bytes.GetSByte2(2));
+
+            bytes.Set(1, a);
+
+            Assert.AreEqual(a, bytes.GetSByte2(1));
+
+        }
+
+        [Test]
+        public void GetSignedByte4()
+        {
+            var bytes = new byte[] { 0x11, 0x22, 0x33, 0x44 };
+            var sb4 = bytes.GetSByte4(0);
+
+            Assert.AreEqual(sb4.X, (sbyte)0x11);
+            Assert.AreEqual(sb4.Y, (sbyte)0x22);
+            Assert.AreEqual(sb4.Z, (sbyte)0x33);
+            Assert.AreEqual(sb4.W, (sbyte)0x44);
+        }
+
+        [Test]
+        public void SetSignedByte4()
+        {
+            var bytes = new byte[4];
+            bytes.Set(0, sbyte4((sbyte)0x11, (sbyte)0x22, (sbyte)0x33, (sbyte)0x44));
+
+            Assert.AreEqual((sbyte)0x11, bytes.GetSByte(0));
+            Assert.AreEqual((sbyte)0x22, bytes.GetSByte(1));
+            Assert.AreEqual((sbyte)0x33, bytes.GetSByte(2));
+            Assert.AreEqual((sbyte)0x44, bytes.GetSByte(3));
+
+        }
+
+        ///========================================================
+        ///    byte
+        ///========================================================
+
+
+        [Test]
+        public void GetByte()
+        {
+            var bytes = new byte[] { 0x00, 0xFF, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 };
+            Assert.AreEqual(0, bytes.GetByte(0));
+            Assert.AreEqual(255, bytes.GetByte(1));
+            Assert.AreEqual(153, bytes.GetByte(9));
+        }
+
+        [Test]
+        public void SetByte()
+        {
+            var bytes = new byte[10];
+            var data = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 };
+
+            for (int i = 0; i < data.Length; ++i)
+            {
+                bytes.Set(i, data[i]);
+            }
+
+            Assert.AreEqual(0, bytes.GetByte(0));
+            Assert.AreEqual(153, bytes.GetByte(9));
+
+            bytes.Set(0, (byte)255);
+            bytes.Set(9, (byte)128);
+
+            Assert.AreEqual(255, bytes.GetByte(0));
+            Assert.AreEqual(128, bytes.GetByte(9));
+
+        }
+
+        [Test]
+        public void GetByte2()
+        {
+            var bytes = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+
+            Assert.AreEqual(byte2(0x00, 0x11), bytes.GetByte2(0));
+            Assert.AreEqual(byte2(0x22, 0x33), bytes.GetByte2(2));
+            Assert.AreEqual(byte2(0x44, 0x55), bytes.GetByte2(4));
+            Assert.AreEqual(byte2(0x66, 0x77), bytes.GetByte2(6));
+
+        }
+
+        [Test]
+        public void SetByte2()
+        {
+            var bytes = new byte[4];
+
+            var a = byte2(0x77, 0x66);
+            var b = byte2(0x33, 0x55);
+
+            bytes.Set(0, a);
+            bytes.Set(2, b);
+
+            Assert.AreEqual(a, bytes.GetByte2(0));
+            Assert.AreEqual(b, bytes.GetByte2(2));
+
+            bytes.Set(1, a);
+
+            Assert.AreEqual(a, bytes.GetByte2(1));
+
+        }
+
+        [Test]
+        public void GetByte4()
+        {
+            var bytes = new byte[] { 0x11, 0x22, 0x33, 0x44 };
+            var b4 = bytes.GetByte4(0);
+
+            Assert.AreEqual(b4.X, 0x11);
+            Assert.AreEqual(b4.Y, 0x22);
+            Assert.AreEqual(b4.Z, 0x33);
+            Assert.AreEqual(b4.W, 0x44);
+        }
+
+        [Test]
+        public void SetByte4()
+        {
+            var bytes = new byte[4];
+            bytes.Set(0, byte4(0x11, 0x22, 0x33, 0x44));
+
+            Assert.AreEqual(0x11, bytes.GetByte(0));
+            Assert.AreEqual(0x22, bytes.GetByte(1));
+            Assert.AreEqual(0x33, bytes.GetByte(2));
+            Assert.AreEqual(0x44, bytes.GetByte(3));
+
+        }
+
+        ///========================================================
+        ///    short
+        ///========================================================
+
+        [Test]
+        public void GetShort()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F };
+
+            var bigEndian = bytes.GetShort(0, false);
+            Assert.AreEqual((short)-4545, bigEndian);
+
+            var littleEndian = bytes.GetShort(0, true);
+            Assert.AreEqual((short)16366, littleEndian);
+
+        }
+
+        [Test]
+        public void SetShort()
+        {
+            var bytes = new byte[2];
+
+            bytes.Set(0, (short)12345, false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x30);
+            Assert.AreEqual(bytes.GetByte(1), 0x39);
+
+            bytes.Set(0, (short)12345, true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x39);
+            Assert.AreEqual(bytes.GetByte(1), 0x30);
+
+        }
+
+        [Test]
+        public void GetShort2()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F, 0x30, 0x39 };
+
+            var bigEndian = bytes.GetShort2(0, false);
+
+            Assert.AreEqual((short)-4545, bigEndian.X);
+            Assert.AreEqual((short)12345, bigEndian.Y);
+
+            var littleEndian = bytes.GetShort2(0, true);
+
+            Assert.AreEqual((short)16366, littleEndian.X);
+            Assert.AreEqual((short)14640, littleEndian.Y);
+
+        }
+
+        [Test]
+        public void SetShort2()
+        {
+            var bytes = new byte[4];
+
+            bytes.Set(0, short2((short)-4545, (short)12345), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0xEE);
+            Assert.AreEqual(bytes.GetByte(1), 0x3F);
+            Assert.AreEqual(bytes.GetByte(2), 0x30);
+            Assert.AreEqual(bytes.GetByte(3), 0x39);
+
+            bytes.Set(0, short2((short)-4545, (short)12345), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x39);
+            Assert.AreEqual(bytes.GetByte(3), 0x30);
+
+        }
+
+        [Test]
+        public void GetShort4()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F, 0x30, 0x39, 0x80, 0x80, 0x45, 0x65 };
+
+            var bigEndian = bytes.GetShort4(0, false);
+
+            Assert.AreEqual((short)-4545, bigEndian.X);
+            Assert.AreEqual((short)12345, bigEndian.Y);
+            Assert.AreEqual((short)-32640, bigEndian.Z);
+            Assert.AreEqual((short)17765, bigEndian.W);
+
+
+            var littleEndian = bytes.GetShort4(0, true);
+
+            Assert.AreEqual((short)16366, littleEndian.X);
+            Assert.AreEqual((short)14640, littleEndian.Y);
+            Assert.AreEqual((short)-32640, littleEndian.Z);
+            Assert.AreEqual((short)25925, littleEndian.W);
+
+        }
+
+        [Test]
+        public void SetShort4()
+        {
+            var bytes = new byte[8];
+
+            bytes.Set(0, short4((short)-4545, (short)12345, (short)-32640, (short)17765), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0xEE);
+            Assert.AreEqual(bytes.GetByte(1), 0x3F);
+            Assert.AreEqual(bytes.GetByte(2), 0x30);
+            Assert.AreEqual(bytes.GetByte(3), 0x39);
+            Assert.AreEqual(bytes.GetByte(4), 0x80);
+            Assert.AreEqual(bytes.GetByte(5), 0x80);
+            Assert.AreEqual(bytes.GetByte(6), 0x45);
+            Assert.AreEqual(bytes.GetByte(7), 0x65);
+
+            bytes.Set(0, short4((short)-4545, (short)12345, (short)-32640, (short)17765), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x39);
+            Assert.AreEqual(bytes.GetByte(3), 0x30);
+            Assert.AreEqual(bytes.GetByte(4), 0x80);
+            Assert.AreEqual(bytes.GetByte(5), 0x80);
+            Assert.AreEqual(bytes.GetByte(6), 0x65);
+            Assert.AreEqual(bytes.GetByte(7), 0x45);
+
+        }
+
+        ///========================================================
+        ///    ushort
+        ///========================================================
+
+        [Test]
+        public void GetUShort()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F };
+
+            var bigEndian = bytes.GetUShort(0, false);
+            Assert.AreEqual((ushort)60991, bigEndian);
+
+            var littleEndian = bytes.GetUShort(0, true);
+            Assert.AreEqual((ushort)16366, littleEndian);
+
+        }
+
+        [Test]
+        public void SetUShort()
+        {
+            var bytes = new byte[2];
+
+            bytes.Set(0, (ushort)12345, false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x30);
+            Assert.AreEqual(bytes.GetByte(1), 0x39);
+
+            bytes.Set(0, (ushort)12345, true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x39);
+            Assert.AreEqual(bytes.GetByte(1), 0x30);
+
+        }
+
+        [Test]
+        public void GetUShort2()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F, 0x30, 0x39 };
+
+            var bigEndian = bytes.GetUShort2(0, false);
+
+            Assert.AreEqual((ushort)60991, bigEndian.X);
+            Assert.AreEqual((ushort)12345, bigEndian.Y);
+
+            var littleEndian = bytes.GetUShort2(0, true);
+
+            Assert.AreEqual((ushort)16366, littleEndian.X);
+            Assert.AreEqual((ushort)14640, littleEndian.Y);
+
+        }
+
+        [Test]
+        public void SetUShort2()
+        {
+            var bytes = new byte[4];
+
+            bytes.Set(0, ushort2((ushort)60991, (ushort)12345), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0xEE);
+            Assert.AreEqual(bytes.GetByte(1), 0x3F);
+            Assert.AreEqual(bytes.GetByte(2), 0x30);
+            Assert.AreEqual(bytes.GetByte(3), 0x39);
+
+            bytes.Set(0, ushort2((ushort)60991, (ushort)12345), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x39);
+            Assert.AreEqual(bytes.GetByte(3), 0x30);
+
+        }
+
+        [Test]
+        public void GetUShort4()
+        {
+            var bytes = new byte[] { 0xEE, 0x3F, 0x30, 0x39, 0x80, 0x80, 0x45, 0x65 };
+
+            var bigEndian = bytes.GetUShort4(0, false);
+
+            Assert.AreEqual((ushort)60991, bigEndian.X);
+            Assert.AreEqual((ushort)12345, bigEndian.Y);
+            Assert.AreEqual((ushort)32896, bigEndian.Z);
+            Assert.AreEqual((ushort)17765, bigEndian.W);
+
+
+            var littleEndian = bytes.GetUShort4(0, true);
+
+            Assert.AreEqual((ushort)16366, littleEndian.X);
+            Assert.AreEqual((ushort)14640, littleEndian.Y);
+            Assert.AreEqual((ushort)32896, littleEndian.Z);
+            Assert.AreEqual((ushort)25925, littleEndian.W);
+
+        }
+
+
+        [Test]
+        public void SetUShort4()
+        {
+            var bytes = new byte[8];
+
+            bytes.Set(0, ushort4((ushort)60991, (ushort)12345, (ushort)32896, (ushort)17765), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0xEE);
+            Assert.AreEqual(bytes.GetByte(1), 0x3F);
+            Assert.AreEqual(bytes.GetByte(2), 0x30);
+            Assert.AreEqual(bytes.GetByte(3), 0x39);
+            Assert.AreEqual(bytes.GetByte(4), 0x80);
+            Assert.AreEqual(bytes.GetByte(5), 0x80);
+            Assert.AreEqual(bytes.GetByte(6), 0x45);
+            Assert.AreEqual(bytes.GetByte(7), 0x65);
+
+            bytes.Set(0, ushort4((ushort)60991, (ushort)12345, (ushort)32896, (ushort)17765), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x39);
+            Assert.AreEqual(bytes.GetByte(3), 0x30);
+            Assert.AreEqual(bytes.GetByte(4), 0x80);
+            Assert.AreEqual(bytes.GetByte(5), 0x80);
+            Assert.AreEqual(bytes.GetByte(6), 0x65);
+            Assert.AreEqual(bytes.GetByte(7), 0x45);
+
+        }
+
+        ///========================================================
+        ///    int
+        ///========================================================
+
+        [Test]
+        public void GetInt()
+        {
+            var bytes = new byte[] { 0x00, 0x00, 0xEE, 0x3F };
+
+            var bigEndian = bytes.GetInt(0, false);
+            Assert.AreEqual((int)60991, bigEndian);
+
+            var littleEndian = bytes.GetInt(0, true);
+            Assert.AreEqual((int)1072562176, littleEndian);
+
+        }
+
+        [Test]
+        public void SetInt()
+        {
+            var bytes = new byte[4];
+
+            bytes.Set(0, (int)12345, false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x00);
+            Assert.AreEqual(bytes.GetByte(1), 0x00);
+            Assert.AreEqual(bytes.GetByte(2), 0x30);
+            Assert.AreEqual(bytes.GetByte(3), 0x39);
+
+            bytes.Set(0, (int)12345, true);
+
+
+            Assert.AreEqual(bytes.GetByte(0), 0x39);
+            Assert.AreEqual(bytes.GetByte(1), 0x30);
+            Assert.AreEqual(bytes.GetByte(2), 0x00);
+            Assert.AreEqual(bytes.GetByte(3), 0x00);
+
+
+        }
+
+        [Test]
+        public void GetInt2()
+        {
+            var bytes = new byte[] { 0x00, 0x00, 0xEE, 0x3F, 0x00, 0x00, 0x30, 0x39 };
+
+            var bigEndian = bytes.GetInt2(0, false);
+
+            Assert.AreEqual((int)60991, bigEndian.X);
+            Assert.AreEqual((int)12345, bigEndian.Y);
+
+            var littleEndian = bytes.GetInt2(0, true);
+
+            Assert.AreEqual((int)1072562176, littleEndian.X);
+            Assert.AreEqual((int)959447040, littleEndian.Y);
+
+        }
+
+        [Test]
+        public void SetInt2()
+        {
+            var bytes = new byte[8];
+
+            bytes.Set(0, int2((int)60991, (int)12345), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x00);
+            Assert.AreEqual(bytes.GetByte(1), 0x00);
+            Assert.AreEqual(bytes.GetByte(2), 0xEE);
+            Assert.AreEqual(bytes.GetByte(3), 0x3F);
+            Assert.AreEqual(bytes.GetByte(4), 0x00);
+            Assert.AreEqual(bytes.GetByte(5), 0x00);
+            Assert.AreEqual(bytes.GetByte(6), 0x30);
+            Assert.AreEqual(bytes.GetByte(7), 0x39);
+
+
+            bytes.Set(0, int2((int)60991, (int)12345), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x00);
+            Assert.AreEqual(bytes.GetByte(3), 0x00);
+            Assert.AreEqual(bytes.GetByte(4), 0x39);
+            Assert.AreEqual(bytes.GetByte(5), 0x30);
+            Assert.AreEqual(bytes.GetByte(6), 0x00);
+            Assert.AreEqual(bytes.GetByte(7), 0x00);
+
+        }
+
+        [Test]
+        public void GetInt4()
+        {
+            var bytes = new byte[] { 0x00, 0x00, 0xEE, 0x3F, 0x00, 0x00, 0x30, 0x39, 0x00, 0x00, 0x80, 0x80, 0x00, 0x00, 0x45, 0x65 };
+
+            var bigEndian = bytes.GetInt4(0, false);
+
+            Assert.AreEqual((int)60991, bigEndian.X);
+            Assert.AreEqual((int)12345, bigEndian.Y);
+            Assert.AreEqual((int)32896, bigEndian.Z);
+            Assert.AreEqual((int)17765, bigEndian.W);
+
+
+            var littleEndian = bytes.GetInt4(0, true);
+
+            Assert.AreEqual((int)1072562176, littleEndian.X);
+            Assert.AreEqual((int)959447040, littleEndian.Y);
+            Assert.AreEqual((int)-2139095040, littleEndian.Z);
+            Assert.AreEqual((int)1699020800, littleEndian.W);
+
+        }
+
+
+        [Test]
+        public void SetInt4()
+        {
+            var bytes = new byte[16];
+
+            bytes.Set(0, int4((int)60991, (int)12345, (int)32896, (int)17765), false);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x00);
+            Assert.AreEqual(bytes.GetByte(1), 0x00);
+            Assert.AreEqual(bytes.GetByte(2), 0xEE);
+            Assert.AreEqual(bytes.GetByte(3), 0x3F);
+
+            Assert.AreEqual(bytes.GetByte(4), 0x00);
+            Assert.AreEqual(bytes.GetByte(5), 0x00);
+            Assert.AreEqual(bytes.GetByte(6), 0x30);
+            Assert.AreEqual(bytes.GetByte(7), 0x39);
+
+            Assert.AreEqual(bytes.GetByte(8), 0x00);
+            Assert.AreEqual(bytes.GetByte(9), 0x00);
+            Assert.AreEqual(bytes.GetByte(10), 0x80);
+            Assert.AreEqual(bytes.GetByte(11), 0x80);
+
+            Assert.AreEqual(bytes.GetByte(12), 0x00);
+            Assert.AreEqual(bytes.GetByte(13), 0x00);
+            Assert.AreEqual(bytes.GetByte(14), 0x45);
+            Assert.AreEqual(bytes.GetByte(15), 0x65);
+
+            bytes.Set(0, int4((int)60991, (int)12345, (int)32896, (int)17765), true);
+
+            Assert.AreEqual(bytes.GetByte(0), 0x3F);
+            Assert.AreEqual(bytes.GetByte(1), 0xEE);
+            Assert.AreEqual(bytes.GetByte(2), 0x00);
+            Assert.AreEqual(bytes.GetByte(3), 0x00);
+
+            Assert.AreEqual(bytes.GetByte(4), 0x39);
+            Assert.AreEqual(bytes.GetByte(5), 0x30);
+            Assert.AreEqual(bytes.GetByte(6), 0x00);
+            Assert.AreEqual(bytes.GetByte(7), 0x00);
+
+            Assert.AreEqual(bytes.GetByte(8), 0x80);
+            Assert.AreEqual(bytes.GetByte(9), 0x80);
+            Assert.AreEqual(bytes.GetByte(10), 0x00);
+            Assert.AreEqual(bytes.GetByte(11), 0x00);
+
+            Assert.AreEqual(bytes.GetByte(12), 0x65);
+            Assert.AreEqual(bytes.GetByte(13), 0x45);
+            Assert.AreEqual(bytes.GetByte(14), 0x00);
+            Assert.AreEqual(bytes.GetByte(15), 0x00);
+
+        }
+
+    }
+}

--- a/Library/Core/UnoCore/Tests/UnoCore.Test.unoproj
+++ b/Library/Core/UnoCore/Tests/UnoCore.Test.unoproj
@@ -95,6 +95,7 @@
     "Bool.Test.uno:Source",
     "Buffer.Test.uno:Source",
     "Byte.Test.uno:Source",
+    "ByteArrayExtensions.Test.uno:Source",
     "Char.Test.uno:Source",
     "Color.Test.uno:Source",
     "DateTime.Test.uno:Source",

--- a/Library/Core/UnoCore/UnoCore.unoproj
+++ b/Library/Core/UnoCore/UnoCore.unoproj
@@ -82,6 +82,7 @@
     "Source/Uno/Byte.uno:Source",
     "Source/Uno/Byte2.uno:Source",
     "Source/Uno/Byte4.uno:Source",
+    "Source/Uno/ByteArrayExtensions.uno:Source",
     "Source/Uno/Char.uno:Source",
     "Source/Uno/CharPunctuationChecker.uno:Source",
     "Source/Uno/Collections/Dictionary.uno:Source",

--- a/tests/src/UnoTest/ShaderGenerator/BatchIndexBuffer.uno
+++ b/tests/src/UnoTest/ShaderGenerator/BatchIndexBuffer.uno
@@ -30,21 +30,21 @@ namespace UnoTest
             this.usage = staticBatch ? BufferUsage.Immutable : BufferUsage.Dynamic;
         }
 
-        public BatchIndexBuffer(IndexType type, Buffer data)
+        public BatchIndexBuffer(IndexType type, byte[] data)
         {
             this.DataType = type;
             this.usage = BufferUsage.Immutable;
-            this.buf = new Uno.Buffer(data.SizeInBytes);
-            for (int i =0; i<buf.SizeInBytes; i++)
+            this.buf = new byte[data.Length];
+            for (int i =0; i<buf.Length; i++)
                 this.buf[i] = data[i];
         }
 
-        Buffer buf;
-        public Buffer Buffer
+        byte[] buf;
+        public byte[] Buffer
         {
             get
             {
-                if (buf == null) buf = new Buffer(maxIndices * StrideInBytes);
+                if (buf == null) buf = new byte[maxIndices * StrideInBytes];
                 return buf;
             }
         }
@@ -78,7 +78,7 @@ namespace UnoTest
                     return null;
 
                 if (ibo == null)
-                    this.ibo = new IndexBuffer(Buffer.SizeInBytes, usage);
+                    this.ibo = new IndexBuffer(Buffer.Length, usage);
 
                 Flush();
                 return ibo;

--- a/tests/src/UnoTest/ShaderGenerator/BatchVertexBuffer.uno
+++ b/tests/src/UnoTest/ShaderGenerator/BatchVertexBuffer.uno
@@ -29,23 +29,23 @@ namespace UnoTest
             this.usage = staticBatch ? BufferUsage.Immutable : BufferUsage.Dynamic;
         }
 
-        public BatchVertexBuffer(VertexAttributeType type, Buffer data)
+        public BatchVertexBuffer(VertexAttributeType type, byte[] data)
         {
             this.DataType = type;
             this.usage = BufferUsage.Immutable;
 
-            this.buf = new Uno.Buffer(data.SizeInBytes);
-            for (int i =0; i<buf.SizeInBytes; i++)
+            this.buf = new byte[data.Length];
+            for (int i =0; i<buf.Length; i++)
                 this.buf[i] = data[i];
         }
 
 
-        Buffer buf;
-        public Buffer Buffer
+        byte[] buf;
+        public byte[] Buffer
         {
             get
             {
-                if (buf == null) buf = new Buffer(maxVertices * StrideInBytes);
+                if (buf == null) buf = new byte[maxVertices * StrideInBytes];
                 return buf;
             }
         }
@@ -195,7 +195,7 @@ namespace UnoTest
             if (buf != null && isDirty)
             {
                 if (vbo == null)
-                    this.vbo = new VertexBuffer(Buffer.SizeInBytes, usage);
+                    this.vbo = new VertexBuffer(Buffer.Length, usage);
 
                 vbo.Update(buf);
                 isDirty = false;


### PR DESCRIPTION
This introduces a new `Bytes` class containing extension methods for manipulating `byte` arrays directly.

We can now use plain `byte[]`, which are more practical than creating `Buffer` objects when we want to work with byte data, and the interface is still pretty much identical.

I think this is a good deal, and patches for `fuselibs` are also ready: https://github.com/mortend/fuselibs/tree/replace-buffer