### PR TITLE
Run more tests on CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,12 +29,10 @@ before_test:
           Copy-Item -Path mesa\x64\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
         }
       }
-  - bin\uno test-gen lib %TEMP%\PackageCompilationTest
 
 test_script:
   - nunit3-console
       src\testing\Uno.TestRunner.Tests\bin\Release\Uno.TestRunner.Tests.dll
       src\ux\Uno.UX.Markup.AST\Tests\bin\Release\Uno.UX.Markup.AST.Tests.dll
       src\ux\Uno.UX.Markup.UXIL\Tests\bin\Release\Uno.UX.Markup.UXIL.Tests.dll
-  - bin\uno test --target=%TARGET% lib
-  - bin\uno build --target=%TARGET% --no-strip %TEMP%\PackageCompilationTest
+  - bash scripts\test.sh %TARGET%

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ build/
 .uno/
 .cache/
 .stuff/
+.test/
 .unobuild
 .vs/
 **/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ before_script:
 
 script:
   - scripts/build.sh
-  - bin/uno test --target=$TARGET lib
-  - bin/uno test-gen lib /tmp/PackageCompilationTest
-  - bin/uno build --target=$TARGET --no-strip /tmp/PackageCompilationTest
+  - scripts/test.sh $TARGET
 
 after_failure:
   - for c in $(ls /cores/core.*); do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,8 +1,36 @@
-#!/bin/sh
+#!/bin/bash
+SELF=`echo $0 | sed 's/\\\\/\\//g'`
+cd "`dirname "$SELF"`/.." || exit 1
+source scripts/common.sh
 
-ROOT=`dirname $0`/..
-COMPILATION_DIR=/tmp/PackageCompilationTest
+# Arguments
+TARGET=$1
 
-"$ROOT/bin/uno" test lib $*
-"$ROOT/bin/uno" test-gen "$ROOT/lib" "$COMPILATION_DIR"
-"$ROOT/bin/uno" build --target=cmake --no-strip --clean "$COMPILATION_DIR"
+# Run uno tests
+uno test $TARGET lib
+uno test $TARGET tests/src/{Uno,UX}Test
+
+# Run compiler tests
+function uno-compiler-test {
+    for config in Debug Release; do
+        exe=src/testing/Uno.CompilerTestRunner/bin/$config/uno-compiler-test.exe
+        if [ -f $exe ]; then
+            dotnet-clr $exe
+            return $?
+        fi
+    done
+
+    echo "ERROR: uno-compiler-test.exe was not found"
+    return 1
+}
+
+uno-compiler-test
+
+# Check that all packages build without errors
+function packages-build-test {
+    dir=.test/build-$1
+    uno test-gen $1 $dir
+    uno build $TARGET --no-strip $dir
+}
+
+packages-build-test lib

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,7 +8,11 @@ TARGET=$1
 
 # Run uno tests
 uno test $TARGET lib
-uno test $TARGET tests/src/{Uno,UX}Test
+
+# Skip when testing 'native' on AppVeyor
+if [[ "$APPVEYOR" != True || "$TARGET" != native ]]; then
+    uno test $TARGET tests/src/{Uno,UX}Test
+fi
 
 # Run compiler tests
 function uno-compiler-test {


### PR DESCRIPTION
This fixes up test.sh and brings back UnoTest, UXTest and our old compiler
tests, which are currently not being run.

Both AppVeyor and Travis now run tests by invoking test.sh, which reduces
duplication and seems to be cleaner than it was before.