### PR TITLE
UnoCore: deprecate profile events in Uno.Diagnostics

### DIFF
--- a/Library/Core/UnoCore/Source/Uno/Diagnostics/AllocateEvent.uno
+++ b/Library/Core/UnoCore/Source/Uno/Diagnostics/AllocateEvent.uno
@@ -1,5 +1,6 @@
 namespace Uno.Diagnostics
 {
+    [Obsolete]
     public class AllocateEvent : ProfileEvent
     {
         public readonly int Class;

--- a/Library/Core/UnoCore/Source/Uno/Diagnostics/EnterEvent.uno
+++ b/Library/Core/UnoCore/Source/Uno/Diagnostics/EnterEvent.uno
@@ -1,5 +1,6 @@
 namespace Uno.Diagnostics
 {
+    [Obsolete]
     public class EnterEvent : ProfileEvent
     {
         public readonly int Id;

--- a/Library/Core/UnoCore/Source/Uno/Diagnostics/ExitEvent.uno
+++ b/Library/Core/UnoCore/Source/Uno/Diagnostics/ExitEvent.uno
@@ -1,5 +1,6 @@
 namespace Uno.Diagnostics
 {
+    [Obsolete]
     public class ExitEvent : ProfileEvent
     {
         public override EventType Type { get { return EventType.Exit; } }

--- a/Library/Core/UnoCore/Source/Uno/Diagnostics/FreeEvent.uno
+++ b/Library/Core/UnoCore/Source/Uno/Diagnostics/FreeEvent.uno
@@ -1,5 +1,6 @@
 namespace Uno.Diagnostics
 {
+    [Obsolete]
     public class FreeEvent : ProfileEvent
     {
         public readonly int Class;


### PR DESCRIPTION
This removes some deprecation warnings received when building `UnoCore`.