### PR TITLE
Fix dependency downloads

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
 install:
   - ps: |
       if ($env:Target -eq "native") {
-        Invoke-WebRequest https://files.fusetools.com/tooling/iyVp8kwQ0vLn-mesa-17.2.3.500.zip -OutFile mesa.zip
+        Invoke-WebRequest https://www.nuget.org/api/v2/package/mesa3d-x64/18.3.4 -OutFile mesa.zip
         Expand-Archive mesa.zip mesa
       }
 
@@ -25,7 +25,7 @@ before_test:
         Get-ChildItem -Path lib -Recurse -Include *Test.unoproj | Select-Object -ExpandProperty DirectoryName | Foreach-Object {
           $buildDir = Join-Path $_ build\Test\Native
           New-Item -Force -ItemType directory -Path $buildDir | Out-Null
-          Copy-Item -Path mesa\x64\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
+          Copy-Item -Path mesa\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
         }
       }
 

--- a/lib/UnoCore/Backends/CIL/CIL.uxl
+++ b/lib/UnoCore/Backends/CIL/CIL.uxl
@@ -31,8 +31,7 @@
     <Template Name="Uno.Native">
         <Require Assembly="@(PACKAGE_DIR)/prebuilt/Uno.Native/Uno.Native.dll" />
         <Require UnmanagedLibrary="@(PACKAGE_DIR)/prebuilt/Uno.Native/libuAsset.dylib" Condition="HOST_MAC" />
-        <Require UnmanagedLibrary.x86="@(PACKAGE_DIR)/prebuilt/Uno.Native/x86/uAsset.dll" Condition="HOST_WIN32" />
-        <Require UnmanagedLibrary.x64="@(PACKAGE_DIR)/prebuilt/Uno.Native/x64/uAsset.dll" Condition="HOST_WIN32" />
+        <Require UnmanagedLibrary="@(PACKAGE_DIR)/prebuilt/Uno.Native/uAsset.dll" Condition="HOST_WIN32" />
     </Template>
 
     <!-- Deprecated -->

--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -4,7 +4,6 @@
 set -e
 cd "`dirname "$0"`"
 
-
 case $1 in
 debug)
     echo "Opening Xcode"
@@ -18,10 +17,13 @@ debug)
     ;;
 uninstall)
     echo "Uninstalling @(BundleIdentifier)"
+    chmod +x "@(Base.Directory)/bin/ios-deploy"
     "@(Base.Directory)/bin/ios-deploy" -9 -1 "@(BundleIdentifier)"
     exit $?
     ;;
 esac
+
+chmod +x "@(Base.Directory)/bin/ios-deploy"
 
 #if @(Cocoapods:Defined)
 pod install

--- a/lib/UnoCore/prebuilt/Uno.Native.stuff
+++ b/lib/UnoCore/prebuilt/Uno.Native.stuff
@@ -1,6 +1,6 @@
 if DOTNET && HOST_WIN32 {
-    /* 1.44MB */ Uno.Native: "https://files.fusetools.com/tooling/PWRYkbaWRH9W-Uno.Native-180312-bf6027-Win32.zip"
+    /* 1.44MB */ Uno.Native: "https://www.nuget.org/api/v2/package/uno-asset-importer-win32-x64/1.0.0"
 }
 if DOTNET && HOST_MAC {
-    /* 1.08MB */ Uno.Native: "https://files.fusetools.com/tooling/NEGisK9vdA37-Uno.Native-180312-4a5f15-macOS.zip"
+    /* 1.08MB */ Uno.Native: "https://www.nuget.org/api/v2/package/uno-asset-importer-macOS/1.0.0"
 }

--- a/lib/UnoCore/prebuilt/uno-base.stuff
+++ b/lib/UnoCore/prebuilt/uno-base.stuff
@@ -2,10 +2,10 @@ if ANDROID {
     "Android": "https://www.nuget.org/api/v2/package/uno-base-android-static-armv7/0.8.730",
 }
 if IOS {
-    "iOS": "https://files.fusetools.com/tooling/PzOS0jxo8U5Q-uno-base-0.8.730-iOS.zip"
+    "iOS": "https://www.nuget.org/api/v2/package/uno-base-iOS-static/0.8.730"
 }
 if OSX {
-    "OSX": "https://files.fusetools.com/tooling/vFhFA3cAEUOi-uno-base-0.8.730-OSX.zip"
+    "OSX": "https://www.nuget.org/api/v2/package/uno-base-macOS-static/0.8.730"
 }
 if WIN32 {
     "Win32": "https://www.nuget.org/api/v2/package/uno-base-vc141-static-x64/0.8.730"


### PR DESCRIPTION
It looks like all dependencies hosted on files.fusetools.com are no longer available, effectively breaking all versions of Fuse and Fuse Studio ever released. Hopefully they will come back again soon...

Dependencies are now repackaged and hosted on nuget.org to get things up and running again and to avoid problems with files.fusetools.com in the future.