### PR TITLE
Android: use response file

### DIFF
--- a/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
+++ b/lib/UnoCore/Targets/Android/app/src/main/CMakeLists.txt
@@ -14,6 +14,13 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -s")
 endif()
 
+# Using response file as workaround for long paths on Windows.
+set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+set(CMAKE_C_RESPONSE_FILE_LINK_FLAG "@")
+set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
+set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
+
 # Find libraries extracted from AARs, if applicable.
 #if @(Gradle.Dependency.NativeImplementation:IsRequired)
 link_directories(@(OutputDirectory:Path)/app/build/native/jni/${ANDROID_ABI})

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
@@ -72,10 +72,6 @@ namespace Uno.Compiler.Backends.CPlusPlus
             EnableStackTrace = Environment.IsDefined("STACKTRACE") || Environment.IsDefined("CPPSTACKTRACE");
             HeaderDirectory = Environment.GetOutputPath("HeaderDirectory");
             SourceDirectory = Environment.GetOutputPath("SourceDirectory");
-
-            // On Android, truncate lengths of filenames to avoid problem with Gradle on Windows.
-            if (Environment.IsDefined("ANDROID"))
-                MaxExportNameLength = 30;
         }
 
         public override bool CanLink(Function f)


### PR DESCRIPTION
This will use a response file to pass arguments to linker, instead of the command-line, and enables us to use normal-length filenames on Android again. Because we now completely avoid the "command too long" issue on Windows.