### PR TITLE
FuseJS.Transpiler: upgrade cached-path-relative

### DIFF
--- a/lib/FuseJS.Transpiler/src/package-lock.json
+++ b/lib/FuseJS.Transpiler/src/package-lock.json
@@ -258,9 +258,9 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "cached-path-relative": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg=="
     },
     "cipher-base": {
       "version": "1.0.4",


### PR DESCRIPTION
Due to CVE-2018-16472, it's recommended to upgrade this package. As
the *only* change betweem 1.0.1 and 1.0.2 is the fix for this
vulnerability, let's upgrade it.

The vulnerability doesn't seem to be a big deal to our users, as they
control the scripts that run in their apps themselves. So there's no
reason to back-port this to older releases.