### PR TITLE
Native: don't show console window on Windows

### DIFF
--- a/lib/UnoCore/Targets/Native/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Native/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 @(CMake.SourceGroups)
 
-add_executable(@(Project.Name:QuoteSpace)
+add_executable(@(Project.Name:QuoteSpace)@(WIN32:Defined:Test(' WIN32', ''))
     @(HeaderFile:Join('\n    ', '"@(HeaderDirectory)/', '"'))
     @(SourceFile:Join('\n    ', '"@(SourceDirectory)/', '"'))
     ${EXTRA_FILES})


### PR DESCRIPTION
This will not open a console window when launching an app using explorer,
but we'll still get console output when launching apps from the
command-line.