### PR TITLE
uno config: print list of current defines

### DIFF
--- a/src/main/Uno.CLI/Diagnostics/Config.cs
+++ b/src/main/Uno.CLI/Diagnostics/Config.cs
@@ -69,7 +69,7 @@ namespace Uno.CLI.Diagnostics
                 WriteHead(".NET assemblies", indent: 0);
                 var configAssembly = typeof (Config).Assembly;
                 var configVersion = configAssembly.GetName().Version;
-                foreach (var f in GetAllAssemblies(configAssembly))
+                foreach (var f in GetDotNetAssemblies(configAssembly))
                     if (f.GetName().Version != configVersion)
                         WriteRow(f.Location.ToRelativePath() + " (" + f.GetName().Version + ")");
             }
@@ -91,7 +91,7 @@ namespace Uno.CLI.Diagnostics
 
         // Not really correct, but good enough
         // http://stackoverflow.com/questions/2384592/is-there-a-way-to-force-all-referenced-assemblies-to-be-loaded-into-the-app-doma
-        static IReadOnlyList<Assembly> GetAllAssemblies(Assembly assembly)
+        static IReadOnlyList<Assembly> GetDotNetAssemblies(Assembly assembly)
         {
             var assemblyDir = Path.GetDirectoryName(assembly.Location);
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();

--- a/src/main/Uno.CLI/Diagnostics/Config.cs
+++ b/src/main/Uno.CLI/Diagnostics/Config.cs
@@ -54,6 +54,11 @@ namespace Uno.CLI.Diagnostics
             foreach (var f in UnoConfig.Current.GetFilenames(Log.IsVerbose))
                 WriteRow(f.ToRelativePath());
 
+            WriteHead("Config defines", indent: 0);
+            var defines = UnoConfigFile.Defines.ToArray();
+            Array.Sort(defines);
+            WriteLine(string.Join(" ", defines));
+
             if (asm || Log.IsVerbose)
             {
                 WriteHead(".NET assemblies", indent: 0);


### PR DESCRIPTION
This is sometimes useful to know, so when invoking 'uno config' we'll print
something like the following.

    Config defines
    DEV WIN32 WINDOWS X64