### PR TITLE
Uno.Compiler: verify visibility of generic arguments

### DIFF
--- a/lib/UnoCore/Tests/Collections/HashSet.Test.uno
+++ b/lib/UnoCore/Tests/Collections/HashSet.Test.uno
@@ -7,7 +7,7 @@ namespace Collections.Test
 {
     public class HashSetTest
     {
-        class DummyClass
+        public class DummyClass
         {
             string _f;
             string _b;

--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Type.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Type.cs
@@ -374,6 +374,9 @@ namespace Uno.Compiler.Core.IL.Validation
                     !Environment.IsGeneratingCode ||
                     !Backend.Has(TypeOptions.IgnoreProtection)))
                 Log.Error(owner.Source, ErrorCode.E4128, dt.Quote() + " is less accessible than " + owner.Quote());
+            else if (dt.IsGenericParameterization)
+                foreach (var pt in dt.GenericArguments)
+                    VerifyVisibility(owner, visibility, pt);
         }
     }
 }

--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Type.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.Type.cs
@@ -369,10 +369,12 @@ namespace Uno.Compiler.Core.IL.Validation
 
         void VerifyVisibility(SourceObject owner, Visibility visibility, DataType dt)
         {
+            if (Backend.Has(TypeOptions.IgnoreProtection) &&
+                Environment.IsGeneratingCode)
+                return;
+
             if (VerifyAccessibleEntity(owner.Source, dt) &&
-                !visibility.IsVisibile(dt) && (
-                    !Environment.IsGeneratingCode ||
-                    !Backend.Has(TypeOptions.IgnoreProtection)))
+                !visibility.IsVisibile(dt))
                 Log.Error(owner.Source, ErrorCode.E4128, dt.Quote() + " is less accessible than " + owner.Quote());
             else if (dt.IsGenericParameterization)
                 foreach (var pt in dt.GenericArguments)


### PR DESCRIPTION
This will catch more compile-time errors like the following:

    E4128: X is less accessible than Y