### PR TITLE
Don't show window when running tests

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
@@ -24,6 +24,8 @@
 #if WIN32
 #include <Uno/WinAPIHelper.h>
 #include <Shellapi.h>
+#elif LINUX || OSX
+#include <XliPlatform/PlatformSpecific/SDL2.h>
 #endif
 
 #ifdef DEBUG_DUMPS
@@ -52,6 +54,16 @@ struct uMainLoop : Xli::WindowEventHandler
                     : 60;
 
         uBase::Auto<Xli::Window> wnd = Xli::Window::Create(uBase::Vector2i(375, 667), "@(Project.Title)", Xli::WindowFlagsResizeable);
+
+        if (!strcmp(getenv("UNO_WINDOW_HIDDEN"), "1"))
+        {
+#if WIN32
+            ShowWindow((HWND)wnd->GetNativeHandle(), SW_HIDE);
+#elif LINUX || OSX
+            SDL_HideWindow(Xli::PlatformSpecific::SDL2::GetWindowHandle(wnd));
+#endif
+        }
+
         uBase::Auto<Xli::GLContext> gl = Xli::GLContext::Create(wnd, Xli::GLContextAttributes::Default());
 
         // Store global references to wnd and gl
@@ -70,7 +82,7 @@ struct uMainLoop : Xli::WindowEventHandler
         wnd->SetEventHandler(this);
         Xli::Window::ProcessMessages();
         @{Uno.Platform.CoreApp.Start():Call()};
-    
+
         while (!wnd->IsClosed())
         {
             double startTime = @{Uno.Diagnostics.Clock.GetSeconds():Call()};

--- a/src/runtime/Uno.AppLoader-MonoMac/UnoGLView.cs
+++ b/src/runtime/Uno.AppLoader-MonoMac/UnoGLView.cs
@@ -74,9 +74,6 @@ namespace Uno.Support.MonoMac
                 _isInitializedHack = true;
             }
 
-            if (Window == null || !Window.IsVisible)
-                return;
-
             OnPreUpdate();
             if (Uno.Application.Current != null)
                 Bootstrapper.OnUpdate();
@@ -101,6 +98,9 @@ namespace Uno.Support.MonoMac
 
         public void Initialize()
         {
+            if (Environment.GetEnvironmentVariable("UNO_WINDOW_HIDDEN") == "1")
+                Window.IsVisible = false;
+
             _unoWindow.Initialize ();
             OpenGL.GL.Initialize(new MonoMacGL(), !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEBUG_GL")));
             ApplicationContext.Initialize(this);

--- a/src/runtime/Uno.AppLoader-WinForms/MainForm.cs
+++ b/src/runtime/Uno.AppLoader-WinForms/MainForm.cs
@@ -36,6 +36,11 @@ namespace Uno.AppLoader
             Platform2.Internal.Application.Start();
         }
 
+        protected override void SetVisibleCore(bool value)
+        {
+            base.SetVisibleCore(Environment.GetEnvironmentVariable("UNO_WINDOW_HIDDEN") != "1" && value);
+        }
+
         string GetAssemblyTitle()
         {
             return (string) typeof(MainForm).Assembly.CustomAttributes

--- a/src/testing/Uno.TestRunner/TestProjectRunner.cs
+++ b/src/testing/Uno.TestRunner/TestProjectRunner.cs
@@ -82,6 +82,9 @@ namespace Uno.TestRunner
                     if (_options.OnlyBuild)
                         return tests;
 
+                    // We don't need a window when running tests.
+                    Environment.SetEnvironmentVariable("UNO_WINDOW_HIDDEN", "1");
+
                     Log targetLog = null;
                     if (_options.RunLocal)
                     {


### PR DESCRIPTION
Since nothing is shown in the window when running tests it's better to hide
the window in this scenario.