### PR TITLE
clean: handle [target] and --configuration args

### DIFF
--- a/src/engine/Uno.Build.Targets/BuildTargets.cs
+++ b/src/engine/Uno.Build.Targets/BuildTargets.cs
@@ -30,7 +30,8 @@ namespace Uno.Build.Targets
             return All.Where(e => (experimental || !e.IsExperimental) && (obsolete || !e.IsObsolete));
         }
 
-        public static BuildTarget Get(string name, List<string> args = null, string def = null)
+        public static BuildTarget Get(string name, List<string> args = null, string def = null,
+                                      bool canReturnNull = false)
         {
             BuildTarget result;
             if (name == null && args != null)
@@ -44,11 +45,14 @@ namespace Uno.Build.Targets
                     return result;
                 }
 
-                name = def ?? Default.Identifier;
+                name = def ?? (canReturnNull ? null : Default.Identifier);
             }
 
             if (name != null && TryGet(name, out result))
                 return result;
+
+            if (canReturnNull)
+                return null;
 
             throw new ArgumentException(name.Quote() + " is not a valid build target -- see \"uno build --help\" for a list of targets");
         }

--- a/src/engine/Uno.Build/BuildDriver.cs
+++ b/src/engine/Uno.Build/BuildDriver.cs
@@ -122,6 +122,12 @@ namespace Uno.Build
                 _cache.Dispose();
         }
 
+        public void Clean()
+        {
+            _compiler.Disk.DeleteDirectory(_env.CacheDirectory);
+            _compiler.Disk.DeleteDirectory(_env.OutputDirectory);
+        }
+
         public BackendResult Build()
         {
             if (Log.HasErrors)

--- a/src/engine/Uno.Build/ProjectCleaner.cs
+++ b/src/engine/Uno.Build/ProjectCleaner.cs
@@ -12,10 +12,14 @@ namespace Uno.Build
     public class ProjectCleaner : DiskObject
     {
         readonly HashSet<string> _cleanedProjects = new HashSet<string>();
+        readonly BuildTarget _target;
+        readonly BuildConfiguration _configuration;
 
-        public ProjectCleaner(Log log)
+        public ProjectCleaner(Log log, BuildTarget target = null, BuildConfiguration configuration = 0)
             : base(log)
         {
+            _target = target;
+            _configuration = configuration;
         }
 
         public void Clean(IEnumerable<string> files)
@@ -49,16 +53,26 @@ namespace Uno.Build
 
             _cleanedProjects.Add(project.FullPath);
 
-            Disk.DeleteDirectory(project.BuildDirectory);
-            Disk.DeleteDirectory(project.CacheDirectory);
+            if (_target != null)
+            {
+                using (var driver = new BuildDriver(Log.GetQuieterLog(), _target,
+                                                    new BuildOptions {Configuration = _configuration},
+                                                    project, project.Config))
+                    driver.Clean();
+            }
+            else
+            {
+                Disk.DeleteDirectory(project.BuildDirectory);
+                Disk.DeleteDirectory(project.CacheDirectory);
 
-            // Remove files installed by stuff
-            Installer.CleanAll(Log,
-                project.StuffFiles.Select(
-                    x => Path.Combine(project.RootDirectory, x.NativePath)));
+                // Remove files installed by stuff
+                Installer.CleanAll(Log,
+                    project.StuffFiles.Select(
+                        x => Path.Combine(project.RootDirectory, x.NativePath)));
 
-            foreach (var pref in project.ProjectReferences)
-                Clean(Project.Load(Path.Combine(project.RootDirectory, pref.ProjectPath)));
+                foreach (var pref in project.ProjectReferences)
+                    Clean(Project.Load(Path.Combine(project.RootDirectory, pref.ProjectPath)));
+            }
         }
     }
 }

--- a/src/main/Uno.CLI/Projects/Clean.cs
+++ b/src/main/Uno.CLI/Projects/Clean.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Mono.Options;
 using Uno.Build;
+using Uno.Build.Targets;
 using Uno.ProjectFormat;
 
 namespace Uno.CLI.Projects
@@ -12,22 +13,38 @@ namespace Uno.CLI.Projects
 
         public override void Help()
         {
-            WriteUsage("[options] [project-path ...]");
+            WriteUsage("[target] [options] [project-path ...]");
 
-            WriteHead("Available options");
-            WriteRow("-r, --recursive",       "Look for project files recursively");
+            WriteHead("Examples", 28);
+            WriteRow("uno clean",                    "Clean all build-files (in current directory)");
+            WriteRow("uno clean android -c Release", "Clean only Android files (Release configuration)");
+
+            WriteHead("Available options", 26);
+            WriteRow("-t, --target=STRING",         "Build target (see: Available build targets)");
+            WriteRow("-c, --configuration=STRING",  "Build configuration [Debug|Release]");
+            WriteRow("-r, --recursive",             "Look for project files recursively");
+
+            WriteHead("Available build targets", 19);
+
+            foreach (var c in BuildTargets.Enumerate(Log.EnableExperimental))
+                WriteRow("* " + c.Identifier.ToLowerInvariant());
         }
 
         public override void Execute(IEnumerable<string> args)
         {
             var recursive = false;
-            var files = new OptionSet {
-                    {"r|recursive", value => recursive = true}
-                }.Parse(args)
-                .Paths(".")
-                .GetProjectFiles(recursive);
+            string targetName = null;
+            BuildConfiguration configuration = 0;
 
-            new ProjectCleaner(Log)
+            var input = new OptionSet {
+                    {"t=|target=",             value => targetName = value },
+                    {"c=|configuration=",      value => configuration = value.ParseEnum<BuildConfiguration>("configuration") },
+                    {"r|recursive",            value => recursive = true}
+                }.Parse(args);
+            var target = BuildTargets.Get(targetName, input, canReturnNull:true);
+            var files = input.Paths(".").GetProjectFiles(recursive);
+
+            new ProjectCleaner(Log, target, configuration)
                 .Clean(files);
         }
     }


### PR DESCRIPTION
This adds more options to `uno clean` that make it possible to clean a specific target/configuration only.