### PR TITLE
Add iPhone Xr and Xs Max Launch Images and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Uno Changelog
 Unreleased
 ----------
 
+### Project Files
+- Support for iPhoneXr Launch Image has been added. This can be customized using the `iOS.LaunchImages.iPhone_Portrait_iPhoneXr_2x` and `iOS.LaunchImages.iPhone_Landscape_iPhoneXr_2x` project-setting.
+- Support for iPhoneXs Max Launch Image has been added. This can be customized using the `iOS.LaunchImages.iPhone_Portrait_iPhoneXsMax_3x` and `iOS.LaunchImages.iPhone_Landscape_iPhoneXsMax_3x` project-setting.
+
+#### Android build target
+- Upgraded to Gradle 5.6, and Gradle-plugin 3.4.2.
+- Upgraded build tools to version 28.0.3.
+- Upgraded support libraries to version 28.0.0.
+- Upgraded SDK compile and target versions to 28
+- Added support for generating [Android App Bundle](https://developer.android.com/platform/technology/app-bundle) on Release
+- Added the following build properties.
+    * `Bundle`
+    * `Bundle.BuildName`
+    * `Bundle.Gradle.Task`
+- Renamed the following build properties.
+    * `APK.Configuration -> Build.Configuration`
+- Set default versionCode to positive Integer (1) so `gradlew` command doesn't produce error when building using latest Gradle
+
 1.12
 ----
 

--- a/lib/UnoCore/Targets/iOS/@(LaunchImages)/Contents.json
+++ b/lib/UnoCore/Targets/iOS/@(LaunchImages)/Contents.json
@@ -1,6 +1,42 @@
 {
   "images" : [
     {
+      "filename" : "iPhone_Portrait_iPhoneXsMax_3x.png",
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "12.0",
+      "subtype" : "2688h",
+      "scale" : "3x"
+    },
+    {
+      "filename" : "iPhone_Landscape_iPhoneXsMax_3x.png",
+      "orientation" : "landscape",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "12.0",
+      "subtype" : "2688h",
+      "scale" : "3x"
+    },
+    {
+      "filename" : "iPhone_Portrait_iPhoneXr_2x.png",
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "12.0",
+      "subtype" : "1792h",
+      "scale" : "2x"
+    },
+    {
+      "filename" : "iPhone_Landscape_iPhoneXr_2x.png",
+      "orientation" : "landscape",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "12.0",
+      "subtype" : "1792h",
+      "scale" : "2x"
+    },
+    {
       "filename" : "iPhone_Portrait_iPhoneX_3x.png",
       "orientation" : "portrait",
       "idiom" : "iphone",

--- a/lib/UnoCore/Targets/iOS/iOS.uxl
+++ b/lib/UnoCore/Targets/iOS/iOS.uxl
@@ -99,6 +99,14 @@
     <Set LaunchImages="@(Project.Name)/Images.xcassets/LaunchImage.launchimage" />
     <ProcessFile Name="@(LaunchImages)/Contents.json" />
 
+    <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Portrait_iPhoneXsMax_3x:Path || '@//Assets/Black.png')"
+        TargetWidth="1242" TargetHeight="2688" TargetName="@(LaunchImages)/iPhone_Portrait_iPhoneXsM_3x.png" />
+    <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Landscape_iPhoneXsMax_3x:Path || '@//Assets/Black.png')"
+        TargetWidth="2688" TargetHeight="1242" TargetName="@(LaunchImages)/iPhone_Landscape_iPhoneXsM_3x.png" />
+    <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Portrait_iPhoneXr_2x:Path || '@//Assets/Black.png')"
+        TargetWidth="828" TargetHeight="1792" TargetName="@(LaunchImages)/iPhone_Portrait_iPhoneXr_2x.png" />
+    <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Landscape_iPhoneXr_2x:Path || '@//Assets/Black.png')"
+        TargetWidth="1792" TargetHeight="828" TargetName="@(LaunchImages)/iPhone_Landscape_iPhoneXr_2x.png" />
     <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Portrait_iPhoneX_3x:Path || '@//Assets/Black.png')"
         TargetWidth="1125" TargetHeight="2436" TargetName="@(LaunchImages)/iPhone_Portrait_iPhoneX_3x.png" />
     <ImageFile Name="@(Project.iOS.LaunchImages.iPhone_Landscape_iPhoneX_3x:Path || '@//Assets/Black.png')"


### PR DESCRIPTION
Support for iPhone XR and iPhone XS Max Launch Image has been added.

Updated Changelog file to accommodate changes from this PR and https://github.com/fuse-open/uno/pull/220