### PR TITLE
Uno.ProjectFormat: automatically add .TS files as FuseJS

### DIFF
--- a/src/engine/Uno.ProjectFormat/IncludeGlobber.cs
+++ b/src/engine/Uno.ProjectFormat/IncludeGlobber.cs
@@ -308,6 +308,8 @@ namespace Uno.ProjectFormat
                     return IncludeItemType.Extensions;
                 case ".STUFF":
                     return IncludeItemType.Stuff;
+                case ".TS":
+                    return IncludeItemType.FuseJS;
                 default:
                     return IncludeItemType.File;
             }


### PR DESCRIPTION
Projects will now transpile TypeScript files by default without having to
edit "*.ts:FuseJS" into the project file first, and this is convenient for
most/all users.

Note that we don't automatically add JavaScript files because transpiling
only applies to scripts that use the new Models API, so we don't know if
a JavaScript file should be transpiled or not. This is not a problem for
TypeScript files, who very likely always need to be transpiled.