### PR TITLE
Detect CMake on Windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,12 +71,6 @@ To support building native apps, we need [CMake](https://cmake.org/) and C++ com
 
 We need [Node.js](https://nodejs.org/en/download/) to support transpiling FuseJS files to ES5.
 
-If `node` isn't found in your *PATH*, the location can be provided like this:
-
-```javascript
-Tools.Node: `%PROGRAMFILES%\nodejs\node.exe`
-```
-
 ## Package manager
 
 ```javascript

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,12 +67,6 @@ To support building native apps, we need [CMake](https://cmake.org/) and C++ com
 - **macOS:** Xcode with command line tools
 - **Windows:** Visual Studio 2017
 
-If `cmake` isn't in found your *PATH*, the location can be provided like this:
-
-```javascript
-Tools.CMake: `%PROGRAMFILES%\CMake\bin\cmake.exe`
-```
-
 ## Node.js
 
 We need [Node.js](https://nodejs.org/en/download/) to support transpiling FuseJS files to ES5.

--- a/lib/UnoCore/Targets/Native/Native.uxl
+++ b/lib/UnoCore/Targets/Native/Native.uxl
@@ -34,7 +34,6 @@
 
     <Set Commands.Build="@(WIN32:Defined:Test('build.bat', 'bash build.sh'))" />
     <Set Commands.Run="@(WIN32:Defined:Test('run.bat', 'bash run.sh'))" />
-    <Set CMake="@(@(Config.Tools.CMake || 'cmake'):QuoteSpace)" />
 
     <ProcessFile Name="build.sh" Condition="UNIX" IsExecutable=true />
     <ProcessFile Name="run.sh" Condition="UNIX" IsExecutable=true />

--- a/lib/UnoCore/Targets/Native/build.bat
+++ b/lib/UnoCore/Targets/Native/build.bat
@@ -1,6 +1,18 @@
 :: @(MSG_ORIGIN)
 :: @(MSG_EDIT_WARNING)
 @echo off
+
+where cmake 1>NUL 2>NUL
+if not %ERRORLEVEL% == 0 (
+    echo ERROR: Unable to find the 'cmake' command. Make sure CMake is installed and added to PATH. >&2
+    echo. >&2
+    echo On Windows, you can install CMake using Chocolatey: >&2
+    echo. >&2
+    echo     choco install cmake >&2
+    echo. >&2
+    exit /b 1
+)
+
 pushd "%~dp0"
 
 cmake -G"@(CMake.Generator)" .

--- a/lib/UnoCore/Targets/Native/build.bat
+++ b/lib/UnoCore/Targets/Native/build.bat
@@ -3,8 +3,8 @@
 @echo off
 pushd "%~dp0"
 
-@(CMake) -G"@(CMake.Generator)" .
+cmake -G"@(CMake.Generator)" .
 if not %ERRORLEVEL% == 0 (popd && exit /b %ERRORLEVEL%)
 
-@(CMake) --build . -- /p:Configuration=@(Native.Configuration) /m
+cmake --build . -- /p:Configuration=@(Native.Configuration) /m
 popd && exit /b %ERRORLEVEL%

--- a/lib/UnoCore/Targets/Native/build.sh
+++ b/lib/UnoCore/Targets/Native/build.sh
@@ -4,7 +4,7 @@
 set -e
 cd "`dirname "$0"`"
 
-if ! which @(CMake) > /dev/null 2>&1; then
+if ! which cmake > /dev/null 2>&1; then
     echo "ERROR: Unable to find the 'cmake' command. Make sure CMake is installed and added to PATH." >&2
 #if @(MAC:Defined)
     echo -e "\nOn macOS, you can install CMake using Homebrew:" >&2
@@ -21,10 +21,10 @@ if ! which xcodebuild > /dev/null 2>&1; then
     exit 1
 fi
 
-@(CMake) -GXcode "$@" .
+cmake -GXcode "$@" .
 xcodebuild -configuration @(Native.Configuration)
 #else
-@(CMake) -DCMAKE_BUILD_TYPE=@(Native.Configuration) "$@" .
+cmake -DCMAKE_BUILD_TYPE=@(Native.Configuration) "$@" .
 
 if [ -f /proc/cpuinfo ]; then
     BUILD_ARGS=-j`grep processor /proc/cpuinfo | wc -l`

--- a/lib/UnoCore/Targets/Native/run.bat
+++ b/lib/UnoCore/Targets/Native/run.bat
@@ -3,6 +3,18 @@
 @echo off
 
 if "%1" == "debug" (
+    where cmake 1>NUL 2>NUL
+    if not %ERRORLEVEL% == 0 (
+        popd
+        echo ERROR: Unable to find the 'cmake' command. Make sure CMake is installed and added to PATH. >&2
+        echo. >&2
+        echo On Windows, you can install CMake using Chocolatey: >&2
+        echo. >&2
+        echo     choco install cmake >&2
+        echo. >&2
+        exit /b 1
+    )
+
     pushd "%~dp0"
 
     cmake -G"@(CMake.Generator)" .

--- a/lib/UnoCore/Targets/Native/run.bat
+++ b/lib/UnoCore/Targets/Native/run.bat
@@ -5,7 +5,7 @@
 if "%1" == "debug" (
     pushd "%~dp0"
 
-    @(CMake) -G"@(CMake.Generator)" .
+    cmake -G"@(CMake.Generator)" .
     if not %ERRORLEVEL% == 0 (popd && exit /b %ERRORLEVEL%)
 
     echo Opening Visual Studio 2017

--- a/lib/UnoCore/Targets/Native/run.sh
+++ b/lib/UnoCore/Targets/Native/run.sh
@@ -8,7 +8,7 @@ case $1 in
 debug)
     shift
 #if @(MAC:Defined)
-    @(CMake) -GXcode "$@" .
+    cmake -GXcode "$@" .
     echo "Opening Xcode"
     open -aXcode "@(Project.Name).xcodeproj"
     exit $?

--- a/src/engine/Uno.Build/JavaScript/FuseJS.cs
+++ b/src/engine/Uno.Build/JavaScript/FuseJS.cs
@@ -17,7 +17,6 @@ namespace Uno.Build.JavaScript
 {
     public class FuseJS : LogObject, IDisposable
     {
-        static readonly string _node = UnoConfig.Current.GetFullPath("Tools.Node", false) ?? "node";
         readonly Task<int> _task;
         readonly StringBuilder _output = new StringBuilder();
         readonly Regex _portFinder = new Regex("port:([0-9]+)");
@@ -31,7 +30,7 @@ namespace Uno.Build.JavaScript
             var upk = packages.GetPackage("FuseJS.Transpiler");
             var script = Path.Combine(upk.SourceDirectory, "server.min.js");
             _task = new Shell(packages.Log).Start(
-                _node, 
+                "node", 
                 script.QuoteSpace(), 
                 outputReceived: (sender, args) => {
                     string port;

--- a/src/engine/Uno.Build/JavaScript/FuseJS.cs
+++ b/src/engine/Uno.Build/JavaScript/FuseJS.cs
@@ -30,15 +30,15 @@ namespace Uno.Build.JavaScript
             var upk = packages.GetPackage("FuseJS.Transpiler");
             var script = Path.Combine(upk.SourceDirectory, "server.min.js");
             _task = new Shell(packages.Log).Start(
-                "node", 
-                script.QuoteSpace(), 
+                "node",
+                script.QuoteSpace(),
                 outputReceived: (sender, args) => {
                     string port;
                     if (TryMatchPort(args.Data, out port))
                         _url = "http://127.0.0.1:" + port;
 
                     _output.AppendLine(args.Data);
-                }, 
+                },
                 errorReceived: (sender, args) => {
                     _output.AppendLine(args.Data);
                 });
@@ -102,7 +102,7 @@ namespace Uno.Build.JavaScript
                 ++i;
             }
 
-            if (_url == null) 
+            if (_url == null)
             {
                 Log.Error("Transpiler doesn't run for unknown reasons.\n" + _output.ToString());
                 return false;


### PR DESCRIPTION
* Provide instructions on how to install CMake when not found.
* Drop `Tools.CMake` and `Tools.Node` config properties.
* Always run `cmake` and `node` from PATH.

Related to #227