### PR TITLE
fix a regression where android status bar is always hidden

### DIFF
--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
@@ -9,11 +9,10 @@
 #if @(Project.Android.Splash.Enabled:Test(1, 0))
         <item name="android:windowBackground">@drawable/@(Project.Android.Splash.SplashFileName || 'splash_background')</item>
 #else
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'true')</item>
         <item name="android:windowBackground">@android:color/transparent</item>
 #endif
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'true')</item>
     </style>
 
 </resources>


### PR DESCRIPTION
The issue has been reported on the forum post : https://forums.fusetools.com/t/statusbar-is-missing-in-android-9/7912