### PR TITLE
Uno.Net.Sockets: fix C++ warnings

### DIFF
--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -123,7 +123,7 @@ namespace Uno.Net
             }
             freeaddrinfo(addr);
 
-            return uArray::New(@{IPAddress[]:TypeOf}, addresses.size(), &addresses[0]);
+            return uArray::New(@{IPAddress[]:TypeOf}, (@{int})addresses.size(), &addresses[0]);
         @}
 
         public static IPAddress[] GetHostAddresses(string hostNameOrAddress)

--- a/lib/Uno.Net.Sockets/Socket.uno
+++ b/lib/Uno.Net.Sockets/Socket.uno
@@ -208,9 +208,9 @@ namespace Uno.Net.Sockets
 
             switch (mode)
             {
-                case @{SelectMode.Read}:  return select(sock + 1, &fds, NULL, NULL, &timeout);
-                case @{SelectMode.Write}: return select(sock + 1, NULL, &fds, NULL, &timeout);
-                case @{SelectMode.Error}: return select(sock + 1, NULL, NULL, &fds, &timeout);
+                case @{SelectMode.Read}:  return select((int)sock + 1, &fds, NULL, NULL, &timeout);
+                case @{SelectMode.Write}: return select((int)sock + 1, NULL, &fds, NULL, &timeout);
+                case @{SelectMode.Error}: return select((int)sock + 1, NULL, NULL, &fds, &timeout);
                 default: U_THROW(@{Uno.Exception(string):New(uString::Utf8("Invalid value for ProtocolType"))});
             }
         @}


### PR DESCRIPTION
Add casts to avoid C++ compile-time warnings.