### PR TITLE
Android: hardcode ${buildDir}

### DIFF
--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -20,7 +20,7 @@ task extractNativeLibraries() {
         configurations.native_implementation.files.each { f ->
             copy {
                 from zipTree(f)
-                into '${buildDir}/native'
+                into 'build/native'
                 include 'jni/**/*'
             }
         }


### PR DESCRIPTION
We want this value to to match 'build' in https://github.com/fuse-open/uno/blob/master/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt#L19,
but ${buildDir} don't expand to 'build' and instead gives '${buildDir}'...

Maybe something changed with quoting in newer gradle versions or maybe the
variable don't exist anymore, but hardcoding the value fixes the problem.