### PR TITLE
FuseJS.Transpiler: upgrade lodash

### DIFF
--- a/lib/FuseJS.Transpiler/src/package-lock.json
+++ b/lib/FuseJS.Transpiler/src/package-lock.json
@@ -2645,9 +2645,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.memoize": {
       "version": "3.0.4",


### PR DESCRIPTION
In #203 we ran `npm audit fix` to replace vulnerable packages, but GitHub still displays the security alert.

This PR is a second attempt to silence the alert by explicitly upgrading `lodash`.