### PR TITLE
Android: opt-in Kotlin support

### DIFF
--- a/lib/UnoCore/Targets/Android/Dependencies.uxl
+++ b/lib/UnoCore/Targets/Android/Dependencies.uxl
@@ -14,4 +14,9 @@
     <Require Gradle.Dependency.Implementation="androidx.legacy:legacy-support-v4:1.0.0" />
     <Require Gradle.Dependency.Implementation="androidx.multidex:multidex:2.0.1" />
 
+    <!-- Kotlin support. -->
+    <Require Condition="KOTLIN" Gradle.Dependency.Implementation="androidx.core:core-ktx:+" />
+    <Require Condition="KOTLIN" Gradle.Dependency.Implementation="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70" />
+    <Require Condition="KOTLIN" Gradle.Dependency.ClassPath="org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70" />
+
 </Extensions>

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -1,4 +1,8 @@
 apply plugin: 'com.android.@(LIBRARY:Defined:Test('library', 'application'))'
+#if @(KOTLIN:Defined)
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+#endif
 
 configurations { native_implementation }
 


### PR DESCRIPTION
This adds opt-in Kotlin support to Android Gradle projects.

1) Add Kotlin-files using UXL:
```
    <CopyFile Condition="ANDROID" JavaFile="org/foo/Bar.kt" />
```
2) Pass `-DKOTLIN` to enable Kotlin support:
```
    uno build android -DKOTLIN
```