### PR TITLE
Android: inform user about --force

### DIFF
--- a/lib/UnoCore/Targets/Android/build.bat
+++ b/lib/UnoCore/Targets/Android/build.bat
@@ -10,6 +10,10 @@ echo These dependencies can be acquired by installing 'android-build-tools': >&2
 echo. >&2
 echo     npm install android-build-tools -g >&2
 echo. >&2
+echo After installing, pass --force to make sure the new configuration is picked up. >&2
+echo. >&2
+echo     uno build android --force >&2
+echo. >&2
 goto ERROR
 #endif
 

--- a/lib/UnoCore/Targets/Android/build.sh
+++ b/lib/UnoCore/Targets/Android/build.sh
@@ -11,6 +11,10 @@ echo "These dependencies can be acquired by installing 'android-build-tools':" >
 echo "" >&2
 echo "    npm install android-build-tools -g" >&2
 echo "" >&2
+echo "After installing, pass --force to make sure the new configuration is picked up." >&2
+echo "" >&2
+echo "    uno build android --force" >&2
+echo "" >&2
 exit 1
 #endif
 


### PR DESCRIPTION
Sometimes Uno needs a --force to clear its cache and find the newly installed
android-build-tools.