### PR TITLE
Build for Linux on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,50 @@
-os: osx
-osx_image: xcode9.2
 language: csharp
 mono: latest
 
-env:
-  matrix:
-    - TARGET=dotnet
-    - TARGET=native
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.2
+      env: TARGET=dotnet
+    - os: osx
+      osx_image: xcode9.2
+      env: TARGET=native
+    - os: linux
+      dist: xenial
+      env: TARGET=native
+      addons:
+        apt:
+          sources:
+            # For g++-7
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - g++-7
+            - libsdl2-dev
+            - libglew-dev
+            - uuid-dev
+      services:
+        - xvfb
+      before_script:
+        - export CC=gcc-7
+        - export CXX=g++-7
+        - export GALLIUM_DRIVER=softpipe
+        - export LIBGL_ALWAYS_SOFTWARE=true
 
 before_script:
-  - ulimit -c unlimited -S
-  - rm -rf /cores/core.*
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      ulimit -c unlimited -S
+      rm -rf /cores/core.*
+    fi
 
 script:
   - scripts/build.sh --release
   - scripts/test.sh $TARGET
 
 after_failure:
-  - for c in $(ls /cores/core.*); do
-      lldb -c $c -o "bt all" -b;
-    done
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      for c in $(ls /cores/core.*); do
+        lldb -c $c -o "bt all" -b;
+      done
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         - export CXX=g++-7
         - export GALLIUM_DRIVER=softpipe
         - export LIBGL_ALWAYS_SOFTWARE=true
+        - export UNO_TEST_ARGS=--only-build
 
 before_script:
   - |

--- a/lib/UnoCore/Source/Uno/IO/Directory.uno
+++ b/lib/UnoCore/Source/Uno/IO/Directory.uno
@@ -273,7 +273,7 @@ namespace Uno.IO
             @}
             else if defined(CPLUSPLUS)
             @{
-                chdir(uCString($0).Ptr);
+                (void)chdir(uCString($0).Ptr);
             @}
             else
                 throw new NotImplementedException();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,11 +7,11 @@ source scripts/common.sh
 TARGET=$1
 
 # Run uno tests
-uno test $TARGET lib
+uno test $TARGET lib $UNO_TEST_ARGS
 
 # Skip when testing 'native' on AppVeyor
 if [[ "$APPVEYOR" != True || "$TARGET" != native ]]; then
-    uno test $TARGET tests/src/{Uno,UX}Test
+    uno test $TARGET tests/src/{Uno,UX}Test $UNO_TEST_ARGS
 fi
 
 # Run compiler tests

--- a/src/testing/Uno.CompilerTestRunner/Program.cs
+++ b/src/testing/Uno.CompilerTestRunner/Program.cs
@@ -13,9 +13,9 @@ namespace Uno.CompilerTestRunner
         {
             try
             {
-                var testsPath = string.Format("{0}..{1}..{1}..{1}..{1}..{1}Tests{1}Compiler", AppDomain.CurrentDomain.BaseDirectory, Path.DirectorySeparatorChar);
+                var testsPath = string.Format("{0}..{1}..{1}..{1}..{1}..{1}tests{1}compiler", AppDomain.CurrentDomain.BaseDirectory, Path.DirectorySeparatorChar);
                 if (!Directory.Exists(testsPath))
-                    testsPath = string.Format("{0}..{1}Tests{1}Compiler", AppDomain.CurrentDomain.BaseDirectory, Path.DirectorySeparatorChar);
+                    testsPath = string.Format("{0}..{1}tests{1}compiler", AppDomain.CurrentDomain.BaseDirectory, Path.DirectorySeparatorChar);
 
                 _compilerTestsRunner = new CompilerTestsRunner(testsPath, Filter(args));
                 _compilerTestsRunner.Run(GetLogger(args));

--- a/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
@@ -20,6 +20,7 @@ namespace Uno.TestRunner.BasicTypes
         public string Filter;
         public string Browser;
         public bool Trace;
+        public bool OnlyBuild;
         public bool AllowDebugger;
         public bool OpenDebugger;
         public bool RunLocal;
@@ -56,6 +57,7 @@ namespace Uno.TestRunner.BasicTypes
                 { "o|timeout=", "Timeout for individual tests (in seconds)", (int v) => { commandOptions.TestTimeout = TimeSpan.FromSeconds(v); } },
                 { "startup-timeout=", "Timeout for connection from uno process (in seconds)", (int v) => { commandOptions.StartupTimeout = TimeSpan.FromSeconds(v); } },
                 { "trace", "Print trace information from unotest", v => { commandOptions.Trace = v != null; } },
+                { "only-build", "Don't run compiled program.",  v => commandOptions.OnlyBuild = v != null },
                 { "allow-debugger", "Don't run compiled program, allow user to start it from a debugger.",  v => commandOptions.AllowDebugger = v != null },
                 { "d|debug", "Open IDE for debugging tests.",  v => commandOptions.OpenDebugger = v != null },
                 { "run-local", "Run the test directly, without using HTTP",  v => commandOptions.RunLocal = v != null },

--- a/src/testing/Uno.TestRunner/TestProjectRunner.cs
+++ b/src/testing/Uno.TestRunner/TestProjectRunner.cs
@@ -79,6 +79,8 @@ namespace Uno.TestRunner
                     var result = builder.Build(proj);
                     if (result.ErrorCount != 0)
                         throw new Exception("Build failed.");
+                    if (_options.OnlyBuild)
+                        return tests;
 
                     Log targetLog = null;
                     if (_options.RunLocal)


### PR DESCRIPTION
This makes sure things build on Linux.

Because we get Segmentation Fault on Travis when we run tests, we only build them. Locally, tests run fine though.