### PR TITLE
Disable C# tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,12 @@ env:
     - TARGET=dotnet
     - TARGET=native
 
-install:
-  - nuget install NUnit.ConsoleRunner -Version 3.8.0
-
 before_script:
   - ulimit -c unlimited -S
   - rm -rf /cores/core.*
 
 script:
   - scripts/build.sh
-  - |
-    mono NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe --agents=1 \
-      src/testing/Uno.TestRunner.Tests/bin/Debug/Uno.TestRunner.Tests.dll \
-      src/ux/Uno.UX.Markup.AST/Tests/bin/Debug/Uno.UX.Markup.AST.Tests.dll \
-      src/ux/Uno.UX.Markup.UXIL/Tests/bin/Debug/Uno.UX.Markup.UXIL.Tests.dll
   - bin/uno test --target=$TARGET lib
   - bin/uno test-gen lib /tmp/PackageCompilationTest
   - bin/uno build --target=$TARGET --no-strip /tmp/PackageCompilationTest


### PR DESCRIPTION
The C# test runner have (randomly) failed a lot on Travis lately, even if all
tests have actually passed, with the following error message:

    NUnit.Engine.NUnitEngineUnloadException : Multiple exceptions encountered. Retrieve AggregatedExceptions property for more information
      ----> System.Runtime.Remoting.RemotingException : Tcp transport error.
      ----> System.Runtime.Remoting.RemotingException : Connection closed
    The command "mono NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe --agents=1 \
      src/testing/Uno.TestRunner.Tests/bin/Debug/Uno.TestRunner.Tests.dll \
      src/ux/Uno.UX.Markup.AST/Tests/bin/Debug/Uno.UX.Markup.AST.Tests.dll \
      src/ux/Uno.UX.Markup.UXIL/Tests/bin/Debug/Uno.UX.Markup.UXIL.Tests.dll
    " exited with 251.

The C# tests are run on AppVeyor in any case. I think that is safe enough and
that we can simply stop running these tests on Travis to avoid this problem.