### PR TITLE
Android: merge Java namespaces

### DIFF
--- a/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/Android_com_fuse_ExperimentalHttp_HttpRequest.java
+++ b/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/Android_com_fuse_ExperimentalHttp_HttpRequest.java
@@ -1,6 +1,6 @@
-package com.Bindings;
+package com.foreign;
 
-public class Android_com_fuse_ExperimentalHttp_HttpRequest extends com.fuse.ExperimentalHttp.HttpRequest implements com.Bindings.UnoWrapped {
+public class Android_com_fuse_ExperimentalHttp_HttpRequest extends com.fuse.ExperimentalHttp.HttpRequest implements com.foreign.UnoWrapped {
 
     public long _unoRef;
     @Override public long _GetUnoPtr() { return _unoRef; }

--- a/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.cpp.uxl
+++ b/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.cpp.uxl
@@ -112,7 +112,7 @@ U_JNIVAR->CallStaticVoidMethod(@{_javaClass}, @{CacheFlush_44283_ID});
 </Body>
         </Method>
         <Method Signature="HttpRequest_IMPL_44284(Android.Base.Wrappers.IJWrapper,Android.Base.Wrappers.IJWrapper,Android.Base.Wrappers.IJWrapper,Android.Base.Wrappers.IJWrapper):Android.Base.Primitives.ujobject">
-            <ProcessFile Name="Android_com_fuse_ExperimentalHttp_HttpRequest.java" TargetName="@(Java.SourceDirectory)/com/Bindings/Android_com_fuse_ExperimentalHttp_HttpRequest.java" />
+            <ProcessFile Name="Android_com_fuse_ExperimentalHttp_HttpRequest.java" TargetName="@(Java.SourceDirectory)/com/foreign/Android_com_fuse_ExperimentalHttp_HttpRequest.java" />
             <ProcessFile Name="HttpRequest.java" TargetName="@(Java.SourceDirectory)/com/fuse/ExperimentalHttp/HttpRequest.java" />
             <ProcessFile Name="PRNGFixes.java" TargetName="@(Java.SourceDirectory)/com/fuse/ExperimentalHttp/PRNGFixes.java" />
             <ProcessFile Name="UploadTask.java" TargetName="@(Java.SourceDirectory)/com/fuse/ExperimentalHttp/UploadTask.java" />
@@ -472,7 +472,7 @@ if (!@{_javaClass}) { THROW_UNO_EXCEPTION("Unable to cache class 'com.fuse.Exper
             <Body>
 if (@{_javaProxyClass}) { return; }
 INIT_JNI;
-@{_javaProxyClass} = NEW_GLOBAL_REF(jclass,@{Android.Base.JNI.LoadClass(Android.Base.Primitives.JNIEnvPtr,Android.Base.Primitives.ConstCharPtr):Call(jni, "com.Bindings.Android_com_fuse_ExperimentalHttp_HttpRequest")});
+@{_javaProxyClass} = NEW_GLOBAL_REF(jclass,@{Android.Base.JNI.LoadClass(Android.Base.Primitives.JNIEnvPtr,Android.Base.Primitives.ConstCharPtr):Call(jni, "com.foreign.Android_com_fuse_ExperimentalHttp_HttpRequest")});
 @{Android.Base.JNI.CheckException(Android.Base.Primitives.JNIEnvPtr):Call(U_JNIVAR)};
 if (!@{_javaProxyClass}) { THROW_UNO_EXCEPTION("Unable to cache class 'Android_com_fuse_ExperimentalHttp_HttpRequest'", 69);; }
 

--- a/lib/Uno.Permissions/Permissions.java
+++ b/lib/Uno.Permissions/Permissions.java
@@ -56,7 +56,7 @@ public final class Permissions {
     public static void startPermissionRequest(UnoObject promise, String[] permissions)
     {
         if (hasPermissions(permissions)) {
-            com.Bindings.ExternedBlockHost.permissionRequestSucceeded(promise);
+            com.foreign.ExternedBlockHost.permissionRequestSucceeded(promise);
         }else{
             _requests.add(new PermissionsRequest(promise, permissions, _permissionRequestID++));
             if(_currentRequest == null)
@@ -94,10 +94,10 @@ public final class Permissions {
             }
             if (ok) {
                 android.util.Log.d("Permissions", "Permissions granted");
-                com.Bindings.ExternedBlockHost.permissionRequestSucceeded(_currentRequest.promise);
+                com.foreign.ExternedBlockHost.permissionRequestSucceeded(_currentRequest.promise);
             } else {
                 android.util.Log.d("Permissions", "Permissions denied");
-                com.Bindings.ExternedBlockHost.permissionRequestFailed(_currentRequest.promise);
+                com.foreign.ExternedBlockHost.permissionRequestFailed(_currentRequest.promise);
             }
         }
         _currentRequest = null;

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/BoolArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/BoolArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class BoolArray extends UnoObject
 {
     public BoolArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newBoolArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newBoolArrayPtr(length));
     }
 
     private BoolArray(long ptr) {
@@ -12,7 +12,7 @@ public class BoolArray extends UnoObject
     }
 
     public BoolArray(boolean[] arr) {
-        super(com.Bindings.ExternedBlockHost.boolArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.boolArrayToUnoArrayPtr(arr));
     }
 
     public static BoolArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class BoolArray extends UnoObject
     }
 
     public boolean get(int index) {
-        return com.Bindings.ExternedBlockHost.getBool(this, index);
+        return com.foreign.ExternedBlockHost.getBool(this, index);
     }
 
     public boolean set(int index, boolean val) {
-        return com.Bindings.ExternedBlockHost.setBool(this, index, val);
+        return com.foreign.ExternedBlockHost.setBool(this, index, val);
     }
 
     public boolean[] copyArray()
     {
-        return (boolean[])com.Bindings.ExternedBlockHost.copyBoolArray(this);
+        return (boolean[])com.foreign.ExternedBlockHost.copyBoolArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ByteArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ByteArray.java
@@ -10,7 +10,7 @@ public class ByteArray extends UnoObject
     }
 
     public ByteArray(int length, boolean unoIsUnsigned) {
-        super(com.Bindings.ExternedBlockHost.newByteArrayPtr(length, unoIsUnsigned));
+        super(com.foreign.ExternedBlockHost.newByteArrayPtr(length, unoIsUnsigned));
         _unoIsUnsigned = unoIsUnsigned;
     }
 
@@ -20,7 +20,7 @@ public class ByteArray extends UnoObject
     }
 
     public ByteArray(byte[] arr) {
-        super(com.Bindings.ExternedBlockHost.byteArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.byteArrayToUnoArrayPtr(arr));
     }
 
     public static ByteArray InitFromUnoPtr(long ptr, boolean unoIsUnsigned)
@@ -30,23 +30,23 @@ public class ByteArray extends UnoObject
 
     public byte get(int index) {
         if (_unoIsUnsigned)
-            return com.Bindings.ExternedBlockHost.getUByte(this, index);
+            return com.foreign.ExternedBlockHost.getUByte(this, index);
         else
-            return com.Bindings.ExternedBlockHost.getByte(this, index);
+            return com.foreign.ExternedBlockHost.getByte(this, index);
     }
 
     public byte set(int index, byte val) {
         if (_unoIsUnsigned)
-            return com.Bindings.ExternedBlockHost.setUByte(this, index, val);
+            return com.foreign.ExternedBlockHost.setUByte(this, index, val);
         else
-            return com.Bindings.ExternedBlockHost.setByte(this, index, val);
+            return com.foreign.ExternedBlockHost.setByte(this, index, val);
     }
 
     public byte[] copyArray()
     {
         if (_unoIsUnsigned)
-            return (byte[])com.Bindings.ExternedBlockHost.copyUByteArray(this);
+            return (byte[])com.foreign.ExternedBlockHost.copyUByteArray(this);
         else
-            return (byte[])com.Bindings.ExternedBlockHost.copyByteArray(this);
+            return (byte[])com.foreign.ExternedBlockHost.copyByteArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/CharArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/CharArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class CharArray extends UnoObject
 {
     public CharArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newCharArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newCharArrayPtr(length));
     }
 
     private CharArray(long ptr) {
@@ -12,7 +12,7 @@ public class CharArray extends UnoObject
     }
 
     public CharArray(char[] arr) {
-        super(com.Bindings.ExternedBlockHost.charArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.charArrayToUnoArrayPtr(arr));
     }
 
     public static CharArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class CharArray extends UnoObject
     }
 
     public char get(int index) {
-        return com.Bindings.ExternedBlockHost.getChar(this, index);
+        return com.foreign.ExternedBlockHost.getChar(this, index);
     }
 
     public char set(int index, char val) {
-        return com.Bindings.ExternedBlockHost.setChar(this, index, val);
+        return com.foreign.ExternedBlockHost.setChar(this, index, val);
     }
 
     public char[] copyArray()
     {
-        return (char[])com.Bindings.ExternedBlockHost.copyCharArray(this);
+        return (char[])com.foreign.ExternedBlockHost.copyCharArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/DoubleArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/DoubleArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class DoubleArray extends UnoObject
 {
     public DoubleArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newDoubleArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newDoubleArrayPtr(length));
     }
 
     private DoubleArray(long ptr) {
@@ -12,7 +12,7 @@ public class DoubleArray extends UnoObject
     }
 
     public DoubleArray(double[] arr) {
-        super(com.Bindings.ExternedBlockHost.doubleArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.doubleArrayToUnoArrayPtr(arr));
     }
 
     public static DoubleArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class DoubleArray extends UnoObject
     }
 
     public double get(int index) {
-        return com.Bindings.ExternedBlockHost.getDouble(this, index);
+        return com.foreign.ExternedBlockHost.getDouble(this, index);
     }
 
     public double set(int index, double val) {
-        return com.Bindings.ExternedBlockHost.setDouble(this, index, val);
+        return com.foreign.ExternedBlockHost.setDouble(this, index, val);
     }
 
     public double[] copyArray()
     {
-        return (double[])com.Bindings.ExternedBlockHost.copyDoubleArray(this);
+        return (double[])com.foreign.ExternedBlockHost.copyDoubleArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/FloatArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/FloatArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class FloatArray extends UnoObject
 {
     public FloatArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newFloatArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newFloatArrayPtr(length));
     }
 
     private FloatArray(long ptr) {
@@ -12,7 +12,7 @@ public class FloatArray extends UnoObject
     }
 
     public FloatArray(float[] arr) {
-        super(com.Bindings.ExternedBlockHost.floatArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.floatArrayToUnoArrayPtr(arr));
     }
 
     public static FloatArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class FloatArray extends UnoObject
     }
 
     public float get(int index) {
-        return com.Bindings.ExternedBlockHost.getFloat(this, index);
+        return com.foreign.ExternedBlockHost.getFloat(this, index);
     }
 
     public float set(int index, float val) {
-        return com.Bindings.ExternedBlockHost.setFloat(this, index, val);
+        return com.foreign.ExternedBlockHost.setFloat(this, index, val);
     }
 
     public float[] copyArray()
     {
-        return (float[])com.Bindings.ExternedBlockHost.copyFloatArray(this);
+        return (float[])com.foreign.ExternedBlockHost.copyFloatArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/IntArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/IntArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class IntArray extends UnoObject
 {
     public IntArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newIntArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newIntArrayPtr(length));
     }
 
     private IntArray(long ptr) {
@@ -12,7 +12,7 @@ public class IntArray extends UnoObject
     }
 
     public IntArray(int[] arr) {
-        super(com.Bindings.ExternedBlockHost.intArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.intArrayToUnoArrayPtr(arr));
     }
 
     public static IntArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class IntArray extends UnoObject
     }
 
     public int get(int index) {
-        return com.Bindings.ExternedBlockHost.getInt(this, index);
+        return com.foreign.ExternedBlockHost.getInt(this, index);
     }
 
     public int set(int index, int val) {
-        return com.Bindings.ExternedBlockHost.setInt(this, index, val);
+        return com.foreign.ExternedBlockHost.setInt(this, index, val);
     }
 
     public int[] copyArray()
     {
-        return (int[])com.Bindings.ExternedBlockHost.copyIntArray(this);
+        return (int[])com.foreign.ExternedBlockHost.copyIntArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/LongArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/LongArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class LongArray extends UnoObject
 {
     public LongArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newLongArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newLongArrayPtr(length));
     }
 
     private LongArray(long ptr) {
@@ -12,7 +12,7 @@ public class LongArray extends UnoObject
     }
 
     public LongArray(long[] arr) {
-        super(com.Bindings.ExternedBlockHost.longArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.longArrayToUnoArrayPtr(arr));
     }
 
     public static LongArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class LongArray extends UnoObject
     }
 
     public long get(int index) {
-        return com.Bindings.ExternedBlockHost.getLong(this, index);
+        return com.foreign.ExternedBlockHost.getLong(this, index);
     }
 
     public long set(int index, long val) {
-        return com.Bindings.ExternedBlockHost.setLong(this, index, val);
+        return com.foreign.ExternedBlockHost.setLong(this, index, val);
     }
 
     public long[] copyArray()
     {
-        return (long[])com.Bindings.ExternedBlockHost.copyLongArray(this);
+        return (long[])com.foreign.ExternedBlockHost.copyLongArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ObjectArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ObjectArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class ObjectArray extends UnoObject
 {
     public ObjectArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newObjectArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newObjectArrayPtr(length));
     }
 
     private ObjectArray(long ptr) {
@@ -13,7 +13,7 @@ public class ObjectArray extends UnoObject
 
     public ObjectArray(UnoObject[] arr)
     {
-        super(com.Bindings.ExternedBlockHost.newObjectArrayPtr(arr.length));
+        super(com.foreign.ExternedBlockHost.newObjectArrayPtr(arr.length));
         int len = arr.length;
         for (int i=0; i<len; i++)
             set(i, arr[i]);
@@ -25,15 +25,15 @@ public class ObjectArray extends UnoObject
     }
 
     public UnoObject get(int index) {
-        return (UnoObject)com.Bindings.ExternedBlockHost.getObject(this, index);
+        return (UnoObject)com.foreign.ExternedBlockHost.getObject(this, index);
     }
 
     public UnoObject set(int index, UnoObject val) {
-        return (UnoObject)com.Bindings.ExternedBlockHost.setObject(this, index, val);
+        return (UnoObject)com.foreign.ExternedBlockHost.setObject(this, index, val);
     }
 
     public UnoObject[] copyArray()
     {
-        return (UnoObject[])com.Bindings.ExternedBlockHost.copyObjectArray(this);
+        return (UnoObject[])com.foreign.ExternedBlockHost.copyObjectArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ShortArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/ShortArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class ShortArray extends UnoObject
 {
     public ShortArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newShortArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newShortArrayPtr(length));
     }
 
     private ShortArray(long ptr) {
@@ -12,7 +12,7 @@ public class ShortArray extends UnoObject
     }
 
     private ShortArray(short[] arr) {
-        super(com.Bindings.ExternedBlockHost.shortArrayToUnoArrayPtr(arr));
+        super(com.foreign.ExternedBlockHost.shortArrayToUnoArrayPtr(arr));
     }
 
     public static ShortArray InitFromUnoPtr(long ptr)
@@ -21,15 +21,15 @@ public class ShortArray extends UnoObject
     }
 
     public short get(int index) {
-        return com.Bindings.ExternedBlockHost.getShort(this, index);
+        return com.foreign.ExternedBlockHost.getShort(this, index);
     }
 
     public short set(int index, short val) {
-        return com.Bindings.ExternedBlockHost.setShort(this, index, val);
+        return com.foreign.ExternedBlockHost.setShort(this, index, val);
     }
 
     public short[] copyArray()
     {
-        return (short[])com.Bindings.ExternedBlockHost.copyShortArray(this);
+        return (short[])com.foreign.ExternedBlockHost.copyShortArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/StringArray.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/StringArray.java
@@ -4,7 +4,7 @@ import com.uno.UnoObject;
 public class StringArray extends UnoObject
 {
     public StringArray(int length) {
-        super(com.Bindings.ExternedBlockHost.newStringArrayPtr(length));
+        super(com.foreign.ExternedBlockHost.newStringArrayPtr(length));
     }
 
     private StringArray(long ptr) {
@@ -13,7 +13,7 @@ public class StringArray extends UnoObject
 
     public StringArray(String[] arr)
     {
-        super(com.Bindings.ExternedBlockHost.newStringArrayPtr(arr.length));
+        super(com.foreign.ExternedBlockHost.newStringArrayPtr(arr.length));
         int len = arr.length;
         for (int i=0; i<len; i++)
             set(i, arr[i]);
@@ -25,15 +25,15 @@ public class StringArray extends UnoObject
     }
 
     public String get(int index) {
-        return com.Bindings.ExternedBlockHost.getString(this, index);
+        return com.foreign.ExternedBlockHost.getString(this, index);
     }
 
     public String set(int index, String val) {
-        return com.Bindings.ExternedBlockHost.setString(this, index, val);
+        return com.foreign.ExternedBlockHost.setString(this, index, val);
     }
 
     public String[] copyArray()
     {
-        return (String[])com.Bindings.ExternedBlockHost.copyStringArray(this);
+        return (String[])com.foreign.ExternedBlockHost.copyStringArray(this);
     }
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/UnoObject.java
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/UnoObject.java
@@ -1,6 +1,6 @@
 package com.uno;
 
-public class UnoObject // implements com.Bindings.UnoWrapped
+public class UnoObject // implements com.foreign.UnoWrapped
 {
     public long _retainedUnoPtr;
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -213,7 +213,7 @@
     <ProcessFile JavaFile="com/fuse/AppRuntimeSettings.java" />
     <ProcessFile JavaFile="com/fuse/App.java" />
     <ProcessFile JavaFile="com/uno/CppManager.java" />
-    <ProcessFile JavaFile="com/Bindings/UnoWrapped.java" />
+    <ProcessFile JavaFile="com/foreign/UnoWrapped.java" />
     <ProcessFile JavaFile="com/fuse/Activity.java" />
     <ProcessFile JavaFile="com/fuse/R.java" />
 

--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -208,14 +208,14 @@
     <Declare Element="JavaFile" TargetDirectory="@(Java.SourceDirectory)" />
 
     <ProcessFile Name="@(Java.PackageDirectory)/@(Activity.Name).java" />
-    <ProcessFile JavaFile="com/fuse/ActivityNativeEntryPoints.java" />
-    <ProcessFile JavaFile="com/fuse/ActivityState.java" />
-    <ProcessFile JavaFile="com/fuse/AppRuntimeSettings.java" />
-    <ProcessFile JavaFile="com/fuse/App.java" />
-    <ProcessFile JavaFile="com/uno/CppManager.java" />
     <ProcessFile JavaFile="com/foreign/UnoWrapped.java" />
     <ProcessFile JavaFile="com/fuse/Activity.java" />
+    <ProcessFile JavaFile="com/fuse/ActivityNativeEntryPoints.java" />
+    <ProcessFile JavaFile="com/fuse/ActivityState.java" />
+    <ProcessFile JavaFile="com/fuse/App.java" />
+    <ProcessFile JavaFile="com/fuse/AppRuntimeSettings.java" />
     <ProcessFile JavaFile="com/fuse/R.java" />
+    <ProcessFile JavaFile="com/uno/CppManager.java" />
 
     <!-- Icons -->
 

--- a/lib/UnoCore/Targets/Android/Uno/Base/JNI.uno
+++ b/lib/UnoCore/Targets/Android/Uno/Base/JNI.uno
@@ -32,7 +32,7 @@ namespace Android.Base
                 ClassLoader_loadClass = extern<jmethodID>(jni) "$0->GetMethodID($0->FindClass(\"java/lang/ClassLoader\"), \"loadClass\", \"(Ljava/lang/String;)Ljava/lang/Class;\")";
                 CheckException(jni);
 
-                extern(jni) "jstring jname = $0->NewStringUTF(\"com.Bindings.UnoHelper\")";
+                extern(jni) "jstring jname = $0->NewStringUTF(\"com.foreign.UnoHelper\")";
                 ujclass classLoader = extern<ujclass>(jni, activityObject, Activity_getClassLoader) "(jclass)$0->CallObjectMethod($1, $2)";
                 var hcls = extern<ujclass>(jni, classLoader, ClassLoader_loadClass) "(jclass)$0->CallObjectMethod($1, $2, jname)";
                 extern (jni, classLoader) "$0->DeleteLocalRef($1)";

--- a/lib/UnoCore/Targets/Android/Uno/Base/Types.cpp.uxl
+++ b/lib/UnoCore/Targets/Android/Uno/Base/Types.cpp.uxl
@@ -4,7 +4,7 @@
     <Using Namespace="Android.Base.Wrappers" />
 
     <Type Name="Bridge">
-        <ProcessFile Name="UnoHelper.java" TargetName="@(Java.SourceDirectory)/com/Bindings/UnoHelper.java" />
+        <ProcessFile Name="UnoHelper.java" TargetName="@(Java.SourceDirectory)/com/foreign/UnoHelper.java" />
         <Require Header.Include="android/log.h" />
         <Require Header.Include="@{Android.Base.JNI:Include}" />
         <Require Header.Include="@{Uno.Exception:Include}" />
@@ -14,7 +14,7 @@
 
                     if (@{_inited}) { return; }
                     @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
-                    @{_helperCls} = reinterpret_cast<jclass>(jni->NewGlobalRef(@{JNI.LoadClass(JNIEnvPtr,ConstCharPtr,bool):Call(@{JNI.GetEnvPtr():Call()}, "com.Bindings.UnoHelper", false)}));
+                    @{_helperCls} = reinterpret_cast<jclass>(jni->NewGlobalRef(@{JNI.LoadClass(JNIEnvPtr,ConstCharPtr,bool):Call(@{JNI.GetEnvPtr():Call()}, "com.foreign.UnoHelper", false)}));
                     if (!@{_helperCls}) {
                         U_THROW(@{Uno.Exception(string):New(uString::Utf8("Could not cache class for UnoHelper",35))});
                     }

--- a/lib/UnoCore/Targets/Android/Uno/Base/UnoHelper.java
+++ b/lib/UnoCore/Targets/Android/Uno/Base/UnoHelper.java
@@ -1,4 +1,4 @@
-﻿package com.Bindings;
+﻿package com.foreign;
 
 import java.util.HashMap;
 import java.util.Observable;
@@ -150,8 +150,8 @@ public class UnoHelper {
 	public static long GetUnoRef(Class<?> cls, Object obj)
 	{
 		if (obj!=null) {
-			if (com.Bindings.UnoWrapped.class.isAssignableFrom(cls)) {
-				return ((com.Bindings.UnoWrapped)obj)._GetUnoPtr();
+			if (com.foreign.UnoWrapped.class.isAssignableFrom(cls)) {
+				return ((com.foreign.UnoWrapped)obj)._GetUnoPtr();
 			} else {
 				return -1;
 			}

--- a/lib/UnoCore/Targets/Android/Uno/Base/Wrappers.cpp.uxl
+++ b/lib/UnoCore/Targets/Android/Uno/Base/Wrappers.cpp.uxl
@@ -147,7 +147,7 @@ return result;
         {
             @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
             JNINativeMethod nativeFunc = {(char* const)"Finalize", (char* const)"(J)V", (void *)&__JWrapper_Finalizer};
-            jclass cls = reinterpret_cast<jclass>(jni->NewGlobalRef(@{JNI.LoadClass(JNIEnvPtr,ConstCharPtr):Call(@{JNI.GetEnvPtr():Call()}, "com.Bindings.UnoHelper")}));
+            jclass cls = reinterpret_cast<jclass>(jni->NewGlobalRef(@{JNI.LoadClass(JNIEnvPtr,ConstCharPtr):Call(@{JNI.GetEnvPtr():Call()}, "com.foreign.UnoHelper")}));
             jint attached = @{JNI.GetEnvPtr():Call()}->RegisterNatives(cls, &nativeFunc, 1);
             if (attached < 0) {
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("Could not register the instantiation callback function",54))});

--- a/lib/UnoCore/Targets/Android/Uno/EntryPoints.cpp
+++ b/lib/UnoCore/Targets/Android/Uno/EntryPoints.cpp
@@ -198,7 +198,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
     }
     jclass activityClass = env->FindClass("@(Activity.Package:Replace('.', '/'))/@(Activity.Name)");
     jclass entryPointsClass = env->FindClass("com/fuse/ActivityNativeEntryPoints");
-    jclass nativeExternClass = env->FindClass("com/Bindings/ExternedBlockHost");
+    jclass nativeExternClass = env->FindClass("com/foreign/ExternedBlockHost");
 
     if (!activityClass)
         U_FATAL("COULD NOT FIND ACTIVITY CLASS");

--- a/lib/UnoCore/Targets/Android/com/foreign/UnoWrapped.java
+++ b/lib/UnoCore/Targets/Android/com/foreign/UnoWrapped.java
@@ -1,2 +1,2 @@
-package com.Bindings;
+package com.foreign;
 public interface UnoWrapped { long _GetUnoPtr(); }

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -449,7 +449,7 @@
     "Targets/Android/build.bat:File",
     "Targets/Android/build.gradle:File",
     "Targets/Android/build.sh:File",
-    "Targets/Android/com/Bindings/UnoWrapped.java:File",
+    "Targets/Android/com/foreign/UnoWrapped.java:File",
     "Targets/Android/com/fuse/Activity.java:File",
     "Targets/Android/com/fuse/ActivityNativeEntryPoints.java:File",
     "Targets/Android/com/fuse/ActivityState.java:File",

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Delegates.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Delegates.cs
@@ -68,7 +68,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 					var package = fullName.Substring(0, fullName.LastIndexOf('.'));
 					var implements = (voidReturn && d.Parameters.Length == 0) ? " implements java.lang.Runnable" : "";
 					ftw.WriteLine("package " + package + ";");
-					ftw.WriteLine("import com.Bindings.*;");
+					ftw.WriteLine("import com.foreign.*;");
 					ftw.WriteLine("import com.uno.BoolArray;");
 					ftw.WriteLine("import com.uno.ByteArray;");
 					ftw.WriteLine("import com.uno.CharArray;");

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Entrypoints.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Entrypoints.cs
@@ -113,7 +113,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 
 		public void WriteJava()
 		{
-			var path = _environment.Combine(_environment.GetString("Java.SourceDirectory"), "com", "Bindings");
+			var path = _environment.Combine(_environment.GetString("Java.SourceDirectory"), "com", "foreign");
 			var filePath = Path.Combine(path, "ExternedBlockHost.java");
 			_disk.WriteAllText(filePath, GenJavaClassCode());
 		}
@@ -149,7 +149,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 			{
 				using (var ftw = new TextFormatter(tw))
 				{
-					ftw.WriteLine("package com.Bindings;\n");
+					ftw.WriteLine("package com.foreign;\n");
 					ftw.WriteLine("import com.uno.UnoObject;");
 					ftw.WriteLine("import com.uno.BoolArray;");
 					ftw.WriteLine("import com.uno.ByteArray;");

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/JavaClass.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/JavaClass.cs
@@ -78,9 +78,9 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 							ftw.WriteLine("import com.uno.ObjectArray;");
 							ftw.WriteLine("import com.uno.ShortArray;");
 							ftw.WriteLine("import com.uno.StringArray;");
-							ftw.WriteLine("import com.Bindings.UnoHelper;");
-							ftw.WriteLine("import com.Bindings.UnoWrapped;");
-							ftw.WriteLine("import com.Bindings.ExternedBlockHost;");
+							ftw.WriteLine("import com.foreign.UnoHelper;");
+							ftw.WriteLine("import com.foreign.UnoWrapped;");
+							ftw.WriteLine("import com.foreign.ExternedBlockHost;");
 
 							var userDefinedImports = AggregateImports();
 							if (userDefinedImports.Count > 0)


### PR DESCRIPTION
The stuff in `com.Bindings` is mostly used by other code in `com.foreign`, so
merging the two seems cleaner and more consistent.

The old `com.Bindings` package is not used directly by any code in Fuselibs
or Fuse Compound, and very unlikely used directly outside of this repo.