### PR TITLE
Uno.Common: silence warnings from generated code

### DIFF
--- a/src/common/Uno.Common/Logging/Log.cs
+++ b/src/common/Uno.Common/Logging/Log.cs
@@ -147,6 +147,10 @@ namespace Uno.Logging
                 WarningLevel == 0)
                 return;
 
+            // Silence warnings from UX generated code (unless -W3 was passed)
+            if (src.FullPath.EndsWith(".g.uno") && WarningLevel < 3)
+                return;
+
             var str = code?.ToString() ?? "W0000";
             Report(src, str, msg, ConsoleColor.Yellow);
 


### PR DESCRIPTION
When working with UX documents I keep getting warnings originating from code
produced by the UX-to-Uno code generator, i.e.:

    .uno\ux15\Icon.g.uno(21.18): W0000: Icon.Size hides inherited member Fuse.Elements.Element.Size -- use the 'new' modifier if hiding is intentional

Silencing warnings from generated code is a lot easier than fixing the code
generator itself, so let's do that for now.