### PR TITLE
UnoCore: don't return null in Uno.Text.Ascii

### DIFF
--- a/lib/UnoCore/Source/Uno/Text/Ascii.uno
+++ b/lib/UnoCore/Source/Uno/Text/Ascii.uno
@@ -10,7 +10,7 @@ namespace Uno.Text
                 return Encoding.ASCII.GetBytes(value);
             else
             {
-                if (string.IsNullOrEmpty(value))
+                if (value == null)
                     return null;
 
                 var res = new byte[value.Length];
@@ -27,7 +27,7 @@ namespace Uno.Text
                 return Encoding.ASCII.GetString(value);
             else
             {
-                if (value == null || value.Length == 0)
+                if (value == null)
                     return null;
 
                 var res = string.Empty;

--- a/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
+++ b/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
@@ -36,5 +36,19 @@ namespace Uno.Text.Test
             var result = Ascii.GetBytes("ш");
             Assert.AreEqual(new byte[] { 0x3f }, result);
         }
+
+        [Test]
+        public void AsciiEmptyDecodeTest()
+        {
+            var result = Ascii.GetString(new byte[0]);
+            Assert.AreEqual("", result);
+        }
+
+        [Test]
+        public void AsciiEmptyEncodeTest()
+        {
+            var result = Ascii.GetBytes("");
+            Assert.AreEqual(new byte[0], result);
+        }
     }
 }


### PR DESCRIPTION
Passing empty string/array should return empty array/string.