### PR TITLE
macOS: install Mono automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ Welcome to Uno, the core component in [Fuse Open], a native app development tool
 npm install @fuse-open/uno
 ```
 
-This will install `uno`. Pass `--save-dev` to install as a dependency in your local project, or `-g` to install
-the command globally on your system.
-
-Please note that this package contains .NET software that will need [Mono](http://www.mono-project.com/download/)
-to run on Linux and macOS.
+This will install the `uno` command and core libraries.
 
 ## Abstract
 

--- a/bin/uno.js
+++ b/bin/uno.js
@@ -1,19 +1,7 @@
 #!/usr/bin/env node
 const path = require('path');
-const {spawn} = require('child_process');
+const run = require('dotnet-run');
 
-function uno(args) {
-    const filename = path.join(__dirname, 'uno');
-    const options = {stdio: 'inherit'};
-
-    if (path.sep == '\\')
-        return spawn(filename + '.exe', args, options);
-    else {
-        args.unshift(filename);
-        return spawn('bash', args, options);
-    }
-}
-
-uno(process.argv.slice(2)).on('exit', function(code) {
-    process.exit(code);
-});
+run(path.join(__dirname, 'uno.exe'),
+    process.argv.slice(2),
+    process.exit);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "@fuse-open/uno",
   "version": "1.12.3",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "dotnet-run": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dotnet-run/-/dotnet-run-1.0.0.tgz",
+      "integrity": "sha512-jgUouzFdtKzY+41fQPGg+F9o73DxkOpjTjWnrJKsywbTjBElWZDwluYLZrGDcmbP0kppBgaduunAXckkfWn8fA=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@fuse-open/uno",
   "version": "1.12.3",
   "description": "Fast, native C# dialect and cross-compiler.",
+  "dependencies": {
+    "dotnet-run": "^1.0.0"
+  },
   "scripts": {
     "build": "bash scripts/build.sh",
     "prepack": "bash scripts/pack.sh",


### PR DESCRIPTION
The [dotnet-run](https://www.npmjs.com/package/dotnet-run) package will detect Mono/.NET or automatically download a suitable version for your system.

> When we can find Mono v5.4.1.7 or greater on your system, we'll use your existing installation. By default we'll download v6.0.0.311 automatically.
>
> We provide minimal Mono releases for macOS, much smaller than official releases. Our v6.0.0.311 is distributed as a 33.6 MB tarball, which installs faster and is more than ten times smaller than the official pkg installer at 362.2 MB. Our package is unobtrusive to your system and will safely co-exist with any existing Mono installation you may or may not have from before.