### PR TITLE
C++: switch to size_t in uArray and uString

### DIFF
--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -123,7 +123,7 @@ namespace Uno.Net
             }
             freeaddrinfo(addr);
 
-            return uArray::New(@{IPAddress[]:TypeOf}, (@{int})addresses.size(), &addresses[0]);
+            return uArray::New(@{IPAddress[]:TypeOf}, addresses.size(), &addresses[0]);
         @}
 
         public static IPAddress[] GetHostAddresses(string hostNameOrAddress)

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
@@ -723,7 +723,7 @@ uObject* uNew(uType* type, size_t size)
     return uInitObject(type, calloc(1, size), size);
 }
 
-static uString* uInitString(int32_t length)
+static uString* uInitString(size_t length)
 {
     size_t size = sizeof(uString) + sizeof(char16_t) * length + sizeof(char16_t);
     uString* string = (uString*)uInitObject(@{string:TypeOf}, calloc(1, size), size);
@@ -732,7 +732,7 @@ static uString* uInitString(int32_t length)
     return string;
 }
 
-uString* uString::New(int32_t length)
+uString* uString::New(size_t length)
 {
     if (length == 0)
     {

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -477,52 +477,52 @@ struct uArrayType : uType
 struct uArray : uObject
 {
     void* _ptr;
-    int32_t _length;
+    size_t _length;
 
-    int32_t Length() const { return _length; }
+    int32_t Length() const { return (int32_t) _length; }
     const void* Ptr() const { return _ptr; }
     void* Ptr() { return _ptr; }
 
-    void MarshalPtr(int32_t index, const void* value, size_t size);
-    uTField TItem(int32_t index);
-    uTField TUnsafe(int32_t index);
+    void MarshalPtr(size_t index, const void* value, size_t size);
+    uTField TItem(size_t index);
+    uTField TUnsafe(size_t index);
 
     template<class T>
-    T& Item(int32_t index) {
+    T& Item(size_t index) {
         U_ASSERT(sizeof(T) == ((uArrayType*)__type)->ElementType->ValueSize);
-        if (index < 0 || index >= _length)
+        if (index >= _length)
             U_THROW_IOORE();
         return ((T*)_ptr)[index];
     }
     template<class T>
-    uStrong<T>& Strong(int32_t index) {
+    uStrong<T>& Strong(size_t index) {
         U_ASSERT(sizeof(T) == ((uArrayType*)__type)->ElementType->ValueSize);
-        if (index < 0 || index >= _length)
+        if (index >= _length)
             U_THROW_IOORE();
         return ((uStrong<T>*)_ptr)[index];
     }
     template<class T>
-    T& Unsafe(int32_t index) {
+    T& Unsafe(size_t index) {
         U_ASSERT(sizeof(T) == ((uArrayType*)__type)->ElementType->ValueSize &&
                  index >= 0 && index < _length);
         return ((T*)_ptr)[index];
     }
     template<class T>
-    uStrong<T>& UnsafeStrong(int32_t index) {
+    uStrong<T>& UnsafeStrong(size_t index) {
         U_ASSERT(sizeof(T) == ((uArrayType*)__type)->ElementType->ValueSize &&
                  index >= 0 && index < _length);
         return ((uStrong<T>*)_ptr)[index];
     }
 
-    static uArray* New(uType* type, int32_t length, const void* optionalData = NULL);
-    static uArray* InitT(uType* type, int32_t length, ...);
+    static uArray* New(uType* type, size_t length, const void* optionalData = NULL);
+    static uArray* InitT(uType* type, size_t length, ...);
 
     template<class T>
-    static uArray* Init(uType* type, int32_t length, ...) {
+    static uArray* Init(uType* type, size_t length, ...) {
         va_list ap;
         va_start(ap, length);
         uArray* array = New(type, length);
-        for (int32_t i = 0; i < length; i++) {
+        for (size_t i = 0; i < length; i++) {
             T item = va_arg(ap, T);
             array->MarshalPtr(i, &item, sizeof(T));
         }
@@ -539,21 +539,21 @@ struct uArray : uObject
 struct uString : uObject
 {
     char16_t* _ptr;
-    int32_t _length;
+    size_t _length;
 
-    int32_t Length() const { return _length; }
+    int32_t Length() const { return (int32_t) _length; }
     const char16_t* Ptr() const { return _ptr; }
 
-    const char16_t& Item(int32_t index) const {
-        if (index < 0 || index >= _length)
+    const char16_t& Item(size_t index) const {
+        if (index >= _length)
             U_THROW_IOORE();
         return _ptr[index];
     }
-    const char16_t& Unsafe(int32_t index) const {
+    const char16_t& Unsafe(size_t index) const {
         return _ptr[index];
     }
 
-    static uString* New(int32_t length);
+    static uString* New(size_t length);
     static uString* Ansi(const char* cstr);
     static uString* Ansi(const char* cstr, size_t length);
     static uString* Utf8(const char* mutf8);
@@ -562,7 +562,7 @@ struct uString : uObject
     static uString* Utf16(const char16_t* utf16, size_t length);
     static uString* Const(const char* mutf8);
     static uString* CharArray(const uArray* chars);
-    static uString* CharArrayRange(const uArray* chars, int32_t startIndex, int32_t length);
+    static uString* CharArrayRange(const uArray* chars, size_t startIndex, size_t length);
     static bool Equals(const uString* left, const uString* right, bool ignoreCase = false);
 };
 
@@ -810,12 +810,12 @@ inline uTPtr uUnboxAny(const uType* type, uObject* object) {
         ? (uint8_t*)uPtr(object) + sizeof(uObject)
         : (void*)object;
 }
-inline uTField uArray::TItem(int32_t index) {
-    if (index < 0 || index >= _length) U_THROW_IOORE();
+inline uTField uArray::TItem(size_t index) {
+    if (index >= _length) U_THROW_IOORE();
     uType* type = ((uArrayType*)__type)->ElementType;
     return uTField(type, (uint8_t*)_ptr + type->ValueSize * index);
 }
-inline uTField uArray::TUnsafe(int32_t index) {
+inline uTField uArray::TUnsafe(size_t index) {
     uType* type = ((uArrayType*)__type)->ElementType;
     return uTField(type, (uint8_t*)_ptr + type->ValueSize * index);
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.mm
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.mm
@@ -20,7 +20,7 @@ namespace uObjC
 		NSUInteger bytes = [string
 			lengthOfBytesUsingEncoding: NativeUTF16Encoding];
 		
-		uString* result = uString::New((int)(bytes / sizeof(char16_t)));
+		uString* result = uString::New(bytes / sizeof(char16_t));
 		
 		NSUInteger usedBytes = 0;
 		if ([string
@@ -34,7 +34,7 @@ namespace uObjC
 		{
 			if (usedBytes != bytes)
 			{
-				result->_length = (int)(usedBytes / sizeof(char16_t));
+				result->_length = usedBytes / sizeof(char16_t);
 				result->_ptr[result->_length] = 0;
 			}
 			return result;

--- a/lib/UnoCore/Source/Uno/String.uno
+++ b/lib/UnoCore/Source/Uno/String.uno
@@ -507,7 +507,7 @@ namespace Uno
 
         public string PadLeft(int totalLength, char paddingSymbol)
         @{
-            int padLength = $0 - $$->_length;
+            int padLength = $0 - $$->Length();
             if (padLength <= 0)
                 return $$;
 
@@ -527,13 +527,13 @@ namespace Uno
 
         public string PadRight(int totalLength, char paddingSymbol)
         @{
-            if ($0 <= $$->_length)
+            if ($0 <= $$->Length())
                 return $$;
 
             uString* result = uString::New($0);
             memcpy(result->_ptr, $$->_ptr, $$->_length * sizeof(@{char}));
 
-            for (int i = $$->_length; i < $0; i++)
+            for (int i = $$->Length(); i < $0; i++)
                 result->_ptr[i] = $1;
 
             return result;

--- a/lib/UnoCore/Source/Uno/Text/Utf8.uno
+++ b/lib/UnoCore/Source/Uno/Text/Utf8.uno
@@ -296,7 +296,7 @@ namespace Uno.Text
             if defined(CPLUSPLUS)
             @{
                 uCString cstr($0);
-                return uArray::New(@{byte[]:TypeOf}, (int32_t) cstr.Length, cstr.Ptr);
+                return uArray::New(@{byte[]:TypeOf}, cstr.Length, cstr.Ptr);
             @}
             else if defined(DOTNET)
                 return Encoding.UTF8.GetBytes(value);

--- a/lib/UnoCore/Source/Uno/Type.uno
+++ b/lib/UnoCore/Source/Uno/Type.uno
@@ -223,7 +223,7 @@ namespace Uno
         {
             if defined(CPLUSPLUS)
             {
-                var array = new Type[extern<int> "(int32_t) $$->GenericCount"];
+                var array = new Type[extern<int> "$$->GenericCount"];
                 for (int i = 0; i < array.Length; i++)
                     array[i] = extern<Type>(i) "$$->Generics[$0]";
                 return array;
@@ -244,7 +244,7 @@ namespace Uno
         {
             if defined(CPLUSPLUS)
             {
-                var array = new Type[extern<int> "(int32_t) $$->InterfaceCount"];
+                var array = new Type[extern<int> "$$->InterfaceCount"];
                 for (int i = 0; i < array.Length; i++)
                     array[i] = extern<Type>(i) "$$->Interfaces[$0].Type";
                 return array;


### PR DESCRIPTION
size_t is commonly used to represent indices and lengths in C/C++ code, and
instead of adding casts to int32_t, we change the interface of uArray and
uString to accept size_t. This seems to align better with a lot of C/C++
code, and is non-breaking since int32_t implicitly converts to size_t and
vice versa. Since many call sites were size_t to begin with we can remove
some explicit casts to int32_t, and since we can remove some often called
"< 0" checks the code is in theory a bit faster now than it was before.

This fixes a few instances of the following warning:

    warning C4267: 'argument': conversion from 'size_t' to 'int32_t', possible loss of data