### PR TITLE
NDK r18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Uno Changelog
 - Upgraded to Gradle 4.4, and Gradle-plugin 3.1.3.
 - Upgraded build tools to version 27.0.3.
 - Upgraded support libraries to version 27.1.1.
-- Upgraded NDK platform version to 14.
+- Upgraded NDK platform version to 16.
 - Upgraded SDK compile and target versions to 26.
+- Fixed issues when building against the new NDK r18.
 - Added the following build property for linking native libraries from downloaded AAR packages. This makes it possible to integrate for example the ARCore SDK.
     * `Gradle.Dependency.NativeImplementation`
 - Added the following UXL file type to more conveniently include java files in generated projects.

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -87,8 +87,6 @@
 
     <Set STL="c++_static" />
 
-    <Require IncludeDirectory="@(NDK.Directory)/sources/android/support/include" />
-
     <!-- C++ source -->
 
     <ProcessFile SourceFile="Uno/EntryPoints.cpp" />

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -85,10 +85,7 @@
 
     <!-- STL config -->
 
-    <Set STL="gnustl_shared" />
-    <Set STL.Directory="@(NDK.Directory)/sources/cxx-stl/gnu-libstdc++/4.9" />
-    <Set STL.IncludeDirectory="@(STL.Directory)/include" />
-    <Require SharedLibrary="@(STL.Directory)/libs/@(ABI)/libgnustl_shared.so" />
+    <Set STL="c++_static" />
 
     <Require IncludeDirectory="@(NDK.Directory)/sources/android/support/include" />
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -92,9 +92,6 @@
 
     <Require IncludeDirectory="@(NDK.Directory)/sources/android/support/include" />
 
-    <!-- HACK: uno-base needs stlport_static -->
-    <Require StaticLibrary="@(NDK.Directory)/sources/cxx-stl/stlport/libs/@(ABI)/libstlport_static.a" />
-
     <!-- C++ source -->
 
     <ProcessFile SourceFile="Uno/EntryPoints.cpp" />

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -17,7 +17,7 @@
 
     <Set JDK.Directory="@(Config.Java.JDK.Directory:Path || JAVA_HOME:Env)" />
     <Set NDK.Directory="@(Config.Android.NDK.Directory:Path || ANDROID_NDK:Env)" />
-    <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '14')" />
+    <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '16')" />
     <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '27.0.3')" />
     <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '26')" />
     <Set SDK.Directory="@(Config.Android.SDK.Directory:Path || ANDROID_SDK:Env)" />

--- a/lib/UnoCore/prebuilt/uno-base.stuff
+++ b/lib/UnoCore/prebuilt/uno-base.stuff
@@ -1,5 +1,5 @@
 if ANDROID {
-    "Android": "https://files.fusetools.com/tooling/ByWkWr0ycr5B-uno-base-0.8.730-android.zip",
+    "Android": "https://www.nuget.org/api/v2/package/uno-base-android-static-armv7/0.8.730",
 }
 if IOS {
     "iOS": "https://files.fusetools.com/tooling/PzOS0jxo8U5Q-uno-base-0.8.730-iOS.zip"


### PR DESCRIPTION
The new NDK r18 removes `libgnustl` and `libstlport`.

These patches switches to `libc++` in uno and uno-base and makes us compatible with NDK r18.

Luckily, fuselibs still works out-of-the-box.