### PR TITLE
Makefile: add lib target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: release diagrams
+.PHONY: lib release diagrams
 default:
 	@bash scripts/build.sh
+lib:
+	@bin/uno doctor -e lib
 unocore:
 	@bash scripts/build-unocore.sh
 release:

--- a/docs/build-instructions.md
+++ b/docs/build-instructions.md
@@ -31,6 +31,7 @@ After building, you can use `<uno-root>/bin/uno` to run your local `uno`.
 
 | Build command   | Action                                                                  |
 |:----------------|:------------------------------------------------------------------------|
+| `make lib`      | Builds Uno libraries in `lib/` only, instead of full build.             |
 | `make install`  | Creates a symlink for `uno` in `/usr/local/bin`.                        |
 | `make release`  | Prepares a release directory for distribution.                          |
 | `make unocore`  | Generates C# code for Uno.Runtime.Core.dll, based on Uno code.          |


### PR DESCRIPTION
This will build Uno libraries in `lib/` only. Saves a lot of time when it's
not necessary to rebuild the compiler and everything.