### PR TITLE
Android: add @(Activity.BaseClass) property

### DIFF
--- a/lib/UnoCore/Targets/Android/@(Java.PackageDirectory)/@(Activity.Name).java
+++ b/lib/UnoCore/Targets/Android/@(Java.PackageDirectory)/@(Activity.Name).java
@@ -32,7 +32,7 @@ import com.fuse.Activity.ActivityListener;
 
 @(Activity.File.Declaration:Join())
 
-public class @(Activity.Name) extends android.support.v7.app.AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback
+public class @(Activity.Name) extends @(Activity.BaseClass) implements ActivityCompat.OnRequestPermissionsResultCallback
 {
 #if !@(LIBRARY:Defined)
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -63,6 +63,7 @@
     <Require AndroidManifest.Permission="android.permission.ACCESS_NETWORK_STATE" />
     <Require AndroidManifest.Permission="android.permission.VIBRATE" />
 
+    <Set Activity.BaseClass="android.support.v7.app.AppCompatActivity" />
     <Set Activity.Name="@(Project.Android.Activity || Project.Name:Identifier)" />
     <Set Activity.Package="@(Project.Android.Package || 'com.apps.@(Project.Name:QIdentifier:ToLower)')" />
     <Set APK.BuildName="app/build/outputs/apk/@(APK.Configuration:ToLower)/app-@(APK.Configuration:ToLower).apk" />

--- a/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/UxlProcessor.cs
@@ -429,6 +429,7 @@ namespace Uno.Compiler.Core.Syntax
             if (!map.TryGetValue(key, out old))
                 map.Add(key, value);
             else if (old.Disambiguation != Disambiguation.Override && (
+                        value.Source.Package != old.Source.Package ||
                         value.Disambiguation == Disambiguation.Override ||
                         old.Disambiguation == Disambiguation.Default && value.Disambiguation != Disambiguation.Default ||
                         old.Disambiguation != Disambiguation.Condition && value.Disambiguation == Disambiguation.Condition)


### PR DESCRIPTION
I ran into a situation where I needed to override a method from Activity on Android.

Providing my own base class allows me to do that in a pretty clean way.