### PR TITLE
Android: revert default ABI #214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Unreleased
     * `x86`
     * `x86_64`
 - Added support for multi-architecture (fat) builds, by default building:
-    * `arm64-v8a` on Debug
+    * `armeabi-v7a` on Debug
     * `armeabi-v7a` + `arm64-v8a` on Release
 - Added support for long filenames on Windows, and building of larger projects.
 - Fixed launching Android Studio on Windows, when passing `--debug`.

--- a/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
+++ b/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
@@ -27,7 +27,7 @@ namespace Uno.ProjectFormat
             {"Mobile.RunsInBackground", PropertyType.Bool, true},
             {"Mobile.Orientations", PropertyType.String, Orientations.Auto},
             {"Android.ApplicationLabel", PropertyType.String, "$(Title)"},
-            {"Android.Architectures.Debug", PropertyType.String, "arm64-v8a"},
+            {"Android.Architectures.Debug", PropertyType.String, "armeabi-v7a"},
             {"Android.Architectures.Release", PropertyType.String, "armeabi-v7a\narm64-v8a"},
             {"Android.Defines", PropertyType.String},
             {"Android.VersionCode", PropertyType.Integer, "$(VersionCode)"},


### PR DESCRIPTION
Some users have reported issues when running Android apps after upgrading to
Uno v1.12, very likely because their devices don't support arm64-v8a, which
is the new default ABI for debug builds.

This seems like a regression, and we should probably have kept armeabi-v7a as
the default ABI in #186 for better compatibility.