### PR TITLE
Obsolete java code

### DIFF
--- a/lib/UnoCore/Targets/Android/@(Java.PackageDirectory)/@(Activity.Name).java
+++ b/lib/UnoCore/Targets/Android/@(Java.PackageDirectory)/@(Activity.Name).java
@@ -150,23 +150,4 @@ public class @(Activity.Name) extends @(Activity.BaseClass) implements ActivityC
         _keepDummySurfaceTexture = new SurfaceTexture(texName);
         return new Surface(_keepDummySurfaceTexture);
     }
-
-    @Deprecated
-    public static Activity GetRootActivity()
-    {
-        Log.w("@(Activity.Name)", "GetRootActivity() is deprecated -- please use com.fuse.Activity.getRootActivity() instead.");
-        return com.fuse.Activity.getRootActivity();
-    }
-    @Deprecated
-    public static int ShowMessageBox(CharSequence caption, CharSequence message, int buttons, int hints)
-    {
-        Log.w("@(Activity.Name)", "ShowMessageBox() is deprecated.");
-        return -1;
-    }
-    @Deprecated
-    public static AssetManager GetAssetManager()
-    {
-        Log.w("@(Activity.Name)", "GetAssetManager() is deprecated.");
-        return com.fuse.App.getCurrent().RootActivity.getAssets();
-    }
 }

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Entrypoints.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Entrypoints.cs
@@ -164,6 +164,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 					ftw.WriteLine("public class ExternedBlockHost");
 					ftw.Indent("{");
 
+					ftw.WriteLine("@Deprecated");
 					ftw.WriteLine("static void debug_log(Object message)");
 					ftw.Indent("{");
 					ftw.WriteLine("android.util.Log.d(\"" + _environment.GetString("Activity.Name") + "\", (message==null ? \"null\" : message.toString()));");

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/JavaClass.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/JavaClass.cs
@@ -97,6 +97,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 
 						if (!_nested)
 						{
+							ftw.WriteLine("@Deprecated");
 							ftw.WriteLine("static void debug_log(Object message)");
 							ftw.Indent("{");
 							ftw.WriteLine("android.util.Log.d(\"" + _environment.GetString("Activity.Name") + "\", (message==null ? \"null\" : message.toString()));");


### PR DESCRIPTION
This deletes some old internal methods that are no longer used, and marks generated `debug_log()` methods as obsolete. Users can easily use methods in `android.util.Log` directly instead.