### PR TITLE
Android - default settings update

### DIFF
--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/colors.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="splashColor">@(Project.Android.Splash.SplashBackgroundColor)</color>
+    <color name="splashColor">@(Project.Android.Splash.SplashBackgroundColor || '#9846EF')</color>
 </resources>

--- a/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
         <item name="android:windowBackground">@android:color/transparent</item>
 #endif
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'true')</item>
+        <item name="android:windowIsTranslucent">@(Project.Android.WindowIsTranslucent || 'false')</item>
     </style>
 
 </resources>


### PR DESCRIPTION
- Added default background color for default splash
- Fixed the translucent window setting to default to false, this fixes strange behaviour with or without orientation: https://www.reddit.com/r/androiddev/comments/ap5zdm/dont_use_windowistranslucent_together_with

https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o

Should only use when necessary: https://tech.pic-collage.com/something-about-android-windowistranslucent-641cc02ff66f