### PR TITLE
iOS: switch to user-installed ios-deploy

### DIFF
--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -17,17 +17,14 @@ debug)
     ;;
 uninstall)
     echo "Uninstalling @(BundleIdentifier)"
-    chmod +x "@(Base.Directory)/bin/ios-deploy"
-    "@(Base.Directory)/bin/ios-deploy" -9 -1 "@(BundleIdentifier)"
+    ios-deploy -9 -1 "@(BundleIdentifier)"
     exit $?
     ;;
 esac
 
-chmod +x "@(Base.Directory)/bin/ios-deploy"
-
 #if @(Cocoapods:Defined)
 pod install
-"@(Base.Directory)/bin/ios-deploy" --noninteractive --debug --bundle "build/Build/Products/@(Pbxproj.Configuration)-iphoneos/@(Project.Name).app" "$@"
+ios-deploy --noninteractive --debug --bundle "build/Build/Products/@(Pbxproj.Configuration)-iphoneos/@(Project.Name).app" "$@"
 #else
-"@(Base.Directory)/bin/ios-deploy" --noninteractive --debug --bundle "build/@(Pbxproj.Configuration)-iphoneos/@(Project.Name).app" "$@"
+ios-deploy --noninteractive --debug --bundle "build/@(Pbxproj.Configuration)-iphoneos/@(Project.Name).app" "$@"
 #endif

--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -15,6 +15,16 @@ debug)
 #endif
     exit $?
     ;;
+esac
+
+if ! which ios-deploy > /dev/null 2>&1; then
+    echo "ERROR: Unable to find the 'ios-deploy' command." >&2
+    echo -e "\nYou can install ios-deploy using NPM:" >&2
+    echo -e "\n    npm install ios-deploy@beta -g\n" >&2
+    exit 1
+fi
+
+case $1 in
 uninstall)
     echo "Uninstalling @(BundleIdentifier)"
     ios-deploy -9 -1 "@(BundleIdentifier)"


### PR DESCRIPTION
Our version of `ios-deploy` that is included in `uno-base` is outdated and no longer works with the most recent version of iOS (#210).

To get around this problem we'll use the system-installed version instead.

Currently, the most recent beta version of `ios-deploy` is required for iOS 13, which can be installed by running this command.

```
npm install ios-deploy@beta -g
```