### PR TITLE
Uno.Configuration: expand ~ to HomeDirectory

### DIFF
--- a/src/common/Uno.Common/Diagnostics/PlatformDetection.cs
+++ b/src/common/Uno.Common/Diagnostics/PlatformDetection.cs
@@ -17,6 +17,59 @@ namespace Uno.Diagnostics
         public static readonly bool IsArm;
         public static readonly bool Is64Bit;
 
+        public static string HomeDirectory
+        {
+            get
+            {
+                var home = Environment.GetEnvironmentVariable("HOME");
+                if (!string.IsNullOrEmpty(home))
+                    return home;
+
+                if (IsWindows)
+                {
+                    var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+                    if (!string.IsNullOrEmpty(userProfile))
+                        return userProfile;
+
+                    var homePath = Environment.GetEnvironmentVariable("HOMEDRIVE") +
+                                   Environment.GetEnvironmentVariable("HOMEPATH");
+                    if (!string.IsNullOrEmpty(homePath))
+                        return homePath;
+
+                    goto THROW;
+                }
+
+                var user = Environment.GetEnvironmentVariable("LOGNAME");
+                if (string.IsNullOrEmpty(user))
+                    user = Environment.GetEnvironmentVariable("USER");
+                if (string.IsNullOrEmpty(user))
+                    user = Environment.GetEnvironmentVariable("LNAME");
+                if (string.IsNullOrEmpty(user))
+                    user = Environment.GetEnvironmentVariable("USERNAME");
+
+                if (IsMac)
+                {
+                    if (!string.IsNullOrEmpty(user))
+                        return "/Users/" + user;
+
+                    goto THROW;
+                }
+
+                if (IsLinux)
+                {
+                    // FIXME:
+                    // if (process.getuid() == 0)
+                    //     return "/root";
+
+                    if (!string.IsNullOrEmpty(user))
+                        return "/home/" + user;
+                }
+
+                THROW:
+                throw new NotSupportedException("Your home directory was not found");
+            }
+        }
+
         public static string SystemString
         {
             get

--- a/src/common/Uno.Common/Diagnostics/PlatformDetection.cs
+++ b/src/common/Uno.Common/Diagnostics/PlatformDetection.cs
@@ -35,37 +35,8 @@ namespace Uno.Diagnostics
                                    Environment.GetEnvironmentVariable("HOMEPATH");
                     if (!string.IsNullOrEmpty(homePath))
                         return homePath;
-
-                    goto THROW;
                 }
 
-                var user = Environment.GetEnvironmentVariable("LOGNAME");
-                if (string.IsNullOrEmpty(user))
-                    user = Environment.GetEnvironmentVariable("USER");
-                if (string.IsNullOrEmpty(user))
-                    user = Environment.GetEnvironmentVariable("LNAME");
-                if (string.IsNullOrEmpty(user))
-                    user = Environment.GetEnvironmentVariable("USERNAME");
-
-                if (IsMac)
-                {
-                    if (!string.IsNullOrEmpty(user))
-                        return "/Users/" + user;
-
-                    goto THROW;
-                }
-
-                if (IsLinux)
-                {
-                    // FIXME:
-                    // if (process.getuid() == 0)
-                    //     return "/root";
-
-                    if (!string.IsNullOrEmpty(user))
-                        return "/home/" + user;
-                }
-
-                THROW:
                 throw new NotSupportedException("Your home directory was not found");
             }
         }

--- a/src/engine/Uno.Configuration/Format/StuffFile.cs
+++ b/src/engine/Uno.Configuration/Format/StuffFile.cs
@@ -69,7 +69,7 @@ namespace Uno.Configuration.Format
             if (value == null)
                 value = string.Empty;
             else if (value.StartsWith("~/") || value == "~")
-                value = (Environment.GetEnvironmentVariable("HOME") ?? "~") + value.Substring(1);
+                value = PlatformDetection.HomeDirectory + value.Substring(1);
 
             Add(new StuffItem(this, type, lineNumber, key, Environment.ExpandEnvironmentVariables(value)));
         }


### PR DESCRIPTION
Before, `~` expanded to `%HOME%` on all platforms which is not robost.

Now, we get `~` in a more robost way that provides several fallbacks and throws an exception if the directory could not be found.

This patch fixes so that more users will get their `~/.unoconfig` loaded properly.