### PR TITLE
Fix regression after #179

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
@@ -55,7 +55,8 @@ struct uMainLoop : Xli::WindowEventHandler
 
         uBase::Auto<Xli::Window> wnd = Xli::Window::Create(uBase::Vector2i(375, 667), "@(Project.Title)", Xli::WindowFlagsResizeable);
 
-        if (!strcmp(getenv("UNO_WINDOW_HIDDEN"), "1"))
+        const char* hidden = getenv("UNO_WINDOW_HIDDEN");
+        if (hidden && !strcmp(hidden, "1"))
         {
 #if WIN32
             ShowWindow((HWND)wnd->GetNativeHandle(), SW_HIDE);

--- a/lib/UnoCore/Source/Uno/IO/Directory.uno
+++ b/lib/UnoCore/Source/Uno/IO/Directory.uno
@@ -273,7 +273,7 @@ namespace Uno.IO
             @}
             else if defined(CPLUSPLUS)
             @{
-                (void)chdir(uCString($0).Ptr);
+                int res = chdir(uCString($0).Ptr);
             @}
             else
                 throw new NotImplementedException();


### PR DESCRIPTION
This fixes a regression after #179. Also fixes a C++ warning again after discovering that casting to void didn't silence the warning.