### PR TITLE
UnoCore: fix extern conditions for XliGraphicsContext

### DIFF
--- a/lib/UnoCore/Source/Uno/Platform/GraphicsContextBackend.uno
+++ b/lib/UnoCore/Source/Uno/Platform/GraphicsContextBackend.uno
@@ -10,7 +10,7 @@ namespace Uno.Platform
     {
         internal static GraphicsContextBackend Instance;
 
-        extern(CPLUSPLUS)
+        extern(CPLUSPLUS && !MOBILE)
         static GraphicsContextBackend()
         {
             Instance = new XliGraphicsContext();

--- a/lib/UnoCore/Source/Uno/Platform/Xli/XliGraphicsContext.uno
+++ b/lib/UnoCore/Source/Uno/Platform/Xli/XliGraphicsContext.uno
@@ -4,15 +4,14 @@ using OpenGL;
 namespace Uno.Platform.Xli
 {
     [TargetSpecificType]
-    [extern(CPLUSPLUS && !MOBILE) Set("TypeName", "uGraphicsContext")]
-    [extern(CPLUSPLUS && !MOBILE) Set("Include", "Uno/GraphicsContext.h")]
-    [extern(CPLUSPLUS && MOBILE) Set("TypeName", "void*")]
-    extern(CPLUSPLUS) struct XliGraphicsContextPtr
+    [Set("TypeName", "uGraphicsContext")]
+    [Set("Include", "Uno/GraphicsContext.h")]
+    extern(CPLUSPLUS && !MOBILE) struct XliGraphicsContextPtr
     {
     }
 
-    [extern(CPLUSPLUS && !MOBILE) Require("Header.Include", "Uno/GraphicsContext.h")]
-    extern(CPLUSPLUS) class XliGraphicsContext : GraphicsContextBackend
+    [Require("Header.Include", "Uno/GraphicsContext.h")]
+    extern(CPLUSPLUS && !MOBILE) class XliGraphicsContext : GraphicsContextBackend
     {
         readonly XliGraphicsContextPtr _ptr;
 


### PR DESCRIPTION
uGraphicsContext isn't available on mobile, and trying to access it gives
compile-time error when building with --no-strip.