### PR TITLE
FuseJS: fix transpiled path

### DIFF
--- a/src/engine/Uno.Build/Packages/PackageCache.cs
+++ b/src/engine/Uno.Build/Packages/PackageCache.cs
@@ -178,7 +178,7 @@ namespace Uno.Build.Packages
                     continue;
 
                 var name = f.NativePath;
-                var nameWithoutExt = Path.GetFileNameWithoutExtension(name);
+                var nameWithoutExt = Path.ChangeExtension(name, null);
                 var inputFile = Path.Combine(project.RootDirectory, name);
                 var outputFile = Path.Combine(project.RootDirectory, ".uno", "fusejs", nameWithoutExt + ".js");
 


### PR DESCRIPTION
GetFileNameWithoutExtension() strips directory components which gives us a
problem when transpiling files contained in a sub-directory.

Using ChangeExtension() instead fixes the problem.