### PR TITLE
More Linux support

### DIFF
--- a/lib/UnoCore/Source/Uno/Guid.uno
+++ b/lib/UnoCore/Source/Uno/Guid.uno
@@ -207,6 +207,27 @@ namespace Uno
                               (@{byte})buf[15])};
         @}
 
+        [Require("Source.Include", "uuid/uuid.h")]
+        [Require("LinkLibrary", "uuid")]
+        extern(LINUX)
+        public static Guid NewGuid()
+        @{
+            unsigned char buf[16];
+            uuid_generate_time_safe(buf);
+            return @{Uno.Guid(uint, ushort, ushort, byte, byte, byte, byte, byte, byte, byte, byte):New(
+                              (@{uint})*(uint32_t*)&buf,
+                              (@{ushort})*(uint16_t*)&buf[4],
+                              (@{ushort})*(uint16_t*)&buf[6],
+                              (@{byte})buf[8],
+                              (@{byte})buf[9],
+                              (@{byte})buf[10],
+                              (@{byte})buf[11],
+                              (@{byte})buf[12],
+                              (@{byte})buf[13],
+                              (@{byte})buf[14],
+                              (@{byte})buf[15])};
+        @}
+
         string[] ValidateGuid(string guid)
         {
             var parts = guid.Split('-');

--- a/lib/UnoCore/prebuilt/uno-base.stuff
+++ b/lib/UnoCore/prebuilt/uno-base.stuff
@@ -11,5 +11,5 @@ if WIN32 {
     "Win32": "https://www.nuget.org/api/v2/package/uno-base-vc141-static-x64/0.8.730"
 }
 if LINUX {
-    "Linux": "https://www.nuget.org/api/v2/package/uno-base-linux-static-x86_64/0.8.730"
+    "Linux": "https://www.nuget.org/api/v2/package/uno-base-linux-static-x86_64/0.8.731"
 }


### PR DESCRIPTION
Following up with some more fixes for Linux.

I'm now able to successfully run the full test suite locally, except UXTest which is also crashing on Win32 currently I think, and is ignored on CI.

I tried to add Linux on Travis, but currently we immediately get segfaults when running tests (maybe related to GL?). I guess the next step is to try valgrind and see if we can get a useful stack trace. I will probably look into this more later when I get the chance. My current changes to the travis script are here: https://github.com/mortend/uno/commit/6158a4c106009e9e573a0241e0cbd53d7b01bbab