### PR TITLE
Auto-sync version info

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "xbash scripts/build.sh",
     "prepack": "xbash scripts/pack.sh",
-    "test": "xbash scripts/test.sh"
+    "test": "xbash scripts/test.sh",
+    "version": "xbash scripts/version.sh"
   },
   "bin": {
     "uno": "bin/uno.js"

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -12,7 +12,7 @@ mkdir -p $DST
 # Detect version info
 VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]'`
 BUILD_NUMBER="0"
-COMMIT="N/A"
+COMMIT=""
 
 if [ -n "$APPVEYOR" ]; then
     BUILD_NUMBER=$APPVEYOR_BUILD_NUMBER
@@ -30,10 +30,10 @@ VERSION_TRIPLET=`echo $VERSION | sed -n -e 's/\([^-]*\).*/\1/p'`
 
 # Create GlobalAssemblyInfo.Override.cs
 sed -e 's/\(AssemblyVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET.$BUILD_NUMBER'\2/' \
-      -e 's/\(AssemblyFileVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET.$BUILD_NUMBER'\2/' \
-      -e 's/\(AssemblyInformationalVersion("\)[^"]*\(")\)/\1'$VERSION'\2/' \
-      -e 's/\(AssemblyConfiguration("\)[^"]*\(")\)/\1'$COMMIT'\2/' \
-      src/GlobalAssemblyInfo.cs > src/GlobalAssemblyInfo.Override.cs
+    -e 's/\(AssemblyFileVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET.$BUILD_NUMBER'\2/' \
+    -e 's/\(AssemblyInformationalVersion("\)[^"]*\(")\)/\1'$VERSION'\2/' \
+    -e 's/\(AssemblyConfiguration("\)[^"]*\(")\)/\1'$COMMIT'\2/' \
+    src/GlobalAssemblyInfo.cs > src/GlobalAssemblyInfo.Override.cs
 
 # Trigger release builds
 h1 "Installing packages"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+SELF=`echo $0 | sed 's/\\\\/\\//g'`
+cd "`dirname "$SELF"`/.." || exit 1
+set -e
+
+# Most of the following code was copied from pack.sh.
+#####################################################
+
+# Detect version info
+VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]'`
+BUILD_NUMBER="0"
+COMMIT=""
+
+# Extract the X.Y.Z part of version, removing the suffix if any
+VERSION_TRIPLET=`echo $VERSION | sed -n -e 's/\([^-]*\).*/\1/p'`
+
+# Create GlobalAssemblyInfo.Override.cs
+sed -e 's/\(AssemblyVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET.$BUILD_NUMBER'\2/' \
+    -e 's/\(AssemblyFileVersion("\)[^"]*\(")\)/\1'$VERSION_TRIPLET.$BUILD_NUMBER'\2/' \
+    -e 's/\(AssemblyInformationalVersion("\)[^"]*\(")\)/\1'$VERSION'\2/' \
+    -e 's/\(AssemblyConfiguration("\)[^"]*\(")\)/\1'$COMMIT'\2/' \
+    src/GlobalAssemblyInfo.cs > src/GlobalAssemblyInfo.Override.cs
+
+echo "Updating GlobalAssemblyInfo to version $VERSION"
+cat src/GlobalAssemblyInfo.Override.cs > src/GlobalAssemblyInfo.cs
+rm src/GlobalAssemblyInfo.Override.cs

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -22,6 +22,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("d159dc86-f510-4fcf-9573-e339bdd6d166")]
 
 // Version information.
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
-[assembly: AssemblyInformationalVersion("1.13.0")]
+[assembly: AssemblyVersion("1.14.0.0")]
+[assembly: AssemblyFileVersion("1.14.0.0")]
+[assembly: AssemblyInformationalVersion("1.14.0-canary.0")]

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -20,16 +20,8 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d159dc86-f510-4fcf-9573-e339bdd6d166")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.* ")]
+
+// Version information.
 [assembly: AssemblyVersion("1.13.0.0")]
 [assembly: AssemblyFileVersion("1.13.0.0")]
 [assembly: AssemblyInformationalVersion("1.13.0")]


### PR DESCRIPTION
This adds a script that's automatically run when using `npm version`. This makes sure version information in the NPM package and .NET assemblies are in sync.