### PR TITLE
Uno.Compiler: report image filename when WriteImageFile() fails

### DIFF
--- a/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
@@ -664,7 +664,8 @@ namespace Uno.Compiler.Core.Syntax
             }
             catch (Exception e)
             {
-                Log.Error(f.SourceName.Source, ErrorCode.E0000, e.Message);
+                Log.Error(new Source(src), ErrorCode.E0000, e.Message);
+                Log.Error(f.SourceName.Source, ErrorCode.E0000, "Failed to convert " + src.Quote());
             }
         }
 


### PR DESCRIPTION
I experienced a problem with an image in an incompatible pixel format, and
this makes it easier to see which image file is causing the problem.