### PR TITLE
Uno.Compiler: fix iOS build error

### DIFF
--- a/src/compiler/Uno.Compiler.Core/Syntax/Macros/MacroExpander.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Macros/MacroExpander.cs
@@ -379,7 +379,7 @@ namespace Uno.Compiler.Core.Syntax.Macros
                     if (call.Arguments != null && call.Arguments.Count == 2)
                     {
                         var root = ExpandConfigRoot(src, calls, index, context);
-                        return new SourceValue(src, GetBool(src, root.String) ?
+                        return new SourceValue(src, !string.IsNullOrEmpty(root.String) && GetBool(src, root.String) ?
                             GetArgumentOrNull(src, call, 0, context) :
                             GetArgumentOrNull(src, call, 1, context));
                     }


### PR DESCRIPTION
Early-out on empty string in MacroExpander. This fixes error when parsing
@(Project.iOS.SystemCapabilities.Push:Test(1,0)) when building for iOS, and
the property is missing in the project file.

    ../../uno/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist(1): E0000: Unable to parse bool ''