### PR TITLE
Uno.ProjectFormat: drop legacy HTML properties

### DIFF
--- a/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
+++ b/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
@@ -82,8 +82,6 @@ namespace Uno.ProjectFormat
             {"iOS.LaunchImages.iPad_Portrait_2x", PropertyType.Path},
             {"iOS.LaunchImages.iPad_Landscape_1x", PropertyType.Path},
             {"iOS.LaunchImages.iPad_Landscape_2x", PropertyType.Path},
-            {"HTML.Title", PropertyType.String, "$(Title)"},
-            {"HTML.Favicon", PropertyType.Path, "$(Icon)"},
             {"Package.Authors", PropertyType.String, "$(Publisher)"},
             {"Package.Copyright", PropertyType.String, "$(Copyright)"},
             {"Package.Description", PropertyType.String, "$(Description)"},


### PR DESCRIPTION
These project properties are no longer used since removing the JavaScript
backend and WebGL targets.