### PR TITLE
Native: always use Xcode on macOS

### DIFF
--- a/lib/UnoCore/Targets/Native/build.sh
+++ b/lib/UnoCore/Targets/Native/build.sh
@@ -9,17 +9,15 @@ if ! which @(CMake) > /dev/null 2>&1; then
     exit 1
 fi
 
+#if @(MAC:Defined)
+@(CMake) -GXcode "$@" .
+xcodebuild -configuration @(Native.Configuration)
+#else
+@(CMake) -DCMAKE_BUILD_TYPE=@(Native.Configuration) "$@" .
+
 if [ -f /proc/cpuinfo ]; then
     BUILD_ARGS=-j`grep processor /proc/cpuinfo | wc -l`
-elif [ "`uname`" = "Darwin" ]; then
-    BUILD_ARGS=-j`sysctl hw.ncpu | cut -d " " -f 2`
-elif [ -n "$NUMBER_OF_PROCESSORS" ]; then
-    BUILD_ARGS=-j$NUMBER_OF_PROCESSORS
 fi
 
-# CMake fails if previously run using a different generator (Xcode).
-# We can avoid that by deleting the cache.
-rm -f CMakeCache.txt
-
-@(CMake) -DCMAKE_BUILD_TYPE=@(Native.Configuration) "$@" .
-@(CMake) --build . --use-stderr -- $BUILD_ARGS
+make -s $BUILD_ARGS
+#endif

--- a/lib/UnoCore/Targets/Native/run.sh
+++ b/lib/UnoCore/Targets/Native/run.sh
@@ -7,11 +7,15 @@ cd "`dirname "$0"`"
 case $1 in
 debug)
     shift
-    rm -f CMakeCache.txt
+#if @(MAC:Defined)
     @(CMake) -GXcode "$@" .
     echo "Opening Xcode"
     open -aXcode "@(Project.Name).xcodeproj"
     exit $?
+#else
+    echo "Debugging is not supported on this platform." >&2
+    exit 1
+#endif
     ;;
 valgrind)
     shift


### PR DESCRIPTION
Now we don't need to delete the CMake cache due to switching generators,
which speeds up subsequent builds.

Also, don't try to launch Xcode if passing --debug on Linux.