### PR TITLE
UnoCore: sub-array support in DeviceBuffer

### DIFF
--- a/lib/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
+++ b/lib/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
@@ -75,6 +75,15 @@ namespace Uno.Graphics
 
         public void Update(Array data, int elementSize, int index, int count)
         {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+            if (elementSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(elementSize));
+            if (index < 0 || index >= data.Length)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            if (count < 0 || index + count > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
             CheckDisposed();
 
             if defined(OPENGL)
@@ -99,6 +108,9 @@ namespace Uno.Graphics
 
         public void Update(Array data, int elementSize)
         {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
             Update(data, elementSize, 0, data.Length);
         }
 

--- a/lib/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
+++ b/lib/UnoCore/Source/Uno/Graphics/DeviceBuffer.uno
@@ -73,27 +73,33 @@ namespace Uno.Graphics
             IsDisposed = true;
         }
 
-        public void Update(Array data, int elementSize)
+        public void Update(Array data, int elementSize, int index, int count)
         {
             CheckDisposed();
 
             if defined(OPENGL)
             {
-                var sizeInBytes = data.Length * elementSize;
+                var sizeInBytes = count * elementSize;
                 var pin = GCHandle.Alloc(data, GCHandleType.Pinned);
+                var addr = pin.AddrOfPinnedObject() + index * elementSize;
                 GL.BindBuffer(GLBufferTarget, GLBufferHandle);
 
                 if (sizeInBytes <= SizeInBytes)
-                    GL.BufferSubData(GLBufferTarget, 0, sizeInBytes, pin.AddrOfPinnedObject());
+                    GL.BufferSubData(GLBufferTarget, 0, sizeInBytes, addr);
                 else
                 {
-                    GL.BufferData(GLBufferTarget, sizeInBytes, pin.AddrOfPinnedObject(), GLInterop.ToGLBufferUsage(Usage));
+                    GL.BufferData(GLBufferTarget, sizeInBytes, addr, GLInterop.ToGLBufferUsage(Usage));
                     SizeInBytes = sizeInBytes;
                 }
 
                 GL.BindBuffer(GLBufferTarget, GLBufferHandle.Zero);
                 pin.Free();
             }
+        }
+
+        public void Update(Array data, int elementSize)
+        {
+            Update(data, elementSize, 0, data.Length);
         }
 
         public void Update(byte[] data)

--- a/lib/UnoCore/Source/Uno/Text/Ascii.uno
+++ b/lib/UnoCore/Source/Uno/Text/Ascii.uno
@@ -54,7 +54,7 @@ namespace Uno.Text
                     throw new ArgumentNullException(nameof(value));
                 if (index < 0 || index >= value.Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                if (count < 0 || index + count >= value.Length)
+                if (count < 0 || index + count > value.Length)
                     throw new ArgumentOutOfRangeException(nameof(count));
 
                 @{

--- a/lib/UnoCore/Source/Uno/Text/Utf8.uno
+++ b/lib/UnoCore/Source/Uno/Text/Utf8.uno
@@ -335,7 +335,7 @@ namespace Uno.Text
                     throw new ArgumentNullException(nameof(value));
                 if (index < 0 || index >= value.Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                if (count < 0 || index + count >= value.Length)
+                if (count < 0 || index + count > value.Length)
                     throw new ArgumentOutOfRangeException(nameof(count));
 
                 @{


### PR DESCRIPTION
This adds a method to upload a sub-array to `DeviceBuffer`.

While at it I added input validation which also led me to fix bugs I discovered in code recently added to `Uno.Text.{Ascii,Utf8}`.

