### PR TITLE
iOS: upgrade project & fix warnings

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -150,7 +150,7 @@
 		5A493D9C151A216A000ACE3F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					5A493DA4151A216A000ACE3F  = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -321,6 +321,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "@(CppStandard)";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -390,6 +391,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "@(CppStandard)";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -374,7 +374,13 @@
 #if !@(LIBRARY:Defined)
 				ONLY_ACTIVE_ARCH = YES;
 #endif
-				OTHER_CFLAGS = "-Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else -Wno-switch";
+				OTHER_CFLAGS = (
+					"-Wno-invalid-offsetof",
+					"-Wno-unused-value",
+					"-Wno-dangling-else",
+					"-Wno-switch",
+					"-Wno-unguarded-availability-new",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -430,7 +436,13 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = @(Project.iOS.DeploymentTarget);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "-Wno-invalid-offsetof -Wno-unused-value -Wno-dangling-else -Wno-switch";
+				OTHER_CFLAGS = (
+					"-Wno-invalid-offsetof",
+					"-Wno-unused-value",
+					"-Wno-dangling-else",
+					"-Wno-switch",
+					"-Wno-unguarded-availability-new",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -440,8 +440,10 @@
 		5A493DBE151A216A000ACE3F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+#if !@(LIBRARY:Defined)
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+#endif
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				CODE_SIGN_ENTITLEMENTS = "@(Project.Name)/@(Project.Name).entitlements";
 #if @(Pbxproj.DevelopmentTeam:IsSet)

--- a/lib/UnoCore/Targets/iOS/@(Schemes)/@(Project.Name).xcscheme
+++ b/lib/UnoCore/Targets/iOS/@(Schemes)/@(Project.Name).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:@(Project.Name).xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "@(Pbxproj.Configuration)"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:@(Project.Name).xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.mm
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.mm
@@ -68,7 +68,7 @@
     return YES;
 }
 
--(BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler{
+-(BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler{
     if ([userActivity.activityType isEqualToString: NSUserActivityTypeBrowsingWeb]) {
         NSURL *url = userActivity.webpageURL;
 


### PR DESCRIPTION
This upgrades the Xcode project, avoiding warnings when opening in Xcode.

This also fixes/silences other compile-time warnings when building the generated project.

```
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/Fuse.Internal.g.mm:931:31: warning: 'UIFontDescriptorSystemDesignSerif' is only available on iOS 13.0 or newer [-Wunguarded-availability-new]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/Fuse.Internal.g.mm:933:38: warning: 'fontDescriptorWithDesign:' is only available on iOS 13.0 or newer [-Wunguarded-availability-new]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/ContainerView.mm:11:31: warning: 'userInterfaceStyle' is only available on iOS 12.0 or newer [-Wunguarded-availability-new]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/iOS/ContainerView.mm:34:31: warning: 'userInterfaceStyle' is only available on iOS 12.0 or newer [-Wunguarded-availability-new]
/Users/morten/fuselibs/Tests/ManualTests/ManualTestingApp/build/iOS/Debug/src/Uno-iOS/AppDelegate.mm:71:151: warning: conflicting parameter types in implementation of 'application:continueUserActivity:restorationHandler:': 'void (^ _Nonnull __strong)(NSArray<id<UIUserActivityRestoring>> * _Nullable __strong)' vs 'void (^__strong _Nonnull)(NSArray * _Nullable __strong)' [-Wmismatched-parameter-types]
```