### PR TITLE
Launch screen storyboard on iOS

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 /* Begin PBXBuildFile section */
 		5AB0DAB318F6CF6C00975F8B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5AB0DAB218F6CF6C00975F8B /* Images.xcassets */; };
 		5A4940FC151D17AD000ACE3F /* data in Resources */ = {isa = PBXBuildFile; fileRef = 5A4940FB151D17AD000ACE3F /* data */; };
+		5F0322E02410910C00F663AF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5F0322DF2410910C00F663AF /* LaunchScreen.storyboard */; };
+		5FEB853A2417246600A63124 /* default-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 5FEB85392417246500A63124 /* default-logo.png */; };
 		@(Pbxproj.PBXBuildFiles)
 /* End PBXBuildFile section */
 
@@ -32,6 +34,8 @@
 
 /* Begin PBXFileReference section */
 		5AB0DAB218F6CF6C00975F8B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "@(Project.Name)/Images.xcassets"; sourceTree = "<group>"; };
+		5F0322DF2410910C00F663AF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = "LaunchScreen.storyboard"; path = "@(Project.Name)/LaunchScreen.storyboard"; sourceTree = "<group>"; };
+		5FEB85392417246500A63124 /* default-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = default-logo.png; path = @(Project.Name)/default-logo.png; sourceTree = "<group>"; };
 #if @(LIBRARY:Defined)
 		5A493DA5151A216A000ACE3F /* $(Project.Name).framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "@(Project.Name).framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 #else
@@ -105,6 +109,8 @@
 		5A4940F1151BFBA0000ACE3F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				5FEB85392417246500A63124 /* default-logo.png */,
+				5F0322DF2410910C00F663AF /* LaunchScreen.storyboard */,
 				5A4940FB151D17AD000ACE3F /* data */,
 				5AB0DAB218F6CF6C00975F8B /* Images.xcassets */,
 			);
@@ -269,7 +275,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				5AB0DAB318F6CF6C00975F8B /* Images.xcassets in Resources */,
+				5FEB853A2417246600A63124 /* default-logo.png in Resources */,
 				5A4940FC151D17AD000ACE3F /* data in Resources */,
+				5F0322E02410910C00F663AF /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -456,7 +464,7 @@
 			buildSettings = {
 #if !@(LIBRARY:Defined)
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 #endif
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				CODE_SIGN_ENTITLEMENTS = "@(Project.Name)/@(Project.Name).entitlements";
@@ -509,7 +517,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				CODE_SIGN_ENTITLEMENTS = "@(Project.Name)/@(Project.Name).entitlements";
 #if @(Pbxproj.DevelopmentTeam:IsSet)

--- a/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
@@ -217,6 +217,7 @@
 	<key>UIViewEdgeAntialiasing</key>
 	<@(Project.iOS.PList.UIViewEdgeAntialiasing:Bool)/>
 #endif
-
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 </dict>
 </plist>

--- a/lib/UnoCore/Targets/iOS/@(Project.Name)/LaunchScreen.storyboard
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name)/LaunchScreen.storyboard
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16085" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16078.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleAspectFit" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="default-logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="ipq-tU-Fa4">
+                                <rect key="frame" x="171" y="412" width="64" height="64"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
+                                </accessibility>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstItem="ipq-tU-Fa4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="b81-Gv-hNX"/>
+                            <constraint firstItem="ipq-tU-Fa4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="rUV-qd-hr3"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="default-logo.png" width="64" height="64"/>
+    </resources>
+</document>

--- a/lib/UnoCore/Targets/iOS/iOS.uxl
+++ b/lib/UnoCore/Targets/iOS/iOS.uxl
@@ -48,11 +48,16 @@
     <ProcessFile Name="@(Project.Name)/@(Project.Name)-Info.plist" />
     <ProcessFile Name="@(Project.Name)/@(Project.Name)-Prefix.pch" />
     <ProcessFile Name="@(Project.Name)/@(Project.Name).entitlements" />
+    <ProcessFile Name="@(Project.Name)/LaunchScreen.storyboard" />
     <ProcessFile Name="build.sh" IsExecutable=true />
     <ProcessFile Name="run.sh" IsExecutable=true />
     <ProcessFile Name="Podfile" Condition="COCOAPODS" />
 
     <!-- Icons -->
+
+    <!-- Default logo for Launch Screen Storyboard -->
+    <ImageFile Name="@(Project.iOS.Icons.iPhone_40_3x:Path || '@//Assets/DefaultIcon.png')"
+        TargetWidth="64" TargetName="@(Project.Name)/default-logo.png" />
 
     <Set Icons="@(Project.Name)/Images.xcassets/AppIcon.appiconset" />
     <ProcessFile Name="@(Icons)/Contents.json" />

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -459,6 +459,7 @@
     "Targets/iOS/@(Project.Name)/@(Project.Name).entitlements:File",
     "Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist:File",
     "Targets/iOS/@(Project.Name)/@(Project.Name)-Prefix.pch:File",
+    "Targets/iOS/@(Project.Name)/LaunchScreen.storyboard:File",
     "Targets/iOS/@(Schemes)/@(Project.Name).xcscheme:File",
     "Targets/iOS/@(Schemes)/xcschememanagement.plist:File",
     "Targets/iOS/build.sh:File",

--- a/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
+++ b/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
@@ -55,7 +55,7 @@ namespace Uno.ProjectFormat
             {"iOS.BundleName", PropertyType.String, "$(Title)"},
             {"iOS.BundleVersion", PropertyType.String, "$(Version)"},
             {"iOS.Defines", PropertyType.String},
-            {"iOS.DeploymentTarget", PropertyType.String, "8.0"},
+            {"iOS.DeploymentTarget", PropertyType.String, "9.0"},
             {"iOS.DevelopmentTeam", PropertyType.String},
             {"iOS.Icons.iPhone_20_2x", PropertyType.Path, "$(Icon)"},
             {"iOS.Icons.iPhone_20_3x", PropertyType.Path, "$(Icon)"},


### PR DESCRIPTION
Xcode project generated by Uno now using `LaunchScreen.storyboard` instead of LaunchImages to comply with new rules from Apple. More info: https://developer.apple.com/news/?id=03042020b

We also bump minimal ios version to ver 9.0