### PR TITLE
Android: fix compile error

### DIFF
--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
 #if !@(Project.Mobile.ShowStatusbar)
         <item name="android:windowFullscreen">true</item>
 #endif
-        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || @'false')</item>
+        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'false')</item>
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 


### PR DESCRIPTION
#211 came in with an extra '@' character, causing compile-time error.

    error: failed linking references.
    C:\Users\morten\.gradle\caches\transforms-1\files-1.1\appcompat-v7-27.1.1.aar\c7791c5f011e3ee28990f27611eb82c8\res\values\values.xml: AAPT: error: expected boolean but got (raw string) @'false'.