### PR TITLE
Solve crash apps with windowIsTranslucent

### DIFF
--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
 #if !@(Project.Mobile.ShowStatusbar)
         <item name="android:windowFullscreen">true</item>
 #endif
-        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || @'false')</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 


### PR DESCRIPTION
Solve crash apps with windowIsTranslucent together with screenOrienta…tion="portrait" on Android 8 Oreo.

https://www.reddit.com/r/androiddev/comments/ap5zdm/dont_use_windowistranslucent_together_with/
https://forums.fusetools.com/t/problem-with-android-api-27-and-later/7430
https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o/50832408#50832408