### PR TITLE
Various UnoCore improvements

### DIFF
--- a/lib/UnoCore/Source/Uno/Rect.uno
+++ b/lib/UnoCore/Source/Uno/Rect.uno
@@ -3,7 +3,7 @@ using Uno.Compiler.ExportTargetInterop;
 namespace Uno
 {
     [extern(DOTNET) DotNetType]
-    public struct Rect // TODO: make immutable?
+    public struct Rect
     {
         public float Left, Top, Right, Bottom;
 

--- a/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLDrawCall.uno
+++ b/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLDrawCall.uno
@@ -208,10 +208,7 @@ namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
         public void Attrib(int index, int componentCount, GLDataType componentType, bool normalized, VertexBuffer buf, int stride, int offset)
         {
             if (buf == null)
-            {
-                // debug_log "WARNING: Vertex attrib buffer was null";
                 return;
-            }
 
             var location = _compiledProgram.GetLocation(index);
 

--- a/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLProgram.uno
+++ b/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLProgram.uno
@@ -78,7 +78,6 @@ namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
             GLCompiledProgram result;
             if (!_cachedPrograms.TryGetValue(key, out result))
             {
-                //debug_log "Compiling shader with " + constStrings.Length + " runtime constants '" + key + "'";
                 result = GetCompiledProgramInternal(constStrings);
                 _cachedPrograms.Add(key, result);
             }

--- a/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLProgram.uno
+++ b/lib/UnoCore/Source/Uno/Runtime/Implementation/ShaderBackends/OpenGL/GLProgram.uno
@@ -1,6 +1,7 @@
 using OpenGL;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Collections;
+using Uno.Text;
 
 namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
 {
@@ -38,18 +39,19 @@ namespace Uno.Runtime.Implementation.ShaderBackends.OpenGL
         GLCompiledProgram GetCompiledProgramInternal(string[] constStrings)
         {
             var vsPrefix = "#ifdef GL_ES\nprecision highp float;\n#endif\n";
-            var fsPrefix = "#ifdef GL_ES\n#extension GL_OES_standard_derivatives : enable\n";
+            var fsPrefix = new StringBuilder("#ifdef GL_ES\n#extension GL_OES_standard_derivatives : enable\n");
 
             if defined(ANDROID)
-                fsPrefix += "#extension GL_OES_EGL_image_external : enable\n";  // extension directive must occur before precision specifier
+                fsPrefix.Append("#extension GL_OES_EGL_image_external : enable\n");  // extension directive must occur before precision specifier
 
-            fsPrefix += "# ifdef GL_FRAGMENT_PRECISION_HIGH\nprecision highp float;\n# else\nprecision mediump float;\n# endif\n#endif\n";
+            fsPrefix.Append("# ifdef GL_FRAGMENT_PRECISION_HIGH\nprecision highp float;\n# else\nprecision mediump float;\n# endif\n#endif\n");
 
-            // TODO: StringBuilder
-            var defines = "";
+            var definesBuilder = new StringBuilder();
 
             for (int i = 0; i < constStrings.Length; i++)
-                defines += "#define " + _constAttribAndUniformNames[i] + " " + constStrings[i] + "\n";
+                definesBuilder.Append("#define " + _constAttribAndUniformNames[i] + " " + constStrings[i] + "\n");
+
+            var defines = definesBuilder.ToString();
 
             return new GLCompiledProgram(vsPrefix + defines + _vsSource,
                                          fsPrefix + defines + _fsSource,

--- a/lib/UnoCore/Source/Uno/Text/Ascii.uno
+++ b/lib/UnoCore/Source/Uno/Text/Ascii.uno
@@ -13,11 +13,14 @@ namespace Uno.Text
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                var res = new byte[value.Length];
-                for (var i = 0; i < value.Length; i++)
-                    res[i] = (byte)(value[i] < 128 ? value[i] : '?');
+                @{
+                    uArray* res = uArray::New(@{byte[]:TypeOf}, value->_length);
 
-                return res;
+                    for (size_t i = 0; i < value->_length; i++)
+                        res->Unsafe<uint8_t>(i) = (uint8_t)(value->_ptr[i] < 128 ? value->_ptr[i] : '?');
+
+                    return res;
+                @}
             }
         }
 
@@ -30,11 +33,14 @@ namespace Uno.Text
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                var res = string.Empty;
-                for (var i = 0; i < value.Length; i++)
-                    res += value[i] < 128 ? (char)value[i] : '?';
+                @{
+                    uString* res = uString::New(value->_length);
+                    
+                    for (size_t i = 0; i < value->_length; i++)
+                        res->_ptr[i] = value->Unsafe<uint8_t>(i) < 128 ? value->Unsafe<uint8_t>(i) : '?';
 
-                return res;
+                    return res;
+                @}
             }
         }
     }

--- a/lib/UnoCore/Source/Uno/Text/Ascii.uno
+++ b/lib/UnoCore/Source/Uno/Text/Ascii.uno
@@ -43,5 +43,29 @@ namespace Uno.Text
                 @}
             }
         }
+
+        public static string GetString(byte[] value, int index, int count)
+        {
+            if defined(DOTNET)
+                return Encoding.ASCII.GetString(value, index, count);
+            else
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+                if (index < 0 || index >= value.Length)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                if (count < 0 || index + count >= value.Length)
+                    throw new ArgumentOutOfRangeException(nameof(count));
+
+                @{
+                    uString* res = uString::New(count);
+                    
+                    for (size_t i = 0; i < count; i++)
+                        res->_ptr[i] = value->Unsafe<uint8_t>(i + index) < 128 ? value->Unsafe<uint8_t>(i + index) : '?';
+
+                    return res;
+                @}
+            }
+        }
     }
 }

--- a/lib/UnoCore/Source/Uno/Text/Ascii.uno
+++ b/lib/UnoCore/Source/Uno/Text/Ascii.uno
@@ -11,7 +11,7 @@ namespace Uno.Text
             else
             {
                 if (value == null)
-                    return null;
+                    throw new ArgumentNullException(nameof(value));
 
                 var res = new byte[value.Length];
                 for (var i = 0; i < value.Length; i++)
@@ -28,7 +28,7 @@ namespace Uno.Text
             else
             {
                 if (value == null)
-                    return null;
+                    throw new ArgumentNullException(nameof(value));
 
                 var res = string.Empty;
                 for (var i = 0; i < value.Length; i++)

--- a/lib/UnoCore/Source/Uno/Text/StringBuilder.uno
+++ b/lib/UnoCore/Source/Uno/Text/StringBuilder.uno
@@ -11,6 +11,15 @@ namespace Uno.Text
 
         public int MaxCapacity { get { return int.MaxValue; }}
 
+        public StringBuilder()
+        {
+        }
+
+        public StringBuilder(string value)
+        {
+            Append(value);
+        }
+
         public override string ToString()
         {
             var c = new char[_totalLength];

--- a/lib/UnoCore/Source/Uno/Text/StringBuilder.uno
+++ b/lib/UnoCore/Source/Uno/Text/StringBuilder.uno
@@ -21,18 +21,31 @@ namespace Uno.Text
         }
 
         public override string ToString()
-        {
-            var c = new char[_totalLength];
-            int x = 0;
-            for (int i = 0; i < _strings.Count; i++)
+        @{
+            uArray* data = @{$$._strings:Get()._data};
+            size_t count = @{$$._strings:Get()._used};
+
+            switch (count)
             {
-                var s = _strings[i];
-                for (var n = 0; n < s.Length; n++)
-                    c[x++] = s[n];
+                case 0:
+                    return @{string.Empty};
+                case 1:
+                    return data->Unsafe<uString*>(0);
             }
 
-            return new string(c);
-        }
+            uString* result = uString::New(@{$$._totalLength});
+            size_t offset = 0;
+
+            for (size_t i = 0; i < count; i++)
+            {
+                uString* s = data->Unsafe<uString*>(i);
+                memcpy(result->_ptr + offset, s->_ptr, s->_length * sizeof(@{char}));
+                offset += s->_length;
+            }
+
+            U_ASSERT(offset == @{$$._totalLength});
+            return result;
+        @}
 
         public int Length { get { return _totalLength; } }
 

--- a/lib/UnoCore/Source/Uno/Text/Utf8.uno
+++ b/lib/UnoCore/Source/Uno/Text/Utf8.uno
@@ -278,6 +278,8 @@ namespace Uno.Text
         public virtual byte[] GetBytes(string s);
         extern(DOTNET)
         public virtual string GetString(byte[] bytes);
+        extern(DOTNET)
+        public virtual string GetString(byte[] bytes, int index, int count);
     }
 
     [extern(DOTNET) DotNetType("System.Text.UTF8Encoding")]

--- a/lib/UnoCore/Source/Uno/Text/Utf8.uno
+++ b/lib/UnoCore/Source/Uno/Text/Utf8.uno
@@ -295,28 +295,54 @@ namespace Uno.Text
     {
         public static byte[] GetBytes(string value)
         {
-            if defined(CPLUSPLUS)
-            @{
-                uCString cstr($0);
-                return uArray::New(@{byte[]:TypeOf}, cstr.Length, cstr.Ptr);
-            @}
-            else if defined(DOTNET)
+            if defined(DOTNET)
                 return Encoding.UTF8.GetBytes(value);
             else
-                build_error;
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                @{
+                    uCString cstr($0);
+                    return uArray::New(@{byte[]:TypeOf}, cstr.Length, cstr.Ptr);
+                @}
+            }
         }
 
         public static string GetString(byte[] value)
         {
-            if defined(CPLUSPLUS)
-            @{
-                const char* utf8 = (const char*)uPtr($0)->Ptr();
-                return uString::Utf8(utf8, $0->Length());
-            @}
-            else if defined(DOTNET)
+            if defined(DOTNET)
                 return Encoding.UTF8.GetString(value);
             else
-                build_error;
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                @{
+                    const char* utf8 = (const char*)uPtr($0)->Ptr();
+                    return uString::Utf8(utf8, $0->Length());
+                @}
+            }
+        }
+
+        public static string GetString(byte[] value, int index, int count)
+        {
+            if defined(DOTNET)
+                return Encoding.UTF8.GetString(value, index, count);
+            else
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+                if (index < 0 || index >= value.Length)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                if (count < 0 || index + count >= value.Length)
+                    throw new ArgumentOutOfRangeException(nameof(count));
+
+                @{
+                    const char* utf8 = (const char*)uPtr($0)->Ptr();
+                    return uString::Utf8(utf8 + index, count);
+                @}
+            }
         }
     }
 }

--- a/lib/UnoCore/Tests/String.Test.uno
+++ b/lib/UnoCore/Tests/String.Test.uno
@@ -766,5 +766,17 @@ namespace Uno.Test
         {
             "abc".IndexOfAny(new char[] {'x'}, 1, 3);
         }
+
+        [Test]
+        public void Join()
+        {
+            Assert.AreEqual(string.Join(" ", new string[0]), "");
+            Assert.AreEqual(string.Join(" ", new[] {"a"}), "a");
+            Assert.AreEqual(string.Join(" ", new[] {"a", "b", "c"}), "a b c");
+            Assert.AreEqual(string.Join(" ", new[] {"a", null, "c"}), "a  c");
+            Assert.AreEqual(string.Join("ab", new[] {"a", "b", "c"}), "aabbabc");
+            Assert.Throws<ArgumentNullException>(() => string.Join("", (object[])null));
+            Assert.Throws<ArgumentNullException>(() => string.Join("", (string[])null));
+        }
     }
 }

--- a/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
+++ b/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
@@ -17,6 +17,13 @@ namespace Uno.Text.Test
         }
 
         [Test]
+        public void AsciiDecodeTest2()
+        {
+            var result = Ascii.GetString(bytes, 1, 2);
+            Assert.AreEqual(chars.Substring(1, 2), result);
+        }
+
+        [Test]
         public void AsciiEncodeTest()
         {
             var result = Ascii.GetBytes(chars);

--- a/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
+++ b/lib/UnoCore/Tests/Text/AsciiEncoding.Test.uno
@@ -50,5 +50,17 @@ namespace Uno.Text.Test
             var result = Ascii.GetBytes("");
             Assert.AreEqual(new byte[0], result);
         }
+
+        [Test]
+        public void AsciiNullDecodeTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => Ascii.GetString(null));
+        }
+
+        [Test]
+        public void AsciiNullEncodeTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => Ascii.GetBytes(null));
+        }
     }
 }

--- a/lib/UnoCore/Tests/Text/Utf8Encoding.Test.uno
+++ b/lib/UnoCore/Tests/Text/Utf8Encoding.Test.uno
@@ -8,11 +8,31 @@ namespace Uno.Text.Test
     {
         byte[] bytes = new byte[] { 0x7e, 0x24, 0x40, 0x26, 0xC2, 0xB1, 0xE0, 0xA5, 0x90, 0xF0, 0x9D, 0x84, 0x9E, 0xF4, 0x8F, 0xBF, 0xBF }; // '~', '$', '@', '&', U+00B1, U+0950, U+01D11E, U+10FFFF
         string chars = "\u007e\u0024\u0040\u0026\u00B1\u0950\uD834\uDD1E\uDBFF\uDFFF"; //~$@&
+
         [Test]
         public void Utf8DecodeTest()
         {
             var result = Utf8.GetString(bytes);
             Assert.AreEqual(chars, result);
+        }
+
+        [Test]
+        public void Utf8DecodeTest2()
+        {
+            var result = Utf8.GetString(bytes, 1, 2);
+            Assert.AreEqual(chars.Substring(1, 2), result);
+        }
+
+        [Test]
+        public void Utf8NullDecodeTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => Utf8.GetString(null));
+        }
+
+        [Test]
+        public void Utf8NullEncodeTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => Utf8.GetBytes(null));
         }
 
         [Test]


### PR DESCRIPTION
Avoid a bunch of string allocations/copies on C++, verify some arguments, and add `GetString(byte[], int, int)` overloads for `Ascii` and `Utf8` to decode a subset of the array.