### PR TITLE
uno doctor: support passing filenames to project files

### DIFF
--- a/src/engine/Uno.Build/Packages/LibraryBuilder.cs
+++ b/src/engine/Uno.Build/Packages/LibraryBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Uno.Collections;

--- a/src/engine/Uno.Build/Packages/PackageCache.cs
+++ b/src/engine/Uno.Build/Packages/PackageCache.cs
@@ -47,7 +47,11 @@ namespace Uno.Build.Packages
                 config = UnoConfig.Current;
 
             foreach (var src in config.GetFullPathArray("Packages.SourcePaths"))
-                _sourcePaths.AddOnce(Path.Combine(src, "build"));
+                _sourcePaths.AddOnce(Path.Combine(
+                    File.Exists(src)
+                        ? Path.GetDirectoryName(src)
+                        : src,
+                    "build"));
             foreach (var src in config.GetFullPathArray("Packages.SearchPaths"))
                 _searchPaths.AddOnce(src);
         }

--- a/src/engine/Uno.Build/Packages/PackageCache.cs
+++ b/src/engine/Uno.Build/Packages/PackageCache.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Uno.Configuration.Format;
 using Uno.Build.JavaScript;
 using Uno.Collections;
 using Uno.Compiler;

--- a/src/main/Uno.CLI/Packages/Doctor.cs
+++ b/src/main/Uno.CLI/Packages/Doctor.cs
@@ -14,7 +14,7 @@ namespace Uno.CLI.Packages
 
         public override void Help()
         {
-            WriteUsage("[options] [source-dir|package-name ...]",
+            WriteUsage("[options] [project-file|directory ...]",
                        "[options] --force [package-name ...]");
 
             WriteHead("Available options", 27);
@@ -46,8 +46,9 @@ namespace Uno.CLI.Packages
 
             Log.ProductHeader();
 
-            // Interpret RebuildList as SourcePaths when a directory is specified.
+            // Interpret RebuildList as SourcePaths when a file or directory is specified.
             if (!force && lib.RebuildList.Count > 0 && (
+                    File.Exists(lib.RebuildList[0]) ||
                     Directory.Exists(lib.RebuildList[0]) ||
                     lib.RebuildList[0].IndexOf('/') != -1 ||
                     lib.RebuildList[0].IndexOf('\\') != -1))


### PR DESCRIPTION
Project filenames can now be passed directly to 'uno doctor' or via
Packages.SourcePaths in .unoconfig.

This syntax makes a lot of sense when you want to be explicit about
which projects to build.