### PR TITLE
UnoCore: add missing file to project

### DIFF
--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -458,6 +458,7 @@
     "Targets/Android/com/fuse/R.java:File",
     "Targets/Android/com/uno/CppManager.java:File",
     "Targets/Android/Dependencies.uxl:Extensions",
+    "Targets/Android/gradle.properties:File",
     "Targets/Android/gradle/wrapper/gradle-wrapper.jar:File",
     "Targets/Android/gradle/wrapper/gradle-wrapper.properties:File",
     "Targets/Android/gradlew:File",


### PR DESCRIPTION
This adds a file reference that was missing in the project, thus missing from `npm pack`-ed builds, causing Android builds to fail since #254.