### PR TITLE
pack.sh: support building outside of Git

### DIFF
--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -10,13 +10,16 @@ rm -rf ${DST:?}/* 2> /dev/null || :
 mkdir -p $DST
 
 # Detect version info
-COMMIT=`git rev-parse HEAD`
+COMMIT=`git rev-parse HEAD 2> /dev/null || :`
 VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]'`
 
 if [ -n "$APPVEYOR_REPO_BRANCH" ]; then
     BRANCH=$APPVEYOR_REPO_BRANCH
-else
+elif [ -n "$COMMIT" ]; then
     BRANCH=`git rev-parse --abbrev-ref HEAD`
+else
+    BRANCH="unknown"
+    COMMIT="unknown"
 fi
 
 if [ -n "$APPVEYOR_BUILD_NUMBER" ]; then


### PR DESCRIPTION
Don't terminate the script if a git command fails.

This fixes building .tar.gz files downloaded from GitHub, reported broken in
https://forums.fusetools.com/t/unable-to-compile-uno-fatal-not-a-git-repository/7817/1