### PR TITLE
remove unused C# references

### DIFF
--- a/lib/UnoCore/Backends/CSharp/Uno/ApplicationContext.cs
+++ b/lib/UnoCore/Backends/CSharp/Uno/ApplicationContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using OpenGL;
 using Uno.Diagnostics;
 using Uno.Graphics;

--- a/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
+++ b/src/compiler/Uno.Compiler.Backends.PInvoke/Uno.Compiler.Backends.PInvoke.csproj
@@ -48,10 +48,6 @@
       <Project>{D159DC86-F510-4FCF-9573-E339BDD6D166}</Project>
       <Name>Uno.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\engine\Uno.ProjectFormat\Uno.ProjectFormat.csproj">
-      <Project>{6C4066B0-F7EA-41B1-B103-0A4F1C3A77D5}</Project>
-      <Name>Uno.ProjectFormat</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Uno.Compiler.Backends.PInvoke.nuspec" />

--- a/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
+++ b/src/compiler/Uno.Compiler.Backends.UnoDoc/Uno.Compiler.Backends.UnoDoc.csproj
@@ -40,8 +40,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
@@ -146,10 +144,6 @@
     <ProjectReference Include="..\..\common\Uno.Common\Uno.Common.csproj">
       <Project>{D159DC86-F510-4FCF-9573-E339BDD6D166}</Project>
       <Name>Uno.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Uno.Compiler.Frontend\Uno.Compiler.Frontend.csproj">
-      <Project>{660301A9-D14E-48C0-A757-2DBD2D4D0E3F}</Project>
-      <Name>Uno.Compiler.Frontend</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
+++ b/src/compiler/Uno.Compiler.Extensions/Uno.Compiler.Extensions.csproj
@@ -77,10 +77,6 @@
       <Project>{9e0318a1-528e-4afd-ab87-c8d58e0cd060}</Project>
       <Name>Uno.Compiler.Backends.CPlusPlus</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Uno.Compiler.Core\Uno.Compiler.Core.csproj">
-      <Project>{c4cf7639-0705-4093-b16d-3261a92f6260}</Project>
-      <Name>Uno.Compiler.Core</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
+++ b/src/engine/Uno.Build.Targets/Uno.Build.Targets.csproj
@@ -108,10 +108,6 @@
       <Project>{660301A9-D14E-48C0-A757-2DBD2D4D0E3F}</Project>
       <Name>Uno.Compiler.Frontend</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Uno.ProjectFormat\Uno.ProjectFormat.csproj">
-      <Project>{6C4066B0-F7EA-41B1-B103-0A4F1C3A77D5}</Project>
-      <Name>Uno.ProjectFormat</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Uno.Build\Uno.Build.csproj">
       <Project>{EE7B3E9E-C1AF-41A1-8B71-42213DAB19F4}</Project>
       <Name>Uno.Build</Name>

--- a/src/engine/Uno.Build/Uno.Build.csproj
+++ b/src/engine/Uno.Build/Uno.Build.csproj
@@ -64,8 +64,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>

--- a/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
+++ b/src/engine/Uno.ProjectFormat/Uno.ProjectFormat.csproj
@@ -39,13 +39,8 @@
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>

--- a/src/main/Uno.CLI.Main/Uno.CLI.Main.csproj
+++ b/src/main/Uno.CLI.Main/Uno.CLI.Main.csproj
@@ -35,10 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/src/runtime/Uno.Runtime.Core/Uno/ApplicationContext.cs
+++ b/src/runtime/Uno.Runtime.Core/Uno/ApplicationContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using OpenGL;
 using Uno.Diagnostics;
 using Uno.Graphics;

--- a/src/testing/Uno.CompilerTestRunner/Uno.CompilerTestRunner.csproj
+++ b/src/testing/Uno.CompilerTestRunner/Uno.CompilerTestRunner.csproj
@@ -40,7 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
     <Compile Include="ErrorItem.cs" />
     <Compile Include="ErrorItemComparer.cs" />
@@ -52,10 +52,6 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\compiler\Uno.Compiler.API\Uno.Compiler.API.csproj">
-      <Project>{B819B724-1A1F-458E-A4AF-4A5BB330C2C4}</Project>
-      <Name>Uno.Compiler.API</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\engine\Uno.Build.Targets\Uno.Build.Targets.csproj">
       <Project>{387C856A-FB1A-4926-BD42-CABFE51485D8}</Project>
       <Name>Uno.Build.Targets</Name>
@@ -67,10 +63,6 @@
     <ProjectReference Include="..\..\engine\Uno.ProjectFormat\Uno.ProjectFormat.csproj">
       <Project>{6C4066B0-F7EA-41B1-B103-0A4F1C3A77D5}</Project>
       <Name>Uno.ProjectFormat</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\engine\Uno.Configuration\Uno.Configuration.csproj">
-      <Project>{95E969AF-23A7-46DE-8EEF-DF1BDDCA55D6}</Project>
-      <Name>Uno.Configuration</Name>
     </ProjectReference>
     <ProjectReference Include="..\Uno.TestRunner.BasicTypes\Uno.TestRunner.BasicTypes.csproj">
       <Project>{1411310F-C68B-43EA-93F0-7E5FEEEE8AE5}</Project>

--- a/src/testing/Uno.TestRunner.BasicTypes/Uno.TestRunner.BasicTypes.csproj
+++ b/src/testing/Uno.TestRunner.BasicTypes/Uno.TestRunner.BasicTypes.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  <Import Project="..\..\GlobalAssemblyInfo.targets" />  
+  <Import Project="..\..\GlobalAssemblyInfo.targets" />
   <ItemGroup>
     <Compile Include="Assertion.cs" />
     <Compile Include="CommandLineOptions.cs" />
@@ -52,10 +52,6 @@
     <ProjectReference Include="..\..\..\src\engine\Uno.Build\Uno.Build.csproj">
       <Project>{ee7b3e9e-c1af-41a1-8b71-42213dab19f4}</Project>
       <Name>Uno.Build</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\engine\Uno.Configuration\Uno.Configuration.csproj">
-      <Project>{95E969AF-23A7-46DE-8EEF-DF1BDDCA55D6}</Project>
-      <Name>Uno.Configuration</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/testing/Uno.TestRunner.Tests/Uno.TestRunner.Tests.csproj
+++ b/src/testing/Uno.TestRunner.Tests/Uno.TestRunner.Tests.csproj
@@ -49,7 +49,6 @@
       <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/src/testing/Uno.TestRunner/Uno.TestRunner.csproj
+++ b/src/testing/Uno.TestRunner/Uno.TestRunner.csproj
@@ -53,10 +53,6 @@
       <Project>{EE7B3E9E-C1AF-41A1-8B71-42213DAB19F4}</Project>
       <Name>Uno.Build</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\src\engine\Uno.Configuration\Uno.Configuration.csproj">
-      <Project>{95E969AF-23A7-46DE-8EEF-DF1BDDCA55D6}</Project>
-      <Name>Uno.Configuration</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\src\engine\Uno.ProjectFormat\Uno.ProjectFormat.csproj">
       <Project>{6C4066B0-F7EA-41B1-B103-0A4F1C3A77D5}</Project>
       <Name>Uno.ProjectFormat</Name>
@@ -64,10 +60,6 @@
     <ProjectReference Include="..\..\..\src\common\Uno.Common\Uno.Common.csproj">
       <Project>{D159DC86-F510-4FCF-9573-E339BDD6D166}</Project>
       <Name>Uno.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\compiler\Uno.Compiler.API\Uno.Compiler.API.csproj">
-      <Project>{B819B724-1A1F-458E-A4AF-4A5BB330C2C4}</Project>
-      <Name>Uno.Compiler.API</Name>
     </ProjectReference>
     <ProjectReference Include="..\Uno.TestRunner.BasicTypes\Uno.TestRunner.BasicTypes.csproj">
       <Project>{1411310F-C68B-43EA-93F0-7E5FEEEE8AE5}</Project>

--- a/src/ux/Uno.UX.Markup.AST/Tests/Helpers/TestHelpers.cs
+++ b/src/ux/Uno.UX.Markup.AST/Tests/Helpers/TestHelpers.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 using System.Xml.Linq;
 using NUnit.Framework;
-using Uno.Compiler.Frontend.Analysis;
 using Uno.UX.Markup.Common;
 
 namespace Uno.UX.Markup.AST.Tests.Helpers

--- a/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
+++ b/src/ux/Uno.UX.Markup.AST/Tests/Uno.UX.Markup.AST.Tests.csproj
@@ -47,10 +47,6 @@
       <Project>{05538951-C4A9-4298-BBA7-FE9F96E3DDC1}</Project>
       <Name>Uno.UX.Markup.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\compiler\Uno.Compiler.Frontend\Uno.Compiler.Frontend.csproj">
-      <Project>{660301A9-D14E-48C0-A757-2DBD2D4D0E3F}</Project>
-      <Name>Uno.Compiler.Frontend</Name>
-    </ProjectReference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
+++ b/src/ux/Uno.UX.Markup.CodeGeneration/Uno.UX.Markup.CodeGeneration.csproj
@@ -60,10 +60,6 @@
       <Project>{C4CF7639-0705-4093-B16D-3261A92F6260}</Project>
       <Name>Uno.Compiler.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\src\compiler\Uno.Compiler.Frontend\Uno.Compiler.Frontend.csproj">
-      <Project>{660301A9-D14E-48C0-A757-2DBD2D4D0E3F}</Project>
-      <Name>Uno.Compiler.Frontend</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Uno.UX.Markup.Common\Uno.UX.Markup.Common.csproj">
       <Project>{05538951-C4A9-4298-BBA7-FE9F96E3DDC1}</Project>
       <Name>Uno.UX.Markup.Common</Name>

--- a/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
+++ b/src/ux/Uno.UX.Markup.CompilerReflection/Uno.UX.Markup.CompilerReflection.csproj
@@ -50,10 +50,6 @@
       <Project>{B819B724-1A1F-458E-A4AF-4A5BB330C2C4}</Project>
       <Name>Uno.Compiler.API</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\src\compiler\Uno.Compiler.Backends.CIL\Uno.Compiler.Backends.CIL.csproj">
-      <Project>{B3B455C8-DD3D-4655-B10C-3C6BE878911E}</Project>
-      <Name>Uno.Compiler.Backends.CIL</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\src\common\Uno.Common\Uno.Common.csproj">
       <Project>{D159DC86-F510-4FCF-9573-E339BDD6D166}</Project>
       <Name>Uno.Common</Name>

--- a/src/ux/Uno.UX.Markup.UXIL/Tests/Uno.UX.Markup.UXIL.Tests.csproj
+++ b/src/ux/Uno.UX.Markup.UXIL/Tests/Uno.UX.Markup.UXIL.Tests.csproj
@@ -42,37 +42,13 @@
       <Project>{1A7E3CC0-8881-4C29-AE67-349226AC7167}</Project>
       <Name>Uno.UX.Markup.UXIL</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Uno.UX.Markup.Reflection\Uno.UX.Markup.Reflection.csproj">
-      <Project>{C28D3D51-8427-4C74-AEDC-AE4CC568F0FC}</Project>
-      <Name>Uno.UX.Markup.Reflection</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Uno.UX.Markup.CompilerReflection\Uno.UX.Markup.CompilerReflection.csproj">
-      <Project>{98F84925-6EA7-4E48-BC35-F5C4730F3D04}</Project>
-      <Name>Uno.UX.Markup.CompilerReflection</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Uno.UX.Markup.Common\Uno.UX.Markup.Common.csproj">
       <Project>{05538951-C4A9-4298-BBA7-FE9F96E3DDC1}</Project>
       <Name>Uno.UX.Markup.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\compiler\Uno.Compiler.Backends.CSharp/Uno.Compiler.Backends.CSharp.csproj">
-      <Project>{90D050F9-B619-4F5F-8CFE-27C2B94CCD1B}</Project>
-      <Name>Uno.Compiler.Backends.CSharp</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\src\common\Uno.Common\Uno.Common.csproj">
       <Project>{D159DC86-F510-4FCF-9573-E339BDD6D166}</Project>
       <Name>Uno.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\compiler\Uno.Compiler.Core\Uno.Compiler.Core.csproj">
-      <Project>{C4CF7639-0705-4093-B16D-3261A92F6260}</Project>
-      <Name>Uno.Compiler.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\compiler\Uno.Compiler.API\Uno.Compiler.API.csproj">
-      <Project>{B819B724-1A1F-458E-A4AF-4A5BB330C2C4}</Project>
-      <Name>Uno.Compiler.API</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\engine\Uno.Build\Uno.Build.csproj">
-      <Project>{EE7B3E9E-C1AF-41A1-8B71-42213DAB19F4}</Project>
-      <Name>Uno.Build</Name>
     </ProjectReference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>


### PR DESCRIPTION
This clean-up removes unnecessary references in C# projects.