### PR TITLE
Android: remove gnustl packaging option

### DIFF
--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -111,10 +111,6 @@ android {
     lintOptions {
         checkReleaseBuilds = false
     }
-
-    packagingOptions {
-        pickFirst 'lib/armeabi-v7a/libgnustl_shared.so'
-    }
 }
 
 @(Gradle.BuildFile.End:Join('\n'))


### PR DESCRIPTION
This was a hint for the build system to choose the first one in case multiple
versions of the library are found. Since we no longer use gnustl after it was
removed in NDK r18 (f99047247218c30cae5f8cb5c8d437b50a45c151), we no longer
need the hint (this was mentioned in #109).