### PR TITLE
UnoCore: fix crash in uLoadXliTexture()

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
@@ -210,9 +210,9 @@ uBase::Vector2 uFloat2ToXliVector2(const @{float2}& vec)
 uImage::Texture* uLoadXliTexture(const uBase::String& filename, uArray* data)
 {
     uBase::String fnUpper = filename.ToUpper();
-    uBase::Auto<uImage::ImageReader> ir;
     uBase::BufferPtr buffer(data->Ptr(), data->Length(), false);
     uBase::BufferStream stream(&buffer, true, false);
+    uBase::Auto<uImage::ImageReader> ir;
 
     if (fnUpper.EndsWith(".PNG"))
         ir = uImage::Png::CreateReader(&stream);


### PR DESCRIPTION
Reorder variables to delete our objects in correct order.

All Uno methods calling this are deprecated, and apparently this hasn't been
used in a long time. I ended up using it while trying some things, so let's
just fix it.