### PR TITLE
Uno.Compiler: fix name resolver bug

### DIFF
--- a/src/compiler/Uno.Compiler.Core/Syntax/Compilers/FunctionCompiler.NameResolver.Identifier.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Compilers/FunctionCompiler.NameResolver.Identifier.cs
@@ -139,11 +139,18 @@ namespace Uno.Compiler.Core.Syntax.Compilers
                             return new PartialValue(new GetMetaProperty(id.Source, mp.ReturnType, mp.Name));
                     }
 
-                    var dt = block.TryFindTypeParent();
-
-                    if (dt != null)
+                    // Object context
+                    for (var dt = block.TryFindTypeParent(); dt != null; dt = dt.ParentType)
                     {
                         var p = TryResolveTypeMember(dt, id, typeParamCount, null, new GetMetaObject(id.Source, TypeBuilder.Parameterize(dt)));
+                        if (p != null)
+                            return p;
+                    }
+
+                    // Static context
+                    for (var dt = block.ParentType; dt != null; dt = dt.ParentType)
+                    {
+                        var p = TryResolveTypeMember(dt, id, typeParamCount, null, null);
                         if (p != null)
                             return p;
                     }

--- a/tests/src/UnoTest/ShaderGenerator/NestedBlock.uno
+++ b/tests/src/UnoTest/ShaderGenerator/NestedBlock.uno
@@ -1,0 +1,31 @@
+namespace UnoTest
+{
+    class NestedBlock
+    {
+        static float4 GetColor()
+        {
+            return float4(1, 1, 0, 1);
+        }
+
+        class Class
+        {
+            public void Draw()
+            {
+                draw Block;
+            }
+
+            block Block
+            {
+                float2[] VertexData:
+                    new[] {
+                        float2(0, 0), float2(1, 0), float2(1, 1),
+                        float2(0, 0), float2(1, 1), float2(0, 1)
+                    };
+                ClipPosition:
+                    float4(vertex_attrib(VertexData), 0, 0);
+                PixelColor:
+                    GetColor();
+            }
+        }
+    }
+}

--- a/tests/src/UnoTest/UnoTest.unoproj
+++ b/tests/src/UnoTest/UnoTest.unoproj
@@ -970,6 +970,7 @@
     "ShaderGenerator/DefaultPrimitivesBlock.uno:Source",
     "ShaderGenerator/DefaultShading.uno:Source",
     "ShaderGenerator/Lights.uno:Source",
+    "ShaderGenerator/NestedBlock.uno:Source",
     "ShaderGenerator/PixelInputs.uno:Source",
     "ShaderGenerator/Quad.uno:Source",
     "ShaderGenerator/ShaderControlFlow.uno:Source",


### PR DESCRIPTION
This fixes bugs when accessing members of a parent class from inside a nested
block.