### PR TITLE
Run Bash from Git for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ install:
         Invoke-WebRequest https://www.nuget.org/api/v2/package/mesa3d-x64/18.3.4 -OutFile mesa.zip
         Expand-Archive mesa.zip mesa
       }
+  - npm install
 
 build_script:
   - npm pack --silent

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -10,7 +10,7 @@ Uno is built using the command-line on Linux, macOS or Windows – or [from insi
 - [NuGet](https://www.nuget.org/downloads/)
 
 Our cross-platform build scripts are written in `bash`, and `make` is a convenient way to invoke the different build tasks.
-Bash is included in Git for Windows.
+Bash is included in [Git for Windows](https://git-scm.com/downloads).
 
 On Windows, we need [vswhere] to locate your Visual Studio 2017 installation. Please make sure we can find `vswhere` in
 `%PATH%` or at `%PROGRAMFILES(x86)%\Microsoft Visual Studio\Installer`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,30 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dotnet-run/-/dotnet-run-1.0.0.tgz",
       "integrity": "sha512-jgUouzFdtKzY+41fQPGg+F9o73DxkOpjTjWnrJKsywbTjBElWZDwluYLZrGDcmbP0kppBgaduunAXckkfWn8fA=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "xbash": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/xbash/-/xbash-1.4.0.tgz",
+      "integrity": "sha512-YIVWhnW8QhCWW39zoDsNIndFLOowrigH/O1UUbvhQJjABnMApsb/zshoAKxejO7eQFD/tmjpkntwvw23vwefPA==",
+      "dev": true,
+      "requires": {
+        "which": "^1.3.1"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "dotnet-run": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dotnet-run/-/dotnet-run-1.0.0.tgz",
-      "integrity": "sha512-jgUouzFdtKzY+41fQPGg+F9o73DxkOpjTjWnrJKsywbTjBElWZDwluYLZrGDcmbP0kppBgaduunAXckkfWn8fA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dotnet-run/-/dotnet-run-1.1.0.tgz",
+      "integrity": "sha512-nuLxPxSKO15jSBcVI5ve2hSIGwfPmjY4VpBPMbi1nyWNqMGCc/9elsfzsVCls8DCM4g9iB7UVnkS+W42WsuuhQ=="
     },
     "isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.13.2",
   "description": "Fast, native C# dialect and cross-compiler.",
   "dependencies": {
-    "dotnet-run": "^1.0.0"
+    "dotnet-run": "^1.1.0"
   },
   "devDependencies": {
     "xbash": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "dependencies": {
     "dotnet-run": "^1.0.0"
   },
+  "devDependencies": {
+    "xbash": "^1.4.0"
+  },
   "scripts": {
-    "build": "bash scripts/build.sh",
-    "prepack": "bash scripts/pack.sh",
-    "test": "bash scripts/test.sh"
+    "build": "xbash scripts/build.sh",
+    "prepack": "xbash scripts/pack.sh",
+    "test": "xbash scripts/test.sh"
   },
   "bin": {
     "uno": "bin/uno.js"


### PR DESCRIPTION
`xbash` is an NPM package that will detect Git for Windows and run `bash.exe` from there, or make a suggestion to install Git for Windows. So, now `bash.exe` no longer needs to added to PATH explicitly, and this makes commands such as `npm pack` more likely to just work.