### PR TITLE
UnoCore: make sure life-cycle events are called on Native

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
@@ -248,14 +248,14 @@ struct uMainLoop : Xli::WindowEventHandler
     virtual bool OnClosing(Xli::Window* wnd, bool& cancel)
     {
         uAutoReleasePool pool;
-
-        // TODO
+        @{Uno.Platform.CoreApp.EnterBackground():Call()};
         return false;
     }
 
     virtual void OnClosed(Xli::Window* wnd)
     {
         uAutoReleasePool pool;
+        @{Uno.Platform.CoreApp.Terminate():Call()};
     }
 
     virtual void OnAppLowMemory(Xli::Window* wnd)


### PR DESCRIPTION
This fixes a bug in apps trying to do something on exit, and nothing gets
done, because the life-cycle callbacks are never called.