### PR TITLE
Library improvements

### DIFF
--- a/lib/UnoCore/Targets/DotNet/DotNetDll.uxl
+++ b/lib/UnoCore/Targets/DotNet/DotNetDll.uxl
@@ -1,3 +1,4 @@
-<Extensions Backend="CIL" Condition="DotNetDll">
+<Extensions Backend="CIL" Condition="DotNetDll || LIBRARY">
     <Set AssemblyDirectory="." />
+    <Set Product="@(Project.Name).dll" />
 </Extensions>

--- a/lib/UnoCore/Targets/DotNet/Executable.uxl
+++ b/lib/UnoCore/Targets/DotNet/Executable.uxl
@@ -1,4 +1,4 @@
-<Extensions Backend="CIL" Condition="EXECUTABLE && !DOTNETDLL">
+<Extensions Backend="CIL" Condition="EXECUTABLE && !LIBRARY && !DOTNETDLL">
 
     <Set PrebuiltDirectory="@(Config.Paths.AppLoader:Path)" />
     <Set AppDirectory="@(Project.Name).app" Condition="HOST_MAC" />

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
@@ -82,7 +82,9 @@ namespace Uno.Compiler.Backends.CIL
             foreach (var e in Environment.Enumerate("UnmanagedLibrary"))
                 Disk.CopyFile(e, _outputDir.UnixToNative());
 
-            if (string.IsNullOrEmpty(Environment.GetString("AppLoader.Assembly")))
+            // Check if we need AppLoader
+            if (Environment.IsDefined("LIBRARY") ||
+                    string.IsNullOrEmpty(Environment.GetString("AppLoader.Assembly")))
                 return;
 
             // Create an executable for given architecture (-DX86 or -DX64)

--- a/src/compiler/Uno.Compiler.Core/IL/Building/Entrypoint/MainClassFinder.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Building/Entrypoint/MainClassFinder.cs
@@ -1,5 +1,9 @@
 ﻿using System.Collections.Generic;
+using Uno.Compiler.API.Domain;
 using Uno.Compiler.API.Domain.IL;
+using Uno.Compiler.API.Domain.IL.Members;
+using Uno.Compiler.API.Domain.IL.Statements;
+using Uno.Compiler.API.Domain.IL.Types;
 
 namespace Uno.Compiler.Core.IL.Building.Entrypoint
 {
@@ -20,6 +24,17 @@ namespace Uno.Compiler.Core.IL.Building.Entrypoint
                     Data.SetMainClass(FoundMainClasses[0]);
                     break;
                 case 0:
+                    // Auto-generate main-class when building a library.
+                    if (Environment.IsDefined("LIBRARY"))
+                    {
+                        var type = new ClassType(Package.Source, Data.IL, null, Modifiers.Generated | Modifiers.Public, Package.Name.ToIdentifier() + "_app");
+                        type.SetBase(Essentials.Application);
+                        type.Constructors.Add(new Constructor(Package.Source, type, null, Modifiers.Generated | Modifiers.Public, new Parameter[0], new Scope()));
+                        Data.IL.Types.Add(type);
+                        Data.SetMainClass(type);
+                        break;
+                    }
+
                     var extraMsg = Package.Name.EndsWith("Test") ? ". If this is a test project, it cannot be started directly, but must be run with a test runner." : "";
                     Log.Error(Package.Source, ErrorCode.E3503, "No non-abstract application classes found in project" + extraMsg);
                     break;


### PR DESCRIPTION
Two improvements when building with `-DLIBRARY`.

* Auto-generate main-class when building a library, avoiding compile-time error about main-class not found.
* Drop AppLoader when building a .NET library, we're only interested in the `.dll` file.