### PR TITLE
C++: optimize string and char classes

### DIFF
--- a/src/compiler/Uno.Compiler.API/Domain/IL/Types/DataType.cs
+++ b/src/compiler/Uno.Compiler.API/Domain/IL/Types/DataType.cs
@@ -117,6 +117,14 @@ namespace Uno.Compiler.API.Domain.IL
                 {
                     case TypeType.Class:
                     case TypeType.Struct:
+                        // Optimization: 'char' and 'string' are pre-initialized.
+                        switch (BuiltinType)
+                        {
+                            case BuiltinType.Char:
+                            case BuiltinType.String:
+                                return false;
+                        }
+
                         return Initializer != null;
                     default:
                         return false;


### PR DESCRIPTION
This change will cause the C++-generator to drop unnecessary calls to
Char_typeof()->Init() and String_typeof()->Init() in all static members
of char and string classes.

This will speed things up because of less overhead at run-time, and static
members of these two classes are typically invoked very frequently.