### PR TITLE
UnoDoc: always support linking

### DIFF
--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/UnoDocBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/UnoDocBackend.cs
@@ -17,7 +17,7 @@ namespace Uno.Compiler.Backends.UnoDoc
 
         public override bool CanLink(Function f)
         {
-            return f.IsExtern;
+            return true;
         }
 
         public override BackendResult Build()


### PR DESCRIPTION
Without this, we'll fail generating the reference documentation, because
we have some API that only have C++ API (the corresponding .NET API is
provided by different, API-compatible means).