### PR TITLE
Android: support fat/multi-arch builds

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/Uno/NativeStackTrace.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/NativeStackTrace.cpp
@@ -10,7 +10,7 @@ uArray* uGetNativeStackTrace(int skipFrames)
     return uArray::New(@{Uno.IntPtr[]:TypeOf}, callStackDepth - skipFrames, callStack + skipFrames);
 }
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(ANDROID)
 
 #include <unwind.h>
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -11,6 +11,7 @@
     <Set SourceDirectory="app/src/main/jni" />
     <Set BinaryDirectory="app/src/main/jniLibs" />
     <Set PathSeparator="@(HOST_WIN32:Defined:Test(';', ':'))" />
+    <!-- Deprecated -->
     <Set ABI="${ANDROID_ABI}" />
 
     <!-- Build tools config -->

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -11,7 +11,7 @@
     <Set SourceDirectory="app/src/main/jni" />
     <Set BinaryDirectory="app/src/main/jniLibs" />
     <Set PathSeparator="@(HOST_WIN32:Defined:Test(';', ':'))" />
-    <Set ABI="arm64-v8a" />
+    <Set ABI="${ANDROID_ABI}" />
 
     <!-- Build tools config -->
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -11,7 +11,7 @@
     <Set SourceDirectory="app/src/main/jni" />
     <Set BinaryDirectory="app/src/main/jniLibs" />
     <Set PathSeparator="@(HOST_WIN32:Defined:Test(';', ':'))" />
-    <Set ABI="armeabi-v7a" />
+    <Set ABI="arm64-v8a" />
 
     <!-- Build tools config -->
 

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -49,9 +49,9 @@ android {
         versionName = '@(Project.Android.VersionName)'
         ndk {
 #if @(DEBUG:Defined)
-            abiFilters = ['arm64-v8a']
+            abiFilters = [@(Project.Android.Architectures.Debug:Join(', ', '\'', '\''))]
 #else
-            abiFilters = ['armeabi-v7a', 'arm64-v8a']
+            abiFilters = [@(Project.Android.Architectures.Release:Join(', ', '\'', '\''))]
 #endif
         }
 

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 task copySharedLibraries {
-    @(SharedLibrary:Join('\n    ', 'copy {\n        from \'', '\'\n        into file('src/main/jniLibs/armeabi-v7a')\n    }'))
+    @(SharedLibrary:Join('\n    ', 'copy {\n        from \'', '\'\n        into file('src/main/jniLibs/@(ABI)')\n    }'))
 }
 
 // Extracts native libraries from AARs in the native_implementation configuration.

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -9,10 +9,6 @@ dependencies {
     @(Gradle.Dependency:Join('\n    '))
 }
 
-task copySharedLibraries {
-    @(SharedLibrary:Join('\n    ', 'copy {\n        from \'', '\'\n        into file('src/main/jniLibs/@(ABI)')\n    }'))
-}
-
 // Extracts native libraries from AARs in the native_implementation configuration.
 // This is done so that the NDK can access these libraries.
 task extractNativeLibraries() {
@@ -29,9 +25,6 @@ task extractNativeLibraries() {
 
 tasks.whenTaskAdded {
     task-> if (task.name.contains('external') && !task.name.contains('Clean')) {
-#if @(SharedLibrary:IsRequired)
-        task.dependsOn(copySharedLibraries)
-#endif
 #if @(Gradle.Dependency.NativeImplementation:IsRequired)
         task.dependsOn(extractNativeLibraries)
 #endif

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -48,7 +48,11 @@ android {
         versionCode = @(Project.Android.VersionCode)
         versionName = '@(Project.Android.VersionName)'
         ndk {
-            abiFilters = ['@(ABI)']
+#if @(DEBUG:Defined)
+            abiFilters = ['arm64-v8a']
+#else
+            abiFilters = ['armeabi-v7a', 'arm64-v8a']
+#endif
         }
 
         externalNativeBuild {

--- a/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
@@ -27,3 +27,5 @@ target_link_libraries(@(Activity.Name)
     @(LinkLibrary:Join('\n    ', '"', '"'))
     @(SharedLibrary:Join('\n    ', '"', '"'))
     @(LinkOrderedStaticLibraries:Join('\n    ', '"', '"')))
+
+@(SharedLibrary:Join('\n', 'file(COPY ', ' DESTINATION src/main/jniLibs/@(ABI))'))

--- a/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 # Find libraries extracted from AARs, if applicable.
 #if @(Gradle.Dependency.NativeImplementation:IsRequired)
-link_directories(@(OutputDirectory:Path)/app/build/native/jni/@(ABI))
+link_directories(@(OutputDirectory:Path)/app/build/native/jni/${ANDROID_ABI})
 #endif
 
 add_library(@(Activity.Name) SHARED
@@ -28,4 +28,4 @@ target_link_libraries(@(Activity.Name)
     @(SharedLibrary:Join('\n    ', '"', '"'))
     @(LinkOrderedStaticLibraries:Join('\n    ', '"', '"')))
 
-@(SharedLibrary:Join('\n', 'file(COPY ', ' DESTINATION src/main/jniLibs/@(ABI))'))
+@(SharedLibrary:Join('\n', 'file(COPY ', ' DESTINATION src/main/jniLibs/${ANDROID_ABI})'))

--- a/lib/UnoCore/prebuilt/uno-base-pinvoke.uxl
+++ b/lib/UnoCore/prebuilt/uno-base-pinvoke.uxl
@@ -4,7 +4,7 @@
     <Set Base.Directory="@('iOS':Path)" Condition="IOS" />
     <Set Base.Directory="@('OSX':Path)" Condition="OSX" />
     <Set Base.Directory="@('Win32':Path)" Condition="WIN32" />
-    <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/@(ABI)" Condition="ANDROID" />
+    <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/${ANDROID_ABI}" Condition="ANDROID" />
     <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME" Condition="IOS" />
     <Set Base.LinkDirectory="@(Base.Directory:Path)/lib" />
     <Set Base.IncludeDirectory="@(Base.Directory:Path)/include" />

--- a/lib/UnoCore/prebuilt/uno-base.stuff
+++ b/lib/UnoCore/prebuilt/uno-base.stuff
@@ -1,5 +1,5 @@
 if ANDROID {
-    "Android": "https://www.nuget.org/api/v2/package/uno-base-android-static-armv7/0.8.730",
+    "Android": "https://www.nuget.org/api/v2/package/uno-base-android-static/0.8.730",
 }
 if IOS {
     "iOS": "https://www.nuget.org/api/v2/package/uno-base-iOS-static/0.8.730"

--- a/lib/UnoCore/prebuilt/uno-base.uxl
+++ b/lib/UnoCore/prebuilt/uno-base.uxl
@@ -5,7 +5,7 @@
     <Set Base.Directory="@('OSX':Path)" Condition="OSX" />
     <Set Base.Directory="@('Win32':Path)" Condition="WIN32" />
     <Set Base.Directory="@('Linux':Path)" Condition="LINUX" />
-    <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/@(ABI)" Condition="ANDROID" />
+    <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/${ANDROID_ABI}" Condition="ANDROID" />
     <Set Base.LinkDirectory="@(Base.Directory:Path)/lib/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME" Condition="IOS" />
     <Set Base.LinkDirectory="@(Base.Directory:Path)/lib" />
     <Set Base.IncludeDirectory="@(Base.Directory:Path)/include" />

--- a/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
+++ b/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
@@ -27,6 +27,8 @@ namespace Uno.ProjectFormat
             {"Mobile.RunsInBackground", PropertyType.Bool, true},
             {"Mobile.Orientations", PropertyType.String, Orientations.Auto},
             {"Android.ApplicationLabel", PropertyType.String, "$(Title)"},
+            {"Android.Architectures.Debug", PropertyType.String, "arm64-v8a"},
+            {"Android.Architectures.Release", PropertyType.String, "armeabi-v7a\narm64-v8a"},
             {"Android.VersionCode", PropertyType.Integer, "$(VersionCode)"},
             {"Android.VersionName", PropertyType.String, "$(Version)"},
             {"Android.Package", PropertyType.String},


### PR DESCRIPTION
This enables building any combination of the following architectures.

* `armeabi-v7a`
* `arm64-v8a`
* `x86`
* `x86_64`

Architectures can be specified in the project file, for Debug and Release separately.

    "Android": {
      "Architectures": {
        "Debug": ["arm64-v8a"],
        "Release": ["armeabi-v7a", "arm64-v8a"]
      }
    }

By default we'll build `arm64-v8a` for debug, and `armeabi-v7a` + `arm64-v8a` for release. Building multiple architectures increases build time significantly, so while testing/developing we usually only want to build one.

Related: #154, https://github.com/fuse-open/fuselibs/pull/1274