### PR TITLE
Modular .NET builds

### DIFF
--- a/lib/UnoCore/Source/Uno/Type.uno
+++ b/lib/UnoCore/Source/Uno/Type.uno
@@ -4,14 +4,26 @@ using Uno.IO;
 
 namespace System.Reflection
 {
-    [extern(DOTNET) DotNetType("System.Reflection.Assembly")]
-    extern(DOTNET)
-    public class Assembly
+    [DotNetType]
+    extern(DOTNET) 
+    public abstract class Assembly
     {
+        public virtual extern string Location { get; }
+        public virtual extern bool GlobalAssemblyCache { get; }
+
         public virtual extern string[] GetManifestResourceNames();
         public virtual extern Stream GetManifestResourceStream(string filename);
-        public virtual extern string Location { get; }
+        public virtual extern AssemblyName GetName();
         public static extern Assembly GetEntryAssembly();
+        public static extern Assembly GetExecutingAssembly();
+        public static extern Assembly LoadFrom(string assemblyFile);
+    }
+
+    [DotNetType]
+    extern(DOTNET) 
+    public sealed class AssemblyName
+    {
+        public virtual extern string Name { get; }
     }
 }
 

--- a/src/compiler/Uno.Compiler.API/Domain/Extensions/BundleFile.cs
+++ b/src/compiler/Uno.Compiler.API/Domain/Extensions/BundleFile.cs
@@ -2,17 +2,19 @@
 {
     public struct BundleFile
     {
+        public readonly SourcePackage Package;
         public readonly string BundleName;
         public readonly string TargetName;
         public readonly string SourcePath;
 
-        public BundleFile(string bundleName, string sourcePath)
-            : this(bundleName, bundleName, sourcePath)
+        public BundleFile(SourcePackage package, string bundleName, string sourcePath)
+            : this(package, bundleName, bundleName, sourcePath)
         {
         }
 
-        public BundleFile(string bundleName, string targetName, string sourcePath)
+        public BundleFile(SourcePackage package, string bundleName, string targetName, string sourcePath)
         {
+            Package = package;
             BundleName = bundleName;
             TargetName = targetName;
             SourcePath = sourcePath;

--- a/src/compiler/Uno.Compiler.API/IBundle.cs
+++ b/src/compiler/Uno.Compiler.API/IBundle.cs
@@ -5,7 +5,7 @@ namespace Uno.Compiler.API
 {
     public interface IBundle
     {
-        Expression AddBundleFile(Source src, string filename);
+        Expression AddFile(Source src, string filename);
         Expression AddProgram(DrawBlock block, Expression program);
     }
 }

--- a/src/compiler/Uno.Compiler.API/IBundle.cs
+++ b/src/compiler/Uno.Compiler.API/IBundle.cs
@@ -5,10 +5,7 @@ namespace Uno.Compiler.API
 {
     public interface IBundle
     {
-        string Directory { get; }
-
         Expression AddBundleFile(Source src, string filename);
         Expression AddProgram(DrawBlock block, Expression program);
-        Expression Add(Expression expression);
     }
 }

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
@@ -33,10 +33,10 @@ namespace Uno.Compiler.Backends.CIL
             Scheduler.AddTransform(new CilTransform(this));
         }
 
-        /*public override bool CanLink(SourcePackage upk)
+        public override bool CanLink(SourcePackage upk)
         {
             return Environment.IsUpToDate(upk, upk.Name + ".dll");
-        }*/
+        }
 
         public override bool CanLink(DataType dt)
         {

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
@@ -102,7 +102,7 @@ namespace Uno.Compiler.Backends.CIL
 
                 Log.Verbose("Creating executable: " + executable.ToRelativePath() + " (" + loader.Architecture + ")");
                 loader.SetAssemblyInfo(Input.Package.Name + "-loader",
-                    new Version(),
+                    Input.Package.ParseVersion(Log),
                     Environment.GetString);
                 loader.SetMainClass(Data.MainClass.CilTypeName(),
                     Path.Combine(_outputDir, Input.Package.Name + ".dll"),

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilBackend.cs
@@ -113,10 +113,8 @@ namespace Uno.Compiler.Backends.CIL
             }
         }
 
-        public override BackendResult Build()
+        public override BackendResult Build(SourcePackage package)
         {
-            var package = Input.Package;
-
             if (package.CanLink)
             {
                 package.Tag = _linker.AddAssemblyFile(Path.Combine(_outputDir, package.Name + ".dll"));
@@ -136,10 +134,7 @@ namespace Uno.Compiler.Backends.CIL
             using (Log.StartProfiler(g.GetType().FullName + ".Save"))
                 g.Save();
 
-            return new CilResult(
-                g.Assembly,
-                _linker.TypeMap,
-                g.Locations);
+            return new CilResult(g.Assembly, _linker.TypeMap, g.Locations);
         }
     }
 }

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.Generate.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.Generate.cs
@@ -28,11 +28,9 @@ namespace Uno.Compiler.Backends.CIL
             for (int i = 0, l = root.Types.Count; i < l; i++)
             {
                 var dt = root.Types[i];
-                // TODO: Enable this again when shader generator doesn't generate invalid code because of 'virtual apply'
-                /*
-                if (dt.Source.Package != _package)
+                if (dt.Package != _package)
                     continue;
-                */
+
                 var dotNetName = dt.HasAttribute(_essentials.DotNetTypeAttribute)
                     ? dt.TryGetAttributeString(_essentials.DotNetTypeAttribute) ?? dt.CilTypeName()
                     : null;

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.cs
@@ -43,7 +43,7 @@ namespace Uno.Compiler.Backends.CIL
             _linker = linker;
             _outputDir = outputDir;
             _assembly = _linker.Universe.DefineDynamicAssembly(
-                new AssemblyName(package.Name) /*{Version = new Version(package.Version)}*/, 
+                new AssemblyName(package.Name) {Version = package.ParseVersion(Log)},
                 AssemblyBuilderAccess.Save,
                 outputDir);
             _module = _assembly.DefineDynamicModule(

--- a/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/CilGenerator.cs
@@ -75,14 +75,14 @@ namespace Uno.Compiler.Backends.CIL
             try
             {
                 // Embed resources (bundle files)
-                if (_package.IsStartup)
+                foreach (var file in _data.Extensions.BundleFiles)
                 {
-                    foreach (var file in _data.Extensions.BundleFiles)
-                    {
-                        var stream = File.OpenRead(file.SourcePath);
-                        streams.Add(stream); // Add it here before we give the stream away
-                        _module.DefineManifestResource(file.TargetName, stream, ResourceAttributes.Public);
-                    }
+                    if (file.Package != _package)
+                        continue;
+
+                    var stream = File.OpenRead(file.SourcePath);
+                    streams.Add(stream); // Add it here before we give the stream away
+                    _module.DefineManifestResource(file.TargetName, stream, ResourceAttributes.Public);
                 }
 
                 // Output assembly

--- a/src/compiler/Uno.Compiler.Backends.CIL/Extensions.cs
+++ b/src/compiler/Uno.Compiler.Backends.CIL/Extensions.cs
@@ -4,6 +4,7 @@ using Uno.Compiler.API.Domain;
 using Uno.Compiler.API.Domain.IL;
 using Uno.Compiler.API.Domain.IL.Expressions;
 using Uno.Compiler.API.Domain.IL.Members;
+using Uno.Logging;
 using ParameterModifier = Uno.Compiler.API.Domain.ParameterModifier;
 using Type = IKVM.Reflection.Type;
 
@@ -180,6 +181,38 @@ namespace Uno.Compiler.Backends.CIL
                     return p.OptionalDefault is Constant 
                         ? ParameterAttributes.Optional 
                         : 0;
+            }
+        }
+
+        public static Version ParseVersion(this SourcePackage package, Log log)
+        {
+            var str = package.Version;
+
+            if (string.IsNullOrEmpty(str))
+                return new Version();
+
+            // Remove suffix
+            var i = str.IndexOf('-');
+            if (i != -1)
+            {
+                str = str.Substring(0, i);
+                if (string.IsNullOrEmpty(str))
+                    return new Version();
+            }
+
+            // Check that version string only contains numbers or periods (X.X.X)
+            foreach (var c in str)
+                if (!char.IsNumber(c) && c != '.')
+                    return new Version();
+
+            try
+            {
+                return new Version(str);
+            }
+            catch
+            {
+                log.Warning(package.Source, null, "Failed to parse version string " + str.Quote());
+                return new Version();
             }
         }
     }

--- a/src/compiler/Uno.Compiler.Backends.Metadata/MetadataGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.Metadata/MetadataGenerator.cs
@@ -30,7 +30,7 @@ namespace Uno.Compiler.Backends.Metadata
             _linker = linker;
             _outputDir = outputDir;
             _assembly = _linker.Universe.DefineDynamicAssembly(
-                new AssemblyName(package.Name),
+                new AssemblyName(package.Name) {Version = package.ParseVersion(Log)},
                 AssemblyBuilderAccess.Save,
                 outputDir);
             var module = _assembly.DefineDynamicModule(

--- a/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.cs
+++ b/src/compiler/Uno.Compiler.Core/IL/Validation/ILVerifier.cs
@@ -156,8 +156,7 @@ namespace Uno.Compiler.Core.IL.Validation
 
                 if (Backend.Has(TypeOptions.IgnoreProtection))
                     return true;
-                // TODO: Enable this again when shader generator doesn't generate invalid code because of 'virtual apply'
-                /*
+
                 if (!entity.IsAccessibleFrom(Type.Source))
                 {
                     Log.Error(src, ErrorCode.E0000,
@@ -165,7 +164,6 @@ namespace Uno.Compiler.Core.IL.Validation
                         entity.Package.Name + " isn't referenced by " + Type.Package.Name);
                     return false;
                 }
-                */
             }
 
             return VerifyAccessibleEntity(src, entity, Type, ((Entity)Function ?? Type) ?? Block, IsPublicMetaProperty);

--- a/src/compiler/Uno.Compiler.Core/Syntax/Binding/NameResolver.MetaProperty.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Binding/NameResolver.MetaProperty.cs
@@ -40,11 +40,7 @@ namespace Uno.Compiler.Core.Syntax.Binding
                         HashSet<DataType> subs;
                         if (_compiler.BlockBuilder.FlattenedTypes.TryGetValue(dt, out subs))
                             foreach (var st in subs)
-                                // TODO: Enable this again when shader generator doesn't generate invalid code because of 'virtual apply'
-                                /*
                                 if (st?.Block != null && st.IsAccessibleFrom(block.Source))
-                                */
-                                if (st?.Block != null)
                                     FindMetaPropertiesRecursive(st.Block, name, visited, result);
                     }
                 }

--- a/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
@@ -150,18 +150,18 @@ namespace Uno.Compiler.Core.Syntax.Builders
             return AddCached("Shader", () => program, block.Method.DeclaringType.UnoName, block);
         }
 
-        public Expression AddBundleFile(Source src, string filename)
+        public Expression AddFile(Source src, string filename)
         {
             return AddCached("File",
                 () =>
                 {
                     var file = CreateFile(src, filename).BundleName;
-                    return GetBundleFile(src, file);
+                    return GetFile(src, file);
                 },
                 filename);
         }
 
-        Expression GetBundleFile(Source src, string file)
+        Expression GetFile(Source src, string file)
         {
             return _ilf.CallMethod(
                 src,

--- a/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
@@ -32,8 +32,6 @@ namespace Uno.Compiler.Core.Syntax.Builders
         readonly ILFactory _ilf;
         readonly Compiler _compiler;
 
-        string IBundle.Directory => _env.BundleDirectory;
-
         public BundleBuilder(
             Backend backend,
             BuildEnvironment env,
@@ -145,11 +143,6 @@ namespace Uno.Compiler.Core.Syntax.Builders
             }
             if (dt.Initializer.HasBody)
                 dt.Initializer.Body.Statements.Add(new StoreField(value.Source, null, field, value));
-        }
-
-        public Expression Add(Expression e)
-        {
-            return AddCached("Expression", () => e, e);
         }
 
         public Expression AddProgram(DrawBlock block, Expression program)

--- a/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Builders/BundleBuilder.cs
@@ -103,6 +103,31 @@ namespace Uno.Compiler.Core.Syntax.Builders
             using (var f = _compiler.Disk.CreateBufferedText(bundlesFile))
                 f.Write(string.Join("\n", bundles));
             _compiler.Data.Extensions.BundleFiles.Add(new BundleFile(_compiler.Input.Package, "bundles", bundlesFile));
+
+            // Deprecated: The 'bundle' file is no longer used, but may be used directly by 3rdparty code.
+            {
+                var index = new List<string>();
+
+                foreach (var e in packages)
+                {
+                    var line = new List<string> {e.Name};
+                    var files = _files.GetList(e);
+                    files.Sort((a, b) => a.BundleName.CompareTo(b.BundleName));
+
+                    foreach (var f in files)
+                    {
+                        line.Add(f.BundleName);
+                        line.Add(f.TargetName);
+                    }
+
+                    index.Add(string.Join(":", line));
+                }
+
+                var bundleFile = Path.Combine(_env.CacheDirectory, "bundle");
+                using (var f = _compiler.Disk.CreateBufferedText(bundleFile))
+                    f.Write(string.Join("\n", index));
+                _compiler.Data.Extensions.BundleFiles.Add(new BundleFile(_compiler.Input.Package, "bundle", bundleFile));
+            }
         }
 
         void Emit(Field field)

--- a/src/compiler/Uno.Compiler.Core/Syntax/Compilers/FunctionCompiler.Expressions.Import.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Compilers/FunctionCompiler.Expressions.Import.cs
@@ -12,7 +12,7 @@ namespace Uno.Compiler.Core.Syntax.Compilers
                 return Expression.Invalid;
 
             Compiler.Disk.GetFullPath(import.Importer.Source, ref filename);
-            return Compiler.BundleBuilder.AddBundleFile(import.Importer.Source, filename);
+            return Compiler.BundleBuilder.AddFile(import.Importer.Source, filename);
         }
     }
 }

--- a/src/compiler/Uno.Compiler.Core/Syntax/Generators/DrawCallGenerator.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Generators/DrawCallGenerator.cs
@@ -161,12 +161,7 @@ namespace Uno.Compiler.Core.Syntax.Generators
 
                         foreach (var st in subArray.Reverse())
                         {
-                            // TODO: Enable this again when shader generator doesn't generate invalid code because of 'virtual apply'
-                            /*
                             if (st.IsAbstract || st.Block == null || !st.IsAccessibleFrom(apply.Source))
-                                continue;
-                            */
-                            if (st.IsAbstract || st.Block == null)
                                 continue;
 
                             var obj = new AsOp(apply.Object.Source, apply.Object, st);


### PR DESCRIPTION
This changes the compiler and CIL backend to emit one .NET assembly per Uno library, rather than one monolithic assembly containing all Uno libraries, which we did before for historical reasons.

This makes it easier to use assemblies built by Uno in other .NET projects, optimize build times by not rebuilding code that is already built, and to cache/prebuild assemblies to further optimize build times. We're also eliminating the need for generated C# projects (`Uno.Runtime.Core`), the C# backend and `corelib` target, because it's now trivial to build `UnoCore.dll` directly using Uno.