### PR TITLE
Android Splash

### DIFF
--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -226,6 +226,9 @@
     <ProcessFile Name="app/build.gradle" />
     <ProcessFile Name="app/src/main/AndroidManifest.xml" />
     <ProcessFile Name="app/src/main/CMakeLists.txt" />
+    <CopyFile Condition="Android" Name="@(Project.Android.Splash.SplashLogo:Path || '@//Assets/DefaultIcon.png')" TargetName="app/src/main/res/drawable/splash_logo.png" />
+    <ProcessFile Name="app/src/main/res/drawable/splash_background.xml" />
+    <ProcessFile Name="app/src/main/res/values/colors.xml" />
     <ProcessFile Name="app/src/main/res/values/strings.xml" />
     <ProcessFile Name="app/src/main/res/values/styles.xml" />
     <ProcessFile Name="build.gradle" />

--- a/lib/UnoCore/Targets/Android/app/src/main/res/drawable/splash_background.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+ 
+ <item android:drawable="@color/splashColor" />
+ 
+ <item>
+	 <bitmap
+	 android:gravity="center"
+	 android:src="@drawable/splash_logo" />
+ </item>
+ 
+</layer-list>

--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/colors.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splashColor">@(Project.Android.Splash.SplashBackgroundColor)</color>
+</resources>

--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
@@ -5,8 +5,16 @@
 #if !@(Project.Mobile.ShowStatusbar)
         <item name="android:windowFullscreen">true</item>
 #endif
-        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'false')</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
+
+#if @(Project.Android.Splash.Enabled:Test(1, 0))
+		<item name="android:windowBackground">@drawable/@(Project.Android.Splash.SplashFileName || 'splash_background')</item>
+#else
+		<item name="android:windowFullscreen">true</item>
+		<item name="android:windowContentOverlay">@null</item>
+		<item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'true')</item>
+		<item name="android:windowBackground">@android:color/transparent</item>
+#endif
+        
     </style>
 
 </resources>

--- a/lib/UnoCore/Targets/Android/com/fuse/App.java
+++ b/lib/UnoCore/Targets/Android/com/fuse/App.java
@@ -24,6 +24,7 @@ import android.annotation.TargetApi;
 import android.view.ViewTreeObserver;
 import android.content.DialogInterface;
 import android.graphics.SurfaceTexture;
+import android.R.color;
 import android.annotation.SuppressLint;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
@@ -88,6 +89,11 @@ public class App {
 
         // call c++ for setup
         ActivityNativeEntryPoints.cppOnCreate(RootActivity);
+        
+        // reset window background for app switcher to be able to take a screenshot of app content
+#if @(Project.Android.Splash.Enabled:Test(1, 0))
+        RootActivity.getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+#endif
 
         // Finish
         HasCreated = true;


### PR DESCRIPTION
- fixed flash of a screen when no splash
- added .unoproj option to add splash screen:

```
"Android": {
  "Splash": {
    "Enabled": true,
    "SplashBackgroundColor": "#9846EF",
    "SplashLogo": "Assets/splash_logo.png",		
  },
}
```