### PR TITLE
Uno.Compiler: support debug_log with multiple arguments

### DIFF
--- a/lib/UnoCore/Source/Uno/String.uno
+++ b/lib/UnoCore/Source/Uno/String.uno
@@ -468,6 +468,18 @@ namespace Uno
             return r;
         }
 
+        public static string Join(string separator, params object[] value)
+        {
+            var strings = new string[value.Length];
+
+            for (int i = 0; i < value.Length; i++)
+                strings[i] = value[i] != null
+                                ? value[i].ToString()
+                                : null;
+
+            return Join(separator, strings);
+        }
+
         public static string Join(string separator, params string[] value)
         {
             var result = "";


### PR DESCRIPTION
Multiple ARGS are expanded to a call to string.Join(" ", ...ARGS).

    debug_log 1, 2, 3;

... becomes

    1 2 3

... which is useful in cases where you don't want to type

    debug_log 1 + " " + 2 + " " + 3;
