### PR TITLE
Remove warnings in UnoCore.Test

### DIFF
--- a/Library/Core/UnoCore/Tests/Buffer.Test.uno
+++ b/Library/Core/UnoCore/Tests/Buffer.Test.uno
@@ -8,7 +8,6 @@ namespace Uno.Test
 {
     public class BufferTest
     {
-
         static byte[] GetRandomTestData(int bytes)
         {
             var data = new byte[bytes];
@@ -45,7 +44,7 @@ namespace Uno.Test
         public void CreateReadOnlySubBuffer()
         {
             var buffer = new Buffer(GetRandomTestData(100));
-            var subBuffer = buffer.CreateReadOnlySubBuffer(25, 50);
+            var subBuffer = buffer.CreateSubBuffer(25, 50);
 
             Assert.AreEqual(subBuffer.SizeInBytes, 50);
 

--- a/Library/Core/UnoCore/Tests/Color.Test.uno
+++ b/Library/Core/UnoCore/Tests/Color.Test.uno
@@ -113,6 +113,7 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void FromHex()
         {
             Assert.AreEqual(Color.FromRgba(0xAABBCCFF), Color.FromHex("ABC"));
@@ -134,11 +135,13 @@ namespace Uno.Test
             Assert.AreEqual((float4)int4(0xAA,0xBB,0xCC,0xFF) / 255f, Color.FromHex("ABC"));
         }
 
+        [Obsolete]
         void _FromHexWithIllegal()
         {
             Color.FromHex("EFG");
         }
 
+        [Obsolete]
         void _FromHexWithSign()
         {
             Color.FromHex("---");

--- a/Library/Core/UnoCore/Tests/Math.Test.uno
+++ b/Library/Core/UnoCore/Tests/Math.Test.uno
@@ -8,8 +8,8 @@ namespace Uno.Test
 {
     public class MathTest
     {
-
         [Test]
+        [Obsolete]
         public void RoundingMode()
         {
             Assert.AreEqual(1, Math.Round(1.5 - 1e-10), 0);
@@ -35,6 +35,7 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void RoundWithDecimals()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Math.Round(Math.PI, -1));
@@ -71,6 +72,7 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void RoundsVectorsWithNoDecimals()
         {
             Assert.AreEqual(float2(1,3), Math.Round(float2(1.4f, 2.9f)), 0);
@@ -79,6 +81,7 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void RoundsVectorsWithDecimals()
         {
             Assert.AreEqual(float2(1, 3), Math.Round(float2(1.4f, 2.9f), 0), 0);

--- a/Library/Core/UnoCore/Tests/Random.Test.uno
+++ b/Library/Core/UnoCore/Tests/Random.Test.uno
@@ -60,6 +60,7 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void FloatOnZeroRange_ReturnsThatNumber()
         {
             var r = new Random(1337);
@@ -67,11 +68,13 @@ namespace Uno.Test
         }
 
         [Test]
+        [Obsolete]
         public void FloatWhenHighIsLowerThanLow_Throws()
         {
             Assert.Throws<ArgumentOutOfRangeException>(FloatHighIsLowerThanLow);
         }
 
+        [Obsolete]
         private void FloatHighIsLowerThanLow()
         {
             var r = new Random(1337);


### PR DESCRIPTION
This removes warnings received when building `UnoCore.Test`.