### PR TITLE
Improve Android AAR support

### DIFF
--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -68,6 +68,7 @@
     <Set Activity.Name="@(Project.Android.Activity || Project.Name:Identifier)" />
     <Set Activity.Package="@(Project.Android.Package || 'com.apps.@(Project.Name:QIdentifier:ToLower)')" />
     <Set Build.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
+    <Set AAR.BuildName="app/build/outputs/aar/app-@(Build.Configuration:ToLower).aar" />
     <Set APK.BuildName="app/build/outputs/apk/@(Build.Configuration:ToLower)/app-@(Build.Configuration:ToLower).apk" />
     <Set APK.Gradle.Task="assemble@(Build.Configuration)" />
     <Set Bundle.BuildName="app/build/outputs/bundle/@(Build.Configuration:ToLower)/app.aab" />
@@ -77,8 +78,12 @@
     <Set Runtime.DebugPauseMilliseconds=0 />
     <Set Runtime.KillActivityOnDestroy=true />
     <Set Runtime.SeperateUnoThread="AppRuntimeSettings.CppMainLoop" />
-    <Set Product="@(Project.Name).apk" />
-    <Set Bundle="@(Project.Name).aab" />
+
+    <!-- Output files -->
+
+    <Set Condition="LIBRARY" Product="@(Project.Name).aar" />
+    <Set Condition="!LIBRARY" Product="@(Project.Name).apk" />
+    <Set Condition="!LIBRARY" Bundle="@(Project.Name).aab" />
 
     <!-- Deprecated properties -->
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -70,7 +70,9 @@
 
     <!-- Build configuration -->
 
-    <Set Build.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
+    <Set Condition="LIBRARY" Build.Configuration="@('!@(DEBUG:Defined)':Test('Release', 'Debug'))" />
+    <Set Condition="!LIBRARY" Build.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
+
     <Set Gradle.AssembleTask="assemble@(Build.Configuration)" />
     <Set Gradle.BundleTask="bundle@(Build.Configuration)" />
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -68,11 +68,12 @@
     <Set Activity.Name="@(Project.Android.Activity || Project.Name:Identifier)" />
     <Set Activity.Package="@(Project.Android.Package || 'com.apps.@(Project.Name:QIdentifier:ToLower)')" />
     <Set Build.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
+    <Set Gradle.AssembleTask="assemble@(Build.Configuration)" />
+    <Set Gradle.BundleTask="bundle@(Build.Configuration)" />
+
     <Set AAR.BuildName="app/build/outputs/aar/app-@(Build.Configuration:ToLower).aar" />
     <Set APK.BuildName="app/build/outputs/apk/@(Build.Configuration:ToLower)/app-@(Build.Configuration:ToLower).apk" />
-    <Set APK.Gradle.Task="assemble@(Build.Configuration)" />
     <Set Bundle.BuildName="app/build/outputs/bundle/@(Build.Configuration:ToLower)/app.aab" />
-    <Set Bundle.Gradle.Task="bundle@(Build.Configuration)" />
     <Set Runtime.CatchCppExceptions=2 />
     <Set Runtime.CppMainLoop="Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN" />
     <Set Runtime.DebugPauseMilliseconds=0 />

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -67,6 +67,9 @@
     <Set Activity.BaseClass="androidx.appcompat.app.AppCompatActivity" />
     <Set Activity.Name="@(Project.Android.Activity || Project.Name:Identifier)" />
     <Set Activity.Package="@(Project.Android.Package || 'com.apps.@(Project.Name:QIdentifier:ToLower)')" />
+
+    <!-- Build configuration -->
+
     <Set Build.Configuration="@('!@(DEBUG:Defined) && @(Project.Android.Key.Store:IsSet)':Test('Release', 'Debug'))" />
     <Set Gradle.AssembleTask="assemble@(Build.Configuration)" />
     <Set Gradle.BundleTask="bundle@(Build.Configuration)" />
@@ -74,6 +77,9 @@
     <Set AAR.BuildName="app/build/outputs/aar/app-@(Build.Configuration:ToLower).aar" />
     <Set APK.BuildName="app/build/outputs/apk/@(Build.Configuration:ToLower)/app-@(Build.Configuration:ToLower).apk" />
     <Set Bundle.BuildName="app/build/outputs/bundle/@(Build.Configuration:ToLower)/app.aab" />
+
+    <!-- Run-time properties -->
+
     <Set Runtime.CatchCppExceptions=2 />
     <Set Runtime.CppMainLoop="Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN" />
     <Set Runtime.DebugPauseMilliseconds=0 />

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -74,9 +74,9 @@
     <Set Gradle.AssembleTask="assemble@(Build.Configuration)" />
     <Set Gradle.BundleTask="bundle@(Build.Configuration)" />
 
-    <Set AAR.BuildName="app/build/outputs/aar/app-@(Build.Configuration:ToLower).aar" />
-    <Set APK.BuildName="app/build/outputs/apk/@(Build.Configuration:ToLower)/app-@(Build.Configuration:ToLower).apk" />
-    <Set Bundle.BuildName="app/build/outputs/bundle/@(Build.Configuration:ToLower)/app.aab" />
+    <Set Outputs.AAR="app/build/outputs/aar/app-@(Build.Configuration:ToLower).aar" />
+    <Set Outputs.APK="app/build/outputs/apk/@(Build.Configuration:ToLower)/app-@(Build.Configuration:ToLower).apk" />
+    <Set Outputs.Bundle="app/build/outputs/bundle/@(Build.Configuration:ToLower)/app.aab" />
 
     <!-- Run-time properties -->
 

--- a/lib/UnoCore/Targets/Android/build.bat
+++ b/lib/UnoCore/Targets/Android/build.bat
@@ -33,11 +33,17 @@ for /D %%D in ("@(SDK.Directory:NativePath)\cmake\*") do (
 
 :BUILD
 call gradlew @(APK.Gradle.Task) %* || goto ERROR
+
+#if @(LIBRARY:Defined)
+copy /Y @(AAR.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
+#else
 copy /Y @(APK.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
-#if !@(DEBUG:Defined)
+# if !@(DEBUG:Defined)
 call gradlew @(Bundle.Gradle.Task) %* || goto ERROR
 copy /Y @(Bundle.BuildName:QuoteSpace:Replace('/', '\\')) @(Bundle:QuoteSpace) || goto ERROR
+# endif
 #endif
+
 popd && exit /b 0
 
 :ERROR

--- a/lib/UnoCore/Targets/Android/build.bat
+++ b/lib/UnoCore/Targets/Android/build.bat
@@ -35,12 +35,12 @@ for /D %%D in ("@(SDK.Directory:NativePath)\cmake\*") do (
 call gradlew @(Gradle.AssembleTask) %* || goto ERROR
 
 #if @(LIBRARY:Defined)
-copy /Y @(AAR.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
+copy /Y @(Outputs.AAR:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
 #else
-copy /Y @(APK.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
+copy /Y @(Outputs.APK:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
 # if !@(DEBUG:Defined)
 call gradlew @(Gradle.BundleTask) %* || goto ERROR
-copy /Y @(Bundle.BuildName:QuoteSpace:Replace('/', '\\')) @(Bundle:QuoteSpace) || goto ERROR
+copy /Y @(Outputs.Bundle:QuoteSpace:Replace('/', '\\')) @(Bundle:QuoteSpace) || goto ERROR
 # endif
 #endif
 

--- a/lib/UnoCore/Targets/Android/build.bat
+++ b/lib/UnoCore/Targets/Android/build.bat
@@ -32,14 +32,14 @@ for /D %%D in ("@(SDK.Directory:NativePath)\cmake\*") do (
 )
 
 :BUILD
-call gradlew @(APK.Gradle.Task) %* || goto ERROR
+call gradlew @(Gradle.AssembleTask) %* || goto ERROR
 
 #if @(LIBRARY:Defined)
 copy /Y @(AAR.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
 #else
 copy /Y @(APK.BuildName:QuoteSpace:Replace('/', '\\')) @(Product:QuoteSpace) || goto ERROR
 # if !@(DEBUG:Defined)
-call gradlew @(Bundle.Gradle.Task) %* || goto ERROR
+call gradlew @(Gradle.BundleTask) %* || goto ERROR
 copy /Y @(Bundle.BuildName:QuoteSpace:Replace('/', '\\')) @(Bundle:QuoteSpace) || goto ERROR
 # endif
 #endif

--- a/lib/UnoCore/Targets/Android/build.sh
+++ b/lib/UnoCore/Targets/Android/build.sh
@@ -25,11 +25,11 @@ export JAVA_HOME="@(JDK.Directory)"
 ./gradlew @(Gradle.AssembleTask) "$@"
 
 #if @(LIBRARY:Defined)
-ln -sf @(AAR.BuildName:QuoteSpace) @(Product:QuoteSpace)
+ln -sf @(Outputs.AAR:QuoteSpace) @(Product:QuoteSpace)
 #else
-ln -sf @(APK.BuildName:QuoteSpace) @(Product:QuoteSpace)
+ln -sf @(Outputs.APK:QuoteSpace) @(Product:QuoteSpace)
 # if !@(DEBUG:Defined)
 ./gradlew @(Gradle.BundleTask)
-ln -sf @(Bundle.BuildName:QuoteSpace) @(Bundle:QuoteSpace)
+ln -sf @(Outputs.Bundle:QuoteSpace) @(Bundle:QuoteSpace)
 # endif
 #endif

--- a/lib/UnoCore/Targets/Android/build.sh
+++ b/lib/UnoCore/Targets/Android/build.sh
@@ -22,14 +22,14 @@ exit 1
 export JAVA_HOME="@(JDK.Directory)"
 #endif
 
-./gradlew @(APK.Gradle.Task) "$@"
+./gradlew @(Gradle.AssembleTask) "$@"
 
 #if @(LIBRARY:Defined)
 ln -sf @(AAR.BuildName:QuoteSpace) @(Product:QuoteSpace)
 #else
 ln -sf @(APK.BuildName:QuoteSpace) @(Product:QuoteSpace)
 # if !@(DEBUG:Defined)
-./gradlew @(Bundle.Gradle.Task)
+./gradlew @(Gradle.BundleTask)
 ln -sf @(Bundle.BuildName:QuoteSpace) @(Bundle:QuoteSpace)
 # endif
 #endif

--- a/lib/UnoCore/Targets/Android/build.sh
+++ b/lib/UnoCore/Targets/Android/build.sh
@@ -23,13 +23,13 @@ export JAVA_HOME="@(JDK.Directory)"
 #endif
 
 ./gradlew @(APK.Gradle.Task) "$@"
-#if !@(DEBUG:Defined)
-./gradlew @(Bundle.Gradle.Task)
-#endif
 
-#if !@(LIBRARY:Defined)
+#if @(LIBRARY:Defined)
+ln -sf @(AAR.BuildName:QuoteSpace) @(Product:QuoteSpace)
+#else
 ln -sf @(APK.BuildName:QuoteSpace) @(Product:QuoteSpace)
-#if !@(DEBUG:Defined)
+# if !@(DEBUG:Defined)
+./gradlew @(Bundle.Gradle.Task)
 ln -sf @(Bundle.BuildName:QuoteSpace) @(Bundle:QuoteSpace)
-#endif
+# endif
 #endif

--- a/lib/UnoCore/Targets/Android/run.bat
+++ b/lib/UnoCore/Targets/Android/run.bat
@@ -12,6 +12,10 @@ if "%1" == "debug" (
     exit /b %ERRORLEVEL%
 )
 
+#if @(LIBRARY:Defined)
+echo ERROR: @(Product) is a library and cannot be run directly.
+exit /b 1
+#else
 if "%1" == "uninstall" (
     echo Uninstalling @(Activity.Package)
     @(Uno) adb uninstall @(Activity.Package)
@@ -24,3 +28,4 @@ if "%1" == "uninstall" (
     --sym-dir="%~dp0src\main\.uno" ^
     %*
 exit /b %ERRORLEVEL%
+#endif

--- a/lib/UnoCore/Targets/Android/run.sh
+++ b/lib/UnoCore/Targets/Android/run.sh
@@ -17,8 +17,13 @@ uninstall)
     ;;
 esac
 
+#if @(LIBRARY:Defined)
+echo "ERROR: @(Product) is a library and cannot be run directly." >&2
+exit 1
+#else
 @(Uno) launch-apk "@(Product)" \
     --package=@(Activity.Package) \
     --activity=@(Activity.Name) \
     --sym-dir="app/src/main/.uno" \
     "$@"
+#endif

--- a/src/engine/Uno.Build.Targets/Android/AndroidBuild.cs
+++ b/src/engine/Uno.Build.Targets/Android/AndroidBuild.cs
@@ -28,7 +28,7 @@ namespace Uno.Build.Targets.Android
         public override void DeleteOutdated(Disk disk, IEnvironment env)
         {
             // Remove previously built APK to avoid Android caching issues
-            var apk = env.GetString("APK.BuildName");
+            var apk = env.GetString("Outputs.APK");
             if (apk.IsValidPath())
                 disk.DeleteFile(env.Combine(apk.UnixToNative()));
 

--- a/src/engine/Uno.Build.Targets/Android/AndroidBuild.cs
+++ b/src/engine/Uno.Build.Targets/Android/AndroidBuild.cs
@@ -27,12 +27,18 @@ namespace Uno.Build.Targets.Android
 
         public override void DeleteOutdated(Disk disk, IEnvironment env)
         {
-            // Remove previously built APK to avoid Android caching issues
-            var apk = env.GetString("Outputs.APK");
-            if (apk.IsValidPath())
-                disk.DeleteFile(env.Combine(apk.UnixToNative()));
+            // Remove previously built AAR, APK and Bundle to avoid caching issues.
+            foreach (var output in new[] {
+                    env.GetString("Outputs.AAR"),
+                    env.GetString("Outputs.APK"),
+                    env.GetString("Outputs.Bundle")
+                })
+            {
+                if (output.IsValidPath())
+                    disk.DeleteFile(env.Combine(output.UnixToNative()));
+            }
 
-            // Delete old Java files so Gradle won't try to build them
+            // Delete old Java files so Gradle won't try to build them.
             disk.DeleteOutdatedFiles(env.GetOutputPath("Java.SourceDirectory"));
         }
     }


### PR DESCRIPTION
This makes build-scripts aware of AAR (Android library) that are produced instead of APK when passing `-DLIBRARY`, and other fixes related to this.