### PR TITLE
TestRunner: Timeout fix after dropping HTTP

### DIFF
--- a/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
@@ -17,8 +17,6 @@ namespace Uno.TestRunner.BasicTypes
         public string Filter;
         public bool Trace;
         public bool OnlyBuild;
-        public bool AllowDebugger;
-        public bool OpenDebugger;
         public bool NoUninstall;
         public bool Library;
         public string OutputDirectory;
@@ -48,8 +46,8 @@ namespace Uno.TestRunner.BasicTypes
                 { "startup-timeout=", "Timeout for connection from uno process (in seconds)", (int v) => Console.Error.WriteLine("WARNING: --startup-timeout is deprecated and has no effect.") },
                 { "trace", "Print trace information from unotest", v => { commandOptions.Trace = v != null; } },
                 { "only-build", "Don't run compiled program.",  v => commandOptions.OnlyBuild = v != null },
-                { "allow-debugger", "Don't run compiled program, allow user to start it from a debugger.",  v => commandOptions.AllowDebugger = v != null },
-                { "d|debug", "Open IDE for debugging tests.",  v => commandOptions.OpenDebugger = v != null },
+                { "allow-debugger", "Don't run compiled program, allow user to start it from a debugger.",  v => Console.Error.WriteLine("WARNING: --allow-debugger is deprecated and has no effect.") },
+                { "d|debug", "Open IDE for debugging tests.",  v => Console.Error.WriteLine("WARNING: --debug is deprecated and has no effect.") },
                 { "run-local", "Run the test directly (not used)",  v => Console.Error.WriteLine("WARNING: --run-local is deprecated and has no effect.") },
                 { "no-uninstall", "Don't uninstall tests after running on device", v => commandOptions.NoUninstall = v != null },
                 { "D=|define=", "Add define, to enable a feature", commandOptions.Defines.Add },

--- a/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
@@ -15,7 +15,6 @@ namespace Uno.TestRunner.BasicTypes
         public BuildTarget Target;
         public bool Verbose;
         public string Filter;
-        public string Browser;
         public bool Trace;
         public bool OnlyBuild;
         public bool AllowDebugger;

--- a/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/CommandLineOptions.cs
@@ -13,8 +13,6 @@ namespace Uno.TestRunner.BasicTypes
         public List<string> Paths;
         public string LogFileName;
         public BuildTarget Target;
-        public TimeSpan TestTimeout;
-        public TimeSpan StartupTimeout;
         public bool Verbose;
         public string Filter;
         public string Browser;
@@ -34,11 +32,7 @@ namespace Uno.TestRunner.BasicTypes
             var verbose = false;
             var quiet = false;
 
-            var commandOptions = new CommandLineOptions
-            {
-                TestTimeout = TimeSpan.FromSeconds(10),
-                StartupTimeout = TimeSpan.FromMinutes(1),
-            };
+            var commandOptions = new CommandLineOptions();
 
             string targetName = null;
             var p = new OptionSet
@@ -51,8 +45,8 @@ namespace Uno.TestRunner.BasicTypes
                 { "q|quiet", "Quiet, only prints output from compiler and debug_log in case of errors.", v => quiet = v != null },
                 { "f|filter=", "Only run tests matching this string", v => commandOptions.Filter = Regex.Escape(v) },
                 { "e|regex-filter=", "Only run tests matching this regular expression", v => commandOptions.Filter = v },
-                { "o|timeout=", "Timeout for individual tests (in seconds)", (int v) => { commandOptions.TestTimeout = TimeSpan.FromSeconds(v); } },
-                { "startup-timeout=", "Timeout for connection from uno process (in seconds)", (int v) => { commandOptions.StartupTimeout = TimeSpan.FromSeconds(v); } },
+                { "o|timeout=", "Timeout for individual tests (in seconds)", (int v) => Console.Error.WriteLine("WARNING: --timeout is deprecated and has no effect.") },
+                { "startup-timeout=", "Timeout for connection from uno process (in seconds)", (int v) => Console.Error.WriteLine("WARNING: --startup-timeout is deprecated and has no effect.") },
                 { "trace", "Print trace information from unotest", v => { commandOptions.Trace = v != null; } },
                 { "only-build", "Don't run compiled program.",  v => commandOptions.OnlyBuild = v != null },
                 { "allow-debugger", "Don't run compiled program, allow user to start it from a debugger.",  v => commandOptions.AllowDebugger = v != null },
@@ -74,12 +68,6 @@ namespace Uno.TestRunner.BasicTypes
 
                 if (verbose && quiet)
                     throw new ArgumentException("Cannot specify both -q and -v");
-
-                if (commandOptions.AllowDebugger || commandOptions.OpenDebugger)
-                {
-                    commandOptions.StartupTimeout = TimeSpan.FromDays(1);
-                    commandOptions.TestTimeout = TimeSpan.FromDays(1);
-                }
             }
             catch (OptionException e)
             {

--- a/src/testing/Uno.TestRunner.BasicTypes/Test.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/Test.cs
@@ -2,7 +2,7 @@
 
 namespace Uno.TestRunner.BasicTypes
 {
-    [DebuggerDisplay("{Name} {Status > TestStatus.NotRun}")]
+    [DebuggerDisplay("{Name} {_status > TestStatus.NotRun}")]
     public class Test
     {
         public enum TestStatus
@@ -16,12 +16,14 @@ namespace Uno.TestRunner.BasicTypes
 
         public string Name { get; }
         public int Microseconds { get; private set; }
-        public TestStatus Status { get; private set; }
-        public bool Ended => Status > TestStatus.Started;
-        public bool Failed => Status == TestStatus.Failed;
+        public bool Ended => _status > TestStatus.Started;
+        public bool Failed => _status == TestStatus.Failed;
+        public bool WasIgnored => _status == TestStatus.Ignored;
         public Assertion Assertion { get; private set; }
         public string Exception { get; private set; }
         public string IgnoreReason { get; private set; }
+
+        TestStatus _status;
 
         public Test(string name)
         {
@@ -30,30 +32,30 @@ namespace Uno.TestRunner.BasicTypes
 
         public void Asserted(Assertion assertion)
         {
-            Status = TestStatus.Failed;
+            _status = TestStatus.Failed;
             Assertion = assertion;
         }
 
         public void Threw(string exception)
         {
-            Status = TestStatus.Failed;
+            _status = TestStatus.Failed;
             Exception = exception;
         }
 
         public void Passed(int microseconds = -1)
         {
             Microseconds = microseconds;
-            Status = TestStatus.Passed;
+            _status = TestStatus.Passed;
         }
 
         public void Started()
         {
-            Status = TestStatus.Started;
+            _status = TestStatus.Started;
         }
 
         public void Ignored(string reason)
         {
-            Status = TestStatus.Ignored;
+            _status = TestStatus.Ignored;
             IgnoreReason = reason;
         }
     }

--- a/src/testing/Uno.TestRunner.BasicTypes/Test.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/Test.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Uno.TestRunner.BasicTypes
 {
-    [DebuggerDisplay("{Name} {_started!=null}")]
+    [DebuggerDisplay("{Name} {_started}")]
     public class Test
     {
         public enum TestStatus
@@ -12,18 +11,17 @@ namespace Uno.TestRunner.BasicTypes
             Passed,
             Ignored,
             Failed
-        };
+        }
 
         public string Name { get; }
         public int Microseconds { get; private set; }
         public TestStatus Status { get; private set; }
         public bool Ended => Status != TestStatus.NotRun;
         public bool Failed => Status == TestStatus.Failed;
-        public bool HasTimedOut { get; private set; }
         public Assertion Assertion { get; private set; }
         public string Exception { get; private set; }
         public string IgnoreReason { get; private set; }
-        private DateTime? _started;
+        private bool _started;
 
         public Test(string name)
         {
@@ -42,13 +40,6 @@ namespace Uno.TestRunner.BasicTypes
             Exception = exception;
         }
 
-        public void TimedOut(double seconds)
-        {
-            Status = TestStatus.Failed;
-            Exception = string.Format("Test timed out after {0} seconds", seconds);
-            HasTimedOut = true;
-        }
-
         public void Passed(int microseconds = -1)
         {
             Microseconds = microseconds;
@@ -57,25 +48,13 @@ namespace Uno.TestRunner.BasicTypes
 
         public void Started()
         {
-            _started = DateTime.Now;
+            _started = true;
         }
 
         public void Ignored(string reason)
         {
             Status = TestStatus.Ignored;
             IgnoreReason = reason;
-        }
-
-        public TimeSpan Duration
-        {
-            get
-            {
-                if (_started == null)
-                {
-                    return new TimeSpan(0);
-                }
-                return DateTime.Now - _started.Value;
-            }
         }
     }
 }

--- a/src/testing/Uno.TestRunner.BasicTypes/Test.cs
+++ b/src/testing/Uno.TestRunner.BasicTypes/Test.cs
@@ -2,12 +2,13 @@
 
 namespace Uno.TestRunner.BasicTypes
 {
-    [DebuggerDisplay("{Name} {_started}")]
+    [DebuggerDisplay("{Name} {Status > TestStatus.NotRun}")]
     public class Test
     {
         public enum TestStatus
         {
             NotRun,
+            Started,
             Passed,
             Ignored,
             Failed
@@ -16,12 +17,11 @@ namespace Uno.TestRunner.BasicTypes
         public string Name { get; }
         public int Microseconds { get; private set; }
         public TestStatus Status { get; private set; }
-        public bool Ended => Status != TestStatus.NotRun;
+        public bool Ended => Status > TestStatus.Started;
         public bool Failed => Status == TestStatus.Failed;
         public Assertion Assertion { get; private set; }
         public string Exception { get; private set; }
         public string IgnoreReason { get; private set; }
-        private bool _started;
 
         public Test(string name)
         {
@@ -48,7 +48,7 @@ namespace Uno.TestRunner.BasicTypes
 
         public void Started()
         {
-            _started = true;
+            Status = TestStatus.Started;
         }
 
         public void Ignored(string reason)

--- a/src/testing/Uno.TestRunner.Loggers/ConsoleLogger.cs
+++ b/src/testing/Uno.TestRunner.Loggers/ConsoleLogger.cs
@@ -96,7 +96,7 @@ namespace Uno.TestRunner.Loggers
                 ColorHelper.SetForeground(ConsoleColor.Red);
                 Write("Failures: {0}", failures);
             }
-            int ignores = tests.Count(t => t.Status == Test.TestStatus.Ignored);
+            int ignores = tests.Count(t => t.WasIgnored);
             if (ignores > 0)
             {
                 ColorHelper.SetForeground(ConsoleColor.Yellow);

--- a/src/testing/Uno.TestRunner.Tests/TestRunTests.cs
+++ b/src/testing/Uno.TestRunner.Tests/TestRunTests.cs
@@ -10,13 +10,10 @@ namespace Uno.TestRunner.Tests
 {
     class TestRunTests
     {
-        private readonly TimeSpan _arbitraryLongTimeout = TimeSpan.FromSeconds(10);
-        private TimeSpan _veryShortTimeout = TimeSpan.FromTicks(1);
-
         [Test]
         public void ThrowsOnIncorrectState()
         {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _arbitraryLongTimeout, _arbitraryLongTimeout);
+            var run = new TestRun(new Mock<ITestResultLogger>().Object);
             Assert.Throws<InvalidOperationException>(() => run.EventOccured(MakeReadyEvent(1)));
             run.Start();
 
@@ -31,7 +28,7 @@ namespace Uno.TestRunner.Tests
         [Test]
         public void StartupSequenceIsCorrect()
         {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _arbitraryLongTimeout, _arbitraryLongTimeout);
+            var run = new TestRun(new Mock<ITestResultLogger>().Object);
             Assert.AreEqual(TestRun.State.NotStarted, run.CurrentState);
             run.Start();
             Assert.AreEqual(TestRun.State.WaitingForReady, run.CurrentState);
@@ -46,7 +43,7 @@ namespace Uno.TestRunner.Tests
         [Test]
         public void RunsAllTestsInCorrectOrder()
         {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _arbitraryLongTimeout, _arbitraryLongTimeout);
+            var run = new TestRun(new Mock<ITestResultLogger>().Object);
             run.Start();
             run.EventOccured(MakeReadyEvent(2));
             run.EventOccured(MakeTestStartedEvent("foo"));
@@ -57,39 +54,6 @@ namespace Uno.TestRunner.Tests
 
             var result = run.WaitUntilFinished();
             Assert.AreEqual(new string[]{ "foo", "bar" }, result.Select(test => test.Name));
-        }
-
-        [Test]
-        public void CancelsTheRestWhenATestTimesOut()
-        {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _veryShortTimeout, _arbitraryLongTimeout);
-            run.Start();
-            run.EventOccured(MakeReadyEvent(3));
-            run.EventOccured(MakeTestStartedEvent("foo"));
-            Thread.Sleep(2);
-            var tests = run.WaitUntilFinished();
-            Assert.IsTrue(tests[0].HasTimedOut);
-            Assert.IsFalse(tests[1].HasTimedOut);
-            Assert.IsFalse(tests[2].HasTimedOut);
-            Assert.IsTrue(tests.TrueForAll(t=>t.Failed));
-        }
-
-        [Test]
-        public void StoredErrorsAreThrownFromWaitUntilFinished()
-        {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _veryShortTimeout, _arbitraryLongTimeout);
-            run.ErrorOccured(new Exception("foo"));
-            var e = Assert.Throws<AggregateException>(() => run.WaitUntilFinished());
-            Assert.AreEqual(1, e.InnerExceptions.Count);
-            Assert.AreEqual("foo", e.InnerExceptions[0].Message);
-        }
-
-        [Test]
-        public void ThrowsIfItNeverHearsFromUnoExe()
-        {
-            var run = new TestRun(new Mock<ITestResultLogger>().Object, _arbitraryLongTimeout, TimeSpan.FromTicks(1));
-            run.Start();
-            Assert.Throws<Exception>(() => run.WaitUntilFinished());
         }
 
         private static NameValueCollection MakeReadyEvent(int testCount)

--- a/src/testing/Uno.TestRunner/TestProjectRunner.cs
+++ b/src/testing/Uno.TestRunner/TestProjectRunner.cs
@@ -59,13 +59,6 @@ namespace Uno.TestRunner
                     options.Defines.AddRange(_options.Defines);
                     options.Undefines.AddRange(_options.Undefines);
 
-                    if (_options.OpenDebugger)
-                    {
-                        options.RunArguments = "debug";
-                        options.Native = false; // disable native build
-                        options.Defines.Add("DEBUG_NATIVE"); // disable native optimizations
-                    }
-
                     var builder = new ProjectBuilder(log, target, options);
                     var result = builder.Build(proj);
                     if (result.ErrorCount != 0)
@@ -81,15 +74,11 @@ namespace Uno.TestRunner
                     Task runTask = null;
                     try
                     {
-                        if (!_options.AllowDebugger)
-                            runTask = Task.Run(() => result.RunAsync(targetLog, cts.Token), cts.Token);
+                        runTask = Task.Run(() => result.RunAsync(targetLog, cts.Token), cts.Token);
                         _testRun.Start();
 
-
                         tests = _testRun.WaitUntilFinished();
-                        if (runTask != null)
-                            runFinished = runTask.Wait(100);
-
+                        runFinished = runTask.Wait(100);
                     }
                     finally
                     {

--- a/src/testing/Uno.TestRunner/TestProjectRunner.cs
+++ b/src/testing/Uno.TestRunner/TestProjectRunner.cs
@@ -35,7 +35,7 @@ namespace Uno.TestRunner
             List<Test> tests = new List<Test>();
             try
             {
-                _testRun = new TestRun(_logger, _options.TestTimeout, _options.StartupTimeout);
+                _testRun = new TestRun(_logger);
 
                 var cts = new CancellationTokenSource();
                 bool runFinished = false;

--- a/src/testing/Uno.TestRunner/TestRun.cs
+++ b/src/testing/Uno.TestRunner/TestRun.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Threading;
 using Uno.TestRunner.BasicTypes;
 using Uno.TestRunner.Loggers;
@@ -16,7 +15,6 @@ namespace Uno.TestRunner
         private int _testCount = -1;
         private State _currentState = State.NotStarted;
         private readonly ManualResetEvent _isFinished = new ManualResetEvent(false);
-        private readonly Stopwatch _runningTime = new Stopwatch();
         private readonly List<Exception> _errors = new List<Exception>();
 
         public TestRun(ITestResultLogger logger)
@@ -30,7 +28,6 @@ namespace Uno.TestRunner
                 throw new InvalidOperationException("Unexpected 'ready'-event");
 
             _currentState = State.WaitingForReady;
-            _runningTime.Start();
         }
 
         public State CurrentState => _currentState;

--- a/src/testing/Uno.TestRunner/TestRun.cs
+++ b/src/testing/Uno.TestRunner/TestRun.cs
@@ -52,11 +52,6 @@ namespace Uno.TestRunner
             }
         }
 
-        public bool IsFinished()
-        {
-            return _isFinished.WaitOne(0);
-        }
-
         public void Update()
         {
             lock (_lock)

--- a/src/testing/Uno.TestRunner/TestRun.cs
+++ b/src/testing/Uno.TestRunner/TestRun.cs
@@ -16,18 +16,12 @@ namespace Uno.TestRunner
         private int _testCount = -1;
         private State _currentState = State.NotStarted;
         private readonly ManualResetEvent _isFinished = new ManualResetEvent(false);
-        private readonly TimeSpan _testTimeout;
-        private readonly TimeSpan _testTimeoutCheckInterval;
-        private readonly TimeSpan _startupTimeout;
         private readonly Stopwatch _runningTime = new Stopwatch();
         private readonly List<Exception> _errors = new List<Exception>();
 
-        public TestRun(ITestResultLogger logger, TimeSpan testTimeout, TimeSpan startupTimeout)
+        public TestRun(ITestResultLogger logger)
         {
             _logger = logger;
-            _testTimeout = testTimeout;
-            _startupTimeout = startupTimeout;
-            _testTimeoutCheckInterval = TimeSpan.FromMilliseconds(Math.Min((int)_testTimeout.TotalMilliseconds, 1000));
         }
 
         public void Start()
@@ -56,54 +50,22 @@ namespace Uno.TestRunner
         {
             lock (_lock)
             {
-                CheckForStartupTimeout();
                 CheckForErrors();
-                CheckForTimeout();
             }
         }
 
         public List<Test> WaitUntilFinished()
         {
-            while (!_isFinished.WaitOne(_testTimeoutCheckInterval))
+            while (!_isFinished.WaitOne())
                 Update();
 
             return _tests;
-        }
-
-        private void CheckForStartupTimeout()
-        {
-            if (_currentState < State.Running && _runningTime.ElapsedMilliseconds > _startupTimeout.TotalMilliseconds)
-            {
-                throw new Exception("Timed out while waiting for uno process to connect.");
-            }
         }
 
         private void CheckForErrors()
         {
             if (_errors.Count > 0)
                 throw new AggregateException(_errors);
-        }
-
-        private void CheckForTimeout()
-        {
-            if (CurrentTest != null && CurrentTest.Duration > _testTimeout)
-            {
-                CurrentTest.TimedOut(CurrentTest.Duration.TotalSeconds);
-                _logger.TestThrew(CurrentTest);
-
-                // fake skipping of all unfinished tests
-                for (int i = _tests.Count; i < _testCount; ++i)
-                {
-                    var dummyTest = new Test(string.Format("UnknownTest{0}", i));
-                    _tests.Add(dummyTest);
-
-                    CurrentTest.Threw("Previous test timed out");
-                    _logger.TestThrew(CurrentTest);
-                }
-
-                _currentState = State.Finished;
-                _isFinished.Set();
-            }
         }
 
         public void EventOccured(NameValueCollection eventDetails)


### PR DESCRIPTION
After dropping HTTP support in #283, we've seen tests timing out when it takes a long time to run the test suite (https://travis-ci.org/fuse-open/fuselibs/builds/643739010#L1714).

This PR fixes the problem by also dropping the timeout functionality, so now running tests will never time out inside the test runner. On AppVeyor and Travis, builds will automatically time out after one hour in any case.