### PR TITLE
uno doctor improvements

### DIFF
--- a/Documentation/CommandLineReference.md
+++ b/Documentation/CommandLineReference.md
@@ -242,7 +242,7 @@ Available options
   -e, --express                Express mode. Don't rebuild packages depending on a modified package
   -z, --clean                  Clean projects before building them
   -c, --configuration=NAME     Set build configuration (Debug|Release) [optional]
-  -b, --build-number=VERSION   Override version for all packages built [optional]
+  -n, --version=X.Y.Z-SUFFIX   Override version number for all packages built [optional]
   -C, --no-cache               Disable in-memory AST & IL caches
   -s, --silent                 Very quiet build log
 ```

--- a/Documentation/CommandLineReference.md
+++ b/Documentation/CommandLineReference.md
@@ -231,19 +231,19 @@ Usage: uno test-gen <path to packages> <path for temporary project> [--exclude=n
 
 ## $ uno doctor
 ```
-Usage: uno doctor [options] [package ...]
+Usage: uno doctor [options] [source-dir|package-name ...]
+  or   uno doctor [options] --force [package-name ...]
 
 Repair/rebuild packages found in search paths.
 
 Available options
-  -a, --all                    Build all projects, regardless of modification time
-  -f, --force                  Update all package caches, regardless of modification time
+  -a, --all                    Build all projects regardless of modification time
+  -f, --force                  Update package caches regardless of modification time
   -e, --express                Express mode. Don't rebuild packages depending on a modified package
   -z, --clean                  Clean projects before building them
   -c, --configuration=NAME     Set build configuration (Debug|Release) [optional]
   -b, --build-number=VERSION   Override version for all packages built [optional]
   -C, --no-cache               Disable in-memory AST & IL caches
-  -P, --no-parallel            Disable multi-threading
   -s, --silent                 Very quiet build log
 ```
 
@@ -261,7 +261,6 @@ Install options
   -n, --version=STRING  Install a specific version of <package>
   -s, --source=URL      Install <package> from a specific source
   -f, --force           Install a package even if already installed
-  -P, --no-parallel     Disable multi-threading
 ```
 
 ## $ uno uninstall

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Uno is built using the command-line on Linux, macOS or Windows – or [from insi
 
 | Build command         | Action                                                            |
 |:----------------------|:------------------------------------------------------------------|
-| `make`<sup>[3]</sup>  | Builds `uno` and standard library. Works on all platforms.        |
+| `make`<sup>[3]</sup>  | Builds `uno` and core library. Works on all platforms.            |
 
  1. On Windows, we need [vswhere] to locate your Visual Studio 2017 installation. Please make sure we can find `vswhere` in
     `%PATH%` or at `%PROGRAMFILES(x86)%\Microsoft Visual Studio\Installer`.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -82,10 +82,10 @@ if [ "$BUILD_LIBRARY" = 1 ]; then
     # Get version number
     VERSION=`cat VERSION.txt`
 
-    h1 "Building standard library"
+    h1 "Building core library"
     if [ "$REBUILD_LIBRARY" = 1 ]; then
-        uno doctor -ac$CONFIGURATION --build-number=$VERSION
+        uno doctor -ac$CONFIGURATION --version=$VERSION lib
     else
-        uno doctor -ec$CONFIGURATION --build-number=$VERSION
+        uno doctor -ec$CONFIGURATION --version=$VERSION lib
     fi
 fi

--- a/src/engine/Uno.Build/Packages/LibraryBuilder.cs
+++ b/src/engine/Uno.Build/Packages/LibraryBuilder.cs
@@ -299,6 +299,13 @@ namespace Uno.Build.Packages
                 if (_dirty.Contains(lib.ToUpperInvariant()))
                     return true;
 
+                // Check if a build with a different version number exists, possibly
+                // the project is already built using 'uno doctor --version=X.Y.Z'.
+                LibraryProject existing;
+                if (string.IsNullOrEmpty(Version) && lib.TryGetExistingBuild(out existing))
+                    // Test the existing build and maybe we don't need to built it again.
+                    lib = existing;
+
                 if (!File.Exists(lib.PackageFile))
                 {
                     Log.Event(IOEvent.Build, lib.Project.Name, "package not found");

--- a/src/engine/Uno.Build/Packages/LibraryBuilder.cs
+++ b/src/engine/Uno.Build/Packages/LibraryBuilder.cs
@@ -18,6 +18,7 @@ namespace Uno.Build.Packages
         public bool RebuildAll;
         public bool SilentBuild;
         public bool CanCache = true;
+        public bool RebuiltListIsSourcePaths;
         public string Version;
         public BuildConfiguration? Configuration;
         public List<string> RebuildList;
@@ -38,6 +39,13 @@ namespace Uno.Build.Packages
         public HashSet<string> GetSourceDirectories(UnoConfig config = null)
         {
             var sourceDirectories = new HashSet<string>();
+
+            if (RebuiltListIsSourcePaths)
+            {
+                sourceDirectories.AddRange(RebuildList);
+                return sourceDirectories;
+            }
+
             var configSourcePaths = (config ?? UnoConfig.Current).GetFullPathArray("Packages.SourcePaths", "PackageSourcePaths");
 
             if (configSourcePaths.Length == 0)
@@ -224,7 +232,7 @@ namespace Uno.Build.Packages
             foreach (var lib in dirty)
                 AddDependenciesFirst(lib, list, added, dirty);
 
-            if (RebuildList != null)
+            if (RebuildList != null && !RebuiltListIsSourcePaths)
                 foreach (var p in RebuildList)
                     if (!_libMap.ContainsKey(p.ToUpperInvariant()))
                         Log.Warning("Package " + p.Quote() + " was not found");
@@ -255,7 +263,7 @@ namespace Uno.Build.Packages
             if (RebuildAll)
                 return all;
 
-            if (RebuildList != null)
+            if (RebuildList != null && !RebuiltListIsSourcePaths)
                 foreach (var p in RebuildList)
                     _dirty.Add(p.ToUpperInvariant());
 

--- a/src/engine/Uno.Build/Packages/LibraryBuilder.cs
+++ b/src/engine/Uno.Build/Packages/LibraryBuilder.cs
@@ -37,15 +37,14 @@ namespace Uno.Build.Packages
 
         public HashSet<string> GetSourceDirectories(UnoConfig config = null)
         {
+            var sourceDirectories = new HashSet<string>();
             var configSourcePaths = (config ?? UnoConfig.Current).GetFullPathArray("Packages.SourcePaths", "PackageSourcePaths");
 
             if (configSourcePaths.Length == 0)
             {
                 Log.VeryVerbose("'Packages.SourcePaths' was not found in .unoconfig");
-                return null;
+                return sourceDirectories;
             }
-
-            var sourceDirectories = new HashSet<string>();
 
             foreach (var source in configSourcePaths)
             {

--- a/src/engine/Uno.Build/Packages/LibraryProject.cs
+++ b/src/engine/Uno.Build/Packages/LibraryProject.cs
@@ -18,14 +18,38 @@ namespace Uno.Build.Packages
         public bool Exists => File.Exists(PackageFile) && File.Exists(ConfigFile);
         public BuildConfiguration Configuration => (BuildConfiguration) Enum.Parse(typeof(BuildConfiguration), File.ReadAllText(ConfigFile).Trim());
 
-        public LibraryProject(Project project, string source)
+        public LibraryProject(Project project, string sourceDir)
         {
             Project = project;
-            PackageDirectory = Path.Combine(source, "build", project.Name);
+            PackageDirectory = Path.Combine(sourceDir, "build", project.Name);
             VersionDirectory = Path.Combine(PackageDirectory, project.Version);
             CacheDirectory = Path.Combine(VersionDirectory, ".uno");
             ConfigFile = Path.Combine(CacheDirectory, "config");
             PackageFile = Path.Combine(CacheDirectory, "package");
+        }
+
+        LibraryProject(LibraryProject lib, string versionDir)
+        {
+            Project = lib.Project;
+            PackageDirectory = lib.PackageDirectory;
+            VersionDirectory = versionDir;
+            CacheDirectory = Path.Combine(VersionDirectory, ".uno");
+            ConfigFile = Path.Combine(CacheDirectory, "config");
+            PackageFile = Path.Combine(CacheDirectory, "package");
+        }
+
+        public bool TryGetExistingBuild(out LibraryProject existing)
+        {
+            existing = null;
+            if (!Directory.Exists(PackageDirectory))
+                return false;
+
+            var versions = Directory.EnumerateDirectories(PackageDirectory).ToArray();
+            if (versions.Length != 1)
+                return false;
+
+            existing = new LibraryProject(this, versions[0]);
+            return true;
         }
 
         int? _hash;

--- a/src/engine/Uno.Build/Packages/UpkBuilder.cs
+++ b/src/engine/Uno.Build/Packages/UpkBuilder.cs
@@ -112,7 +112,7 @@ namespace Uno.Build.Packages
                 try
                 {
                     var upper = project.FullPath.ToUpperInvariant();
-                    foreach (var source in _libBuilder.GetSourceDirectories(project.Config) ?? new HashSet<string>())
+                    foreach (var source in _libBuilder.GetSourceDirectories(project.Config))
                     {
                         if (upper.StartsWith(source.ToUpperInvariant()))
                         {

--- a/src/main/Uno.CLI/Packages/Doctor.cs
+++ b/src/main/Uno.CLI/Packages/Doctor.cs
@@ -23,7 +23,7 @@ namespace Uno.CLI.Packages
             WriteRow("-e, --express",              "Express mode. Don't rebuild packages depending on a modified package");
             WriteRow("-z, --clean",                "Clean projects before building them");
             WriteRow("-c, --configuration=NAME",   "Set build configuration (Debug|Release)", true);
-            WriteRow("-b, --build-number=VERSION", "Override version for all packages built", true);
+            WriteRow("-n, --version=X.Y.Z-SUFFIX", "Override version number for all packages built", true);
             WriteRow("-C, --no-cache",             "Disable in-memory AST & IL caches");
             WriteRow("-s, --silent",               "Very quiet build log");
         }
@@ -38,7 +38,8 @@ namespace Uno.CLI.Packages
                     { "x|e|express", value => lib.Express = true },
                     { "z|clean", value => lib.Clean = true },
                     { "c=|configuration=", value => lib.Configuration = value.ParseEnum<BuildConfiguration>("configuration") },
-                    { "b=|build-number=", value => lib.Version = value.ParseString("build-number") },
+                    { "b=|build-number=", value => { lib.Version = value.ParseString("build-number"); Log.Warning("--build-number is deprecated, please use --version instead."); }},
+                    { "n=|version=", value => lib.Version = value.ParseString("version") },
                     { "C|no-cache", value => lib.CanCache = false },
                     { "s|silent", value => lib.SilentBuild = true },
                 }.Parse(args);


### PR DESCRIPTION
This comes with some improvements to the `uno doctor` command, most notably the ability to control which projects are actually built by passing directories on the command-line.

This makes it possible to build the right version when there are multiple copies of for example `fuselibs` in flight.