### PR TITLE
Fix regression in ShaderGenerator

### DIFF
--- a/src/compiler/Uno.Compiler.API/Domain/IL/Types/RefArrayType.cs
+++ b/src/compiler/Uno.Compiler.API/Domain/IL/Types/RefArrayType.cs
@@ -4,9 +4,9 @@ namespace Uno.Compiler.API.Domain.IL.Types
 {
     public sealed class RefArrayType : ArrayType
     {
-        public static RefArrayType CreateMaster(DataType baseType)
+        public static RefArrayType CreateMaster(DataType intType, DataType objectType)
         {
-            return new RefArrayType(baseType.Source, baseType, baseType);
+            return new RefArrayType(objectType.Source, objectType, objectType);
         }
 
         public static RefArrayType Create(RefArrayType master, DataType elmType)

--- a/src/compiler/Uno.Compiler.API/Domain/IL/Types/RefArrayType.cs
+++ b/src/compiler/Uno.Compiler.API/Domain/IL/Types/RefArrayType.cs
@@ -6,13 +6,21 @@ namespace Uno.Compiler.API.Domain.IL.Types
     {
         public static RefArrayType CreateMaster(DataType intType, DataType objectType)
         {
-            return new RefArrayType(objectType.Source, objectType, objectType);
+            var result = new RefArrayType(objectType.Source, objectType, objectType);
+            var length = new Property(objectType.Source, null, Modifiers.Public | Modifiers.Extern | Modifiers.Generated, "Length", result, intType);
+            length.CreateGetMethod(objectType.Source, length.Modifiers);
+            result.Properties.Add(length);
+            return result;
         }
 
         public static RefArrayType Create(RefArrayType master, DataType elmType)
         {
             var result = new RefArrayType(elmType.Source, elmType, master.Base);
             result.SetMasterDefinition(master);
+            var length = new Property(elmType.Source, null, Modifiers.Public | Modifiers.Extern | Modifiers.Generated, "Length", result, master.Properties[0].ReturnType);
+            length.CreateGetMethod(elmType.Source, length.Modifiers);
+            length.SetMasterDefinition(master.Properties[0]);
+            result.Properties.Add(length);
             return result;
         }
 

--- a/src/compiler/Uno.Compiler.Core/Syntax/Builders/TypeBuilder.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Builders/TypeBuilder.cs
@@ -129,7 +129,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
             return elementType.RefArray ?? (
                    elementType.RefArray =
                         elementType.Equals(_ilf.Essentials.Array)
-                            ? RefArrayType.CreateMaster(_ilf.Essentials.Array)
+                            ? RefArrayType.CreateMaster(_ilf.Essentials.Int, _ilf.Essentials.Array)
                             : RefArrayType.Create(GetArray(_ilf.Essentials.Array), elementType)
                 );
         }


### PR DESCRIPTION
Unfortunately, it turns out parts of #85 broke our shader generator.

The shader generator turns regular arrays into `fixed` arrays in shader code, and up-casts to `Uno.Array` confuse things. Patching the shader generator is starting to look like a yak-shaving project, so the easiest fix for now is to just revert these two commits. Sorry about the cruft.