### PR TITLE
Native target link elements and warning fix

### DIFF
--- a/lib/UnoCore/Targets/Native/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Native/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PROJECT_SOURCE_DIR}/@(BinaryDirecto
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PROJECT_SOURCE_DIR}/@(BinaryDirectory))
 
 if (UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else --std=@(CppStandard)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else -Wno-switch --std=@(CppStandard)")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --std=@(CStandard)")
 endif()
 

--- a/lib/UnoCore/Targets/Native/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Native/CMakeLists.txt
@@ -36,7 +36,9 @@ add_executable(@(Project.Name:QuoteSpace)
     @(SourceFile:Join('\n    ', '"@(SourceDirectory)/', '"'))
     ${EXTRA_FILES})
 
-target_link_libraries(@(Project.Name:QuoteSpace) @(LinkLibrary:Join(' ')))
+target_link_libraries(@(Project.Name:QuoteSpace) @(LinkLibrary:Join(' '))
+    @(LinkLibrary.Debug:Join(' ', 'debug '))
+    @(LinkLibrary.Release:Join(' ', 'optimized ')))
 
 @(SharedLibrary:Join('\n', 'file(COPY "', '" DESTINATION ${PROJECT_SOURCE_DIR}/@(BinaryDirectory))'))
 #if @(X64:Defined)

--- a/lib/UnoCore/Targets/Native/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Native/CMakeLists.txt
@@ -11,8 +11,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PROJECT_SOURCE_DIR}/@(BinaryDirecto
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${PROJECT_SOURCE_DIR}/@(BinaryDirectory))
 
 if (UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else -Wno-switch --std=@(CppStandard)")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --std=@(CStandard)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=@(CppStandard)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else -Wno-switch")
 endif()
 
 if (APPLE)

--- a/lib/UnoCore/Targets/Native/Native.uxl
+++ b/lib/UnoCore/Targets/Native/Native.uxl
@@ -18,6 +18,8 @@
     <Define X64="HOST_X64 && !X86" />
 
     <!-- Build system -->
+    <Declare Element="LinkLibrary.Debug" />
+    <Declare Element="LinkLibrary.Release" />
     <Declare Element="SharedLibrary" />
     <Declare Element="SharedLibrary.x86" />
     <Declare Element="SharedLibrary.x64" />


### PR DESCRIPTION
Add new `LinkLibrary.{Debug, Release}` elements for the Native build target, and disable warning in generated code.