### PR TITLE
Uno.UX.Markup: add ux:Simulate attribute

### DIFF
--- a/src/ux/Uno.UX.Markup.AST/Generator.cs
+++ b/src/ux/Uno.UX.Markup.AST/Generator.cs
@@ -74,12 +74,14 @@ namespace Uno.UX.Markup.AST
     {
         public bool IsInnerClass { get; private set; }
         public bool AutoCtor { get; private set; }
+        public bool Simulate { get; private set; }
         public string ClassName { get; private set; }
 
-        internal ClassGenerator(bool isInnerClass, string className, bool autoCtor)
+        internal ClassGenerator(bool isInnerClass, string className, bool autoCtor, bool simulate)
         {
             IsInnerClass = isInnerClass;
             AutoCtor = autoCtor;
+            Simulate = simulate;
             ClassName = className;
         }
     }

--- a/src/ux/Uno.UX.Markup.AST/Parser.cs
+++ b/src/ux/Uno.UX.Markup.AST/Parser.cs
@@ -8,7 +8,6 @@ using Uno.UX.Markup.Common;
 
 namespace Uno.UX.Markup.AST
 {
-
     public class Parser
     {
         static Element Parse(string projName, string p, out XDocument xdoc, Common.IMarkupErrorLog log)
@@ -42,7 +41,6 @@ namespace Uno.UX.Markup.AST
 
             return parser.ParseRoot(parser._doc.Root);
         }
-
 
         readonly string _projectName;
         readonly string _filePath;
@@ -175,7 +173,6 @@ namespace Uno.UX.Markup.AST
                 }
             }
 
-            
             var uxDependency = GetUXAttrib(elm, UxAttribute.Dependency, null);
             var uxTemplate = GetUXAttrib(elm, UxAttribute.Template, null);
             var uxName = GetUXAttrib(elm, UxAttribute.Name, null);
@@ -183,7 +180,6 @@ namespace Uno.UX.Markup.AST
             var uxValue = GetUXAttrib(elm, UxAttribute.Value, null);
             var uxKey = GetUXAttrib(elm, UxAttribute.Key, null);
             var binding = GetUXAttrib(elm, UxAttribute.Binding, null);
-            
 
             if (uxDependency != null && uxName != null)
                 ReportError(elm, "Cannot specify both ux:Dependency and ux:Name");
@@ -232,12 +228,10 @@ namespace Uno.UX.Markup.AST
                 .Select(x => new Property(x.Name.LocalName, x.Value, source, x.Name.NamespaceName))
                 .ToArray();
 
-
             var uxPath = GetUXAttrib(elm, UxAttribute.Path, null);
             var clearColor = GetUXAttrib(elm, UxAttribute.ClearColor, null);
             var children = elm.Nodes().Select(Parse).Where(x => x != null).ToArray();
             var condition = GetUXAttrib(elm, UxAttribute.Condition, null);
-
 
             if (uxProperty != null)
             {
@@ -258,8 +252,6 @@ namespace Uno.UX.Markup.AST
                     ReportError(elm, "Nodes marked with ux:Property can not specify ux:Binding, because they don't represent objects.");
                 }
             }
-
-            
 
             ReportErrorOnUnvisitedUXAttribs(elm);
 

--- a/src/ux/Uno.UX.Markup.AST/Parser.cs
+++ b/src/ux/Uno.UX.Markup.AST/Parser.cs
@@ -166,7 +166,7 @@ namespace Uno.UX.Markup.AST
                 {
                     typeName = "object";
                     ns = Configuration.DefaultNamespace;
-                    generator = new ClassGenerator(false, _projectName.ToIdentifier() + "_" + System.IO.Path.GetFileNameWithoutExtension(_filePath).ToIdentifier() + "_res", true);
+                    generator = new ClassGenerator(false, _projectName.ToIdentifier() + "_" + System.IO.Path.GetFileNameWithoutExtension(_filePath).ToIdentifier() + "_res", true, true);
                 }
                 else
                 {
@@ -323,6 +323,14 @@ namespace Uno.UX.Markup.AST
                 ReportError(elm, "Unable to parse 'ux:AutoCtor', must be 'true' or 'false'.");
             }
 
+            bool simulate = true;
+            var simulateString = GetUXAttrib(elm, UxAttribute.Simulate, "true");
+
+            if (simulateString != null && !bool.TryParse(simulateString, out simulate))
+            {
+                ReportError(elm, "Unable to parse 'ux:Simulate', must be 'true' or 'false'.");
+            }
+
             bool isInnerClass = false;
             var className = GetUXAttrib(elm, UxAttribute.ClassName, null);
             
@@ -414,7 +422,7 @@ namespace Uno.UX.Markup.AST
 
             if (className != null)
             {
-                return new ClassGenerator(isInnerClass, className, autoCtor);
+                return new ClassGenerator(isInnerClass, className, autoCtor, simulate);
             }
 
             if (elm == _doc.Root)
@@ -422,7 +430,7 @@ namespace Uno.UX.Markup.AST
                 if (elm.Name.LocalName == "App" ||
                     elm.Name.LocalName == "ExportedViews")
                 {
-                    return new ClassGenerator(isInnerClass, Path.GetFileNameWithoutExtension(_filePath), autoCtor);
+                    return new ClassGenerator(isInnerClass, Path.GetFileNameWithoutExtension(_filePath), autoCtor, simulate);
                 }
             }
 

--- a/src/ux/Uno.UX.Markup.Common/Attributes.cs
+++ b/src/ux/Uno.UX.Markup.Common/Attributes.cs
@@ -34,6 +34,7 @@ namespace Uno.UX.Markup.Common
         Template,
         Test,
         Value,
+        Simulate // Set to false to disable simulator for this class
     }
 
     public static class Attributes

--- a/src/ux/Uno.UX.Markup.UXIL/ClassNode.IDataType.cs
+++ b/src/ux/Uno.UX.Markup.UXIL/ClassNode.IDataType.cs
@@ -50,6 +50,8 @@ namespace Uno.UX.Markup.UXIL
 
         public string FullName => GeneratedClassName.FullName;
 
+        public override string ToString() => GeneratedClassName.FullName;
+
         public IEnumerable<IProperty> PrecompiledProperties => BaseType is ClassNode ? (BaseType as ClassNode).PrecompiledProperties : BaseType.Properties;
 
         IEnumerable<IProperty> IDataType.Properties =>

--- a/src/ux/Uno.UX.Markup.UXIL/ClassNode.cs
+++ b/src/ux/Uno.UX.Markup.UXIL/ClassNode.cs
@@ -11,6 +11,8 @@ namespace Uno.UX.Markup.UXIL
 
         public bool AutoCtor { get; private set; }
 
+        public bool Simulate { get; private set; }
+
         public bool IsTest { get; }
 
         public bool IsAppClass
@@ -18,11 +20,12 @@ namespace Uno.UX.Markup.UXIL
             get { return ActualIDataTypeImpl.FullName == "Fuse.App" || ActualIDataTypeImpl.FullName == "Fuse.ExportedViews"; }
         }
 
-        internal ClassNode(FileSourceInfo source, bool isInnerClass, string name, IDataType baseType, TypeNameHelper generatedClassName, Vector<float> clearColor, bool autoCtor, bool isTest, IEnumerable<RawProperty> rawProperties)
+        internal ClassNode(FileSourceInfo source, bool isInnerClass, string name, IDataType baseType, TypeNameHelper generatedClassName, Vector<float> clearColor, bool autoCtor, bool simulate, bool isTest, IEnumerable<RawProperty> rawProperties)
             : base(source, name, generatedClassName, baseType, clearColor, InstanceType.None, rawProperties)
         {
             IsInnerClass = isInnerClass;
             AutoCtor = autoCtor;
+            Simulate = simulate;
             IsTest = isTest;
             BaseType = baseType;
         }

--- a/src/ux/Uno.UX.Markup.UXIL/Compiler.cs
+++ b/src/ux/Uno.UX.Markup.UXIL/Compiler.cs
@@ -1202,7 +1202,7 @@ namespace Uno.UX.Markup.UXIL
             {
                 var cg = (AST.ClassGenerator)generator;
                 var name = e.UXName ?? "this";
-                var cl = new UXIL.ClassNode(e.Source, cg.IsInnerClass, name, dt, new TypeNameHelper(cg.ClassName), clearColor, cg.AutoCtor, false, rawProperties);
+                var cl = new UXIL.ClassNode(e.Source, cg.IsInnerClass, name, dt, new TypeNameHelper(cg.ClassName), clearColor, cg.AutoCtor, cg.Simulate, false, rawProperties);
 
                 if (!isInnerClass)
                     _rootClasses.Add(cl);
@@ -1221,7 +1221,7 @@ namespace Uno.UX.Markup.UXIL
 
                 var testClassName = new TypeNameHelper(tg.TestName);
 
-                var testClass = new UXIL.ClassNode(e.Source, false, "this", testBootstrapper, testClassName, clearColor, true, true, rawProperties);
+                var testClass = new UXIL.ClassNode(e.Source, false, "this", testBootstrapper, testClassName, clearColor, true, true, true, rawProperties);
                 _rootClasses.Add(testClass);
                 _nodes.Add(testClassName, testClass);
 

--- a/src/ux/Uno.UX.Markup.UXIL/Compiler.cs
+++ b/src/ux/Uno.UX.Markup.UXIL/Compiler.cs
@@ -36,9 +36,9 @@ namespace Uno.UX.Markup.UXIL
 
     public class Document
     {
-        public IEnumerable<Node> NodesInDocumentOrder { get; }
+        public List<Node> NodesInDocumentOrder { get; }
 
-        internal Document(IEnumerable<Node> nodesInDocumentOrder)
+        internal Document(List<Node> nodesInDocumentOrder)
         {
             NodesInDocumentOrder = nodesInDocumentOrder;
         }
@@ -47,7 +47,7 @@ namespace Uno.UX.Markup.UXIL
     public class Project
     {
         public Dictionary<string, Document> Documents { get; private set; }
-        public IEnumerable<ClassNode> RootClasses { get; private set; }
+        public List<ClassNode> RootClasses { get; private set; }
 
         public string ProjectName { get; private set; }
         public string GeneratedPath { get; private set; }
@@ -59,7 +59,7 @@ namespace Uno.UX.Markup.UXIL
 
         internal Project(string projectName, string generatedPath, 
             Dictionary<string, Document> documents,
-            IEnumerable<ClassNode> rootClasses, 
+            List<ClassNode> rootClasses, 
             IEnumerable<UXPropertyAccessorSource> uxPropertyAccessors,
             IEnumerable<UXPropertyClass> uxProperties,
             IEnumerable<KeyValuePair<string, List<Node>>> globalResources)
@@ -157,7 +157,7 @@ namespace Uno.UX.Markup.UXIL
                     .DescendantNodesAndSelf()
                     .OfType<AST.Element>()
                     .Select(astNode => comp._astNodeToNode[astNode])
-                    .ToArray();
+                    .ToList();
 
                 return new Document(nodesInDocumentOrder);
             });


### PR DESCRIPTION
UX classes with Uno code-behinds don't work properly in the simulator. To
solve this, we can set this attribute to false to disable bytecode generating
and always instantiate the precompiled Uno class instead.