### PR TITLE
C++: remove support for legacy iOS bindings

### DIFF
--- a/Library/Core/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
+++ b/Library/Core/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
@@ -16,7 +16,6 @@
     <Declare TypeElement="Source.Declaration" />
     <Declare TypeElement="Source.Include" />
     <Declare TypeElement="Source.Import" />
-    <Declare TypeElement="Type.Initialization" />
     <Declare TypeProperty="ForwardDeclaration" />
     <Declare TypeProperty="Include" />
     <Declare TypeProperty="TypeName" />
@@ -53,8 +52,6 @@
 
     <!-- UnoCore extensions -->
     <Declare Element="Main.Include" />
-    <Declare Element="TypeExtension.Declaration" />
-    <Declare Element="TypeExtension.Initialization" />
     <Declare Element="TypeObjects.Declaration" />
     <Declare Element="TypeObjects.FunctionPointer" />
 
@@ -93,9 +90,6 @@
     <Deprecate iOS.PrefixHeader.Declaration="Xcode.PrefixHeader.Declaration" />
     <Deprecate Java.Extern.RegisterFunctions="Java.Extern.RegisterFunction" />
     <Deprecate Source.FileExtension="FileExtension" />
-    <Deprecate TypeInitialization="Type.Initialization" />
-    <Deprecate UnoCore.TypeExtension.Declaration="TypeExtension.Declaration" />
-    <Deprecate UnoCore.TypeExtension.Initialization="TypeExtension.Initialization" />
 
     <!-- Keywords -->
     <Set Keywords>

--- a/Library/Core/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
+++ b/Library/Core/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
@@ -196,7 +196,7 @@ static uType* uNewType(uint32_t type, const char* name, const uTypeOptions& opti
         memcpy((uint8_t*)result + offset, (uint8_t*)base + offset, base->TypeSize - offset);
         result->Base = base;
     }
-    @(TypeExtension.Initialization:Join())
+
     _RuntimeTypes->push_back(result);
     return result;
 }

--- a/Library/Core/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/Library/Core/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -190,9 +190,6 @@ struct uType : uObject
     uReflection Reflection;
 #endif
 
-    // Extensions
-    @(TypeExtension.Declaration:Join())
-
     // V-table
     void(*fp_build_)(uType*);
     const void* fp_ctor_;

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppGenerator.cs
@@ -135,16 +135,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
 
             foreach (var ext in extTypes)
             {
-                // Workaround that disables merging of Obj-C files because of duplicated defines produced by binding generator.
-                // TODO: Find a way to generate bindings without these defines
-                if (ext.Key == "mm")
-                {
-                    foreach (var dt in ext.Value)
-                        ExportType(_env, _essentials, _backend, dt);
-
-                    continue;
-                }
-
                 var count = ext.Value.Count;
                 var types = new CppType[count];
                 var declSet = new HashSet<string>();
@@ -463,7 +453,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
                     _cpp.Unindent();
                 }
 
-                WriteTypeInitialization(dt);
                 _cpp.EndScope();
 
                 _cpp.WriteLine(type.TypeOfType + "* " + type.TypeOfFunction + "()");
@@ -648,7 +637,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 _cpp.Unindent();
             }
 
-            WriteTypeInitialization(dt);
             _cpp.WriteLine("return type;");
             _cpp.EndScope();
             _h.Skip();
@@ -717,9 +705,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
 
             _cpp.EndLine(");");
             _cpp.Unindent();
-
-            WriteTypeInitialization(dt);
-
             _cpp.WriteLine("return type;");
             _cpp.EndScope();
         }
@@ -758,8 +743,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 _cpp.Unindent();
                 _cpp.EndLine(");");
             }
-
-            WriteTypeInitialization(dt);
 
             _cpp.WriteLine("return type;");
             _cpp.EndScope();
@@ -1152,29 +1135,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 " " + _backend.GetStaticName(f.DeclaringType, f.DeclaringType) +
                 "::" + _backend.GetMemberName(f) + GetParameterList(f, ParameterFlags.ObjectByRef));
             _h.WriteInterfaceMethodBody(f);
-        }
-
-        void WriteTypeInitialization(DataType dt)
-        {
-            bool hasTypeInitializer = false;
-
-            foreach (var e in _env.GetSet(dt, "Type.Initialization"))
-            {
-                if (!hasTypeInitializer)
-                {
-                    _cpp.Skip();
-                    _cpp.BeginScope();
-                    hasTypeInitializer = true;
-                }
-
-                _cpp.WriteLines(e);
-            }
-
-            if (hasTypeInitializer)
-            {
-                _cpp.EndScope();
-                _cpp.Skip();
-            }
         }
 
         string GetFunctionDeclaration(Function f, string suffix = "_fn")


### PR DESCRIPTION
The old iOS bindings haven't been used in a long time, and this gets some more old code out of the way.