### PR TITLE
UnoCore: deprecate MSVC12 define

### DIFF
--- a/lib/Uno.Net.Http/HttpMessageHandler.uno
+++ b/lib/Uno.Net.Http/HttpMessageHandler.uno
@@ -14,7 +14,7 @@ namespace Uno.Net.Http
 
             internal static void IncrementPendingRequests()
             {
-                if defined(CIL || LINUX || MSVC12)
+                if defined(CIL || LINUX || MSVC)
                 {
                     lock (_syncLock)
                     {
@@ -26,7 +26,7 @@ namespace Uno.Net.Http
 
             internal static void DecrementPendingRequests()
             {
-                if defined(CIL || LINUX || MSVC12)
+                if defined(CIL || LINUX || MSVC)
                 {
                     lock (_syncLock)
                     {
@@ -40,7 +40,7 @@ namespace Uno.Net.Http
             {
                 if defined(CIL)
                     CilHttpMessageHandler.ProcessEvents();
-                if defined(LINUX || MSVC12)
+                if defined(LINUX || MSVC)
                     XliHttpMessageHandler.ProcessEvents();
             }
         }

--- a/lib/Uno.Net.Http/HttpMessageHandlerRequest.uno
+++ b/lib/Uno.Net.Http/HttpMessageHandlerRequest.uno
@@ -40,7 +40,7 @@ namespace Uno.Net.Http
 
             if defined(ANDROID)
                 _httpRequest = new AndroidHttpRequest(this, method, url);
-            if defined(LINUX || MSVC12)
+            if defined(LINUX || MSVC)
                 _httpRequest = new XliHttpRequest(this, method, url);
             if defined(APPLE)
                 _httpRequest = new iOSHttpRequest(this, method, url);

--- a/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.cpp.uxl
+++ b/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.cpp.uxl
@@ -1,4 +1,4 @@
-<Extensions Backend="CPlusPlus" Condition="LINUX || MSVC12">
+<Extensions Backend="CPlusPlus" Condition="LINUX || MSVC">
 
     <Using Namespace="Uno.Net.Http.Implementation" />
 

--- a/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.uno
+++ b/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.uno
@@ -4,17 +4,17 @@ using Uno.Compiler.ExportTargetInterop;
 namespace Uno.Net.Http.Implementation
 {
     [TargetSpecificType]
-    extern(LINUX || MSVC12) struct XliHttpClientHandle
+    extern(LINUX || MSVC) struct XliHttpClientHandle
     {
     }
 
     [TargetSpecificType]
-    extern(LINUX || MSVC12) struct XliHttpRequestHandle
+    extern(LINUX || MSVC) struct XliHttpRequestHandle
     {
     }
 
     [TargetSpecificImplementation]
-    internal extern(LINUX || MSVC12) static class XliHttpMessageHandler
+    internal extern(LINUX || MSVC) static class XliHttpMessageHandler
     {
         internal static XliHttpClientHandle _clientHandle;
 
@@ -33,7 +33,7 @@ namespace Uno.Net.Http.Implementation
     }
 
     [TargetSpecificImplementation]
-    internal extern(LINUX || MSVC12) class XliHttpRequest : IHttpRequest
+    internal extern(LINUX || MSVC) class XliHttpRequest : IHttpRequest
     {
         HttpMessageHandlerRequest _request;
         XliHttpRequestHandle _requestHandle;

--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -135,7 +135,7 @@ namespace Uno.Net
                 (hostNameOrAddress.Length == 255 && hostNameOrAddress[254] != '.'))
                 throw new ArgumentOutOfRangeException("hostNameOrAddress");
 
-            if defined(MSVC12)
+            if defined(MSVC)
                 NetworkHelpers.EnsureWinsockInitialized();
 
             if defined(CPLUSPLUS)

--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -7,9 +7,9 @@ namespace Uno.Net
 {
     [DotNetType("System.Net.Dns")]
     [extern(APPLE) Require("Source.Include", "ifaddrs.h")]
-    [extern(!MSVC) Require("Source.Include", "sys/socket.h")]
-    [extern(!MSVC) Require("Source.Include", "netdb.h")]
-    [extern(!MSVC) Require("Source.Include", "netinet/in.h")]
+    [extern(UNIX) Require("Source.Include", "sys/socket.h")]
+    [extern(UNIX) Require("Source.Include", "netdb.h")]
+    [extern(UNIX) Require("Source.Include", "netinet/in.h")]
     [extern(MSVC) Require("Source.Include", "ws2tcpip.h")]
     [Require("Source.Include", "vector")]
     [ForeignInclude(Language.Java, "java.util.*", "java.net.*")]
@@ -140,7 +140,7 @@ namespace Uno.Net
 
             if defined(CPLUSPLUS)
             {
-                if defined(!MSVC)
+                if defined(UNIX)
                 {
                     if (hostNameOrAddress.Length == 0)
                     {

--- a/lib/Uno.Net.Sockets/IPAddress.uno
+++ b/lib/Uno.Net.Sockets/IPAddress.uno
@@ -41,7 +41,7 @@ namespace Uno.Net
 
     }
 
-    [extern(!MSVC) Require("Source.Include", "arpa/inet.h")]
+    [extern(UNIX) Require("Source.Include", "arpa/inet.h")]
     [extern(MSVC) Require("Source.Include", "ws2tcpip.h")]
     [DotNetType("System.Net.IPAddress")]
     public class IPAddress

--- a/lib/Uno.Net.Sockets/NetworkHelpers.uno
+++ b/lib/Uno.Net.Sockets/NetworkHelpers.uno
@@ -4,7 +4,7 @@ namespace Uno.Net
 {
     [extern(MSVC) Require("Source.Include", "winsock2.h")]
     [extern(MSVC) Require("LinkLibrary", "ws2_32")]
-    [extern(!MSVC) Require("Source.Include", "errno.h")]
+    [extern(UNIX) Require("Source.Include", "errno.h")]
     extern(CPLUSPLUS) internal class NetworkHelpers
     {
         extern(MSVC) public static string GetError()
@@ -24,7 +24,7 @@ namespace Uno.Net
             return ret;
         @}
 
-        extern(!MSVC) public static string GetError()
+        extern(UNIX) public static string GetError()
         @{
             return uString::Utf8(strerror(errno));
         @}

--- a/lib/Uno.Net.Sockets/Socket.uno
+++ b/lib/Uno.Net.Sockets/Socket.uno
@@ -291,7 +291,7 @@ namespace Uno.Net.Sockets
         {
             if defined(CPLUSPLUS)
             {
-                if defined(MSVC12)
+                if defined(MSVC)
                     NetworkHelpers.EnsureWinsockInitialized();
 
                 var family = SocketHelpers.GetFamily(addressFamily);
@@ -541,7 +541,7 @@ namespace Uno.Net.Sockets
             if defined(CPLUSPLUS)
             {
                 int result;
-                if defined(MSVC12)
+                if defined(MSVC)
                     result = extern<int>(_handle) "closesocket($0)";
                 else
                     result = extern<int>(_handle) "close($0)";

--- a/lib/Uno.Net.Sockets/Socket.uno
+++ b/lib/Uno.Net.Sockets/Socket.uno
@@ -47,12 +47,12 @@ namespace Uno.Net.Sockets
         None = 0
     }
 
-    [extern(!MSVC) Require("Source.Include", "sys/socket.h")]
+    [extern(UNIX) Require("Source.Include", "sys/socket.h")]
     [extern(MSVC) Require("Source.Declaration", "typedef ULONG in_addr_t;")]
     [extern(MSVC) Require("Source.Declaration", "#define SHUT_RD SD_RECEIVE")]
     [extern(MSVC) Require("Source.Declaration", "#define SHUT_WR SD_SEND")]
     [extern(MSVC) Require("Source.Declaration", "#define SHUT_RDWR SD_BOTH")]
-    [extern(!MSVC) Require("Source.Include", "errno.h")]
+    [extern(UNIX) Require("Source.Include", "errno.h")]
     extern(CPLUSPLUS) internal class SocketHelpers
     {
         public static int GetFamily(AddressFamily addressFamily)
@@ -228,7 +228,7 @@ namespace Uno.Net.Sockets
             return ret;
         @}
 
-        extern(!MSVC) public static int Ioctl(Socket.SocketHandle sock, int request, out int arg)
+        extern(UNIX) public static int Ioctl(Socket.SocketHandle sock, int request, out int arg)
         @{
             return ioctl(sock, request, arg);
         @}
@@ -241,7 +241,7 @@ namespace Uno.Net.Sockets
             return result;
         @}
 
-        extern(!MSVC) public static int Shutdown(Socket.SocketHandle sock, int how)
+        extern(UNIX) public static int Shutdown(Socket.SocketHandle sock, int how)
         @{
             int result = shutdown(sock, how);
             if (result < 0 && errno == ENOTCONN)
@@ -254,19 +254,19 @@ namespace Uno.Net.Sockets
     [extern(MSVC) Require("Header.Include", "ws2tcpip.h")]
     [extern(MSVC) Require("LinkLibrary", "ws2_32")]
     [extern(ANDROID) Require("Source.Include", "arpa/inet.h")]
-    [extern(!MSVC) Require("Source.Include", "netdb.h")]
-    [extern(!MSVC) Require("Source.Include", "netinet/in.h")]
-    [extern(!MSVC) Require("Source.Include", "sys/ioctl.h")]
-    [extern(!MSVC) Require("Source.Include", "sys/socket.h")]
-    [extern(!MSVC) Require("Source.Include", "sys/types.h")]
-    [extern(!MSVC) Require("Source.Include", "unistd.h")]
+    [extern(UNIX) Require("Source.Include", "netdb.h")]
+    [extern(UNIX) Require("Source.Include", "netinet/in.h")]
+    [extern(UNIX) Require("Source.Include", "sys/ioctl.h")]
+    [extern(UNIX) Require("Source.Include", "sys/socket.h")]
+    [extern(UNIX) Require("Source.Include", "sys/types.h")]
+    [extern(UNIX) Require("Source.Include", "unistd.h")]
     public class Socket : IDisposable
     {
         [TargetSpecificType]
         [extern(MSVC) Set("TypeName", "SOCKET")]
         [extern(MSVC) Set("DefaultValue", "INVALID_SOCKET")]
-        [extern(CPLUSPLUS && !MSVC) Set("TypeName", "int")]
-        [extern(CPLUSPLUS && !MSVC) Set("DefaultValue", "-1")]
+        [extern(CPLUSPLUS && UNIX) Set("TypeName", "int")]
+        [extern(CPLUSPLUS && UNIX) Set("DefaultValue", "-1")]
         extern(CPLUSPLUS) internal struct SocketHandle
         {
             public static readonly SocketHandle Invalid;

--- a/lib/UnoCore/Targets/Native/Native.uxl
+++ b/lib/UnoCore/Targets/Native/Native.uxl
@@ -10,6 +10,7 @@
 
     <!-- Environment -->
     <Define MSVC="HOST_WIN32" />
+    <!-- Deprecated -->
     <Define MSVC12="HOST_WIN32" />
 
     <!-- Architecture (override by -DX86 or -DX64) -->


### PR DESCRIPTION
We're using MSVC version 15 and not 12, so this define is outdated and should
be removed in the future.