### PR TITLE
Android: add google repository to all projects #130

### DIFF
--- a/lib/UnoCore/Targets/Android/Dependencies.uxl
+++ b/lib/UnoCore/Targets/Android/Dependencies.uxl
@@ -1,5 +1,6 @@
 <Extensions Backend="CPlusPlus" Condition="ANDROID">
 
+    <Require Gradle.AllProjects.Repository="google()" />
     <Require Gradle.AllProjects.Repository="jcenter()" />
     <Require Gradle.AllProjects.Repository="mavenCentral()" />
     <Require Gradle.BuildScript.Repository="google()" />


### PR DESCRIPTION
Myself and others have occasionally experienced trouble when downloading
dependencies when building for Android, and this seems to fix the problem.

I haven't seen this problem in a while and it seems to have been caused by
temporary issues on Google servers, but it doesn't cause any harm to add the
fix anyway, hopefully avoiding similar trouble in the future.