### PR TITLE
FuseJS.Transpiler: upgrade to minimist 1.2.5

### DIFF
--- a/lib/FuseJS.Transpiler/src/package-lock.json
+++ b/lib/FuseJS.Transpiler/src/package-lock.json
@@ -3134,9 +3134,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",


### PR DESCRIPTION
This upgrades minimist to silence security warning in GitHub.

I tried rebuilding the minified JavaScript after upgrading, but `server.min.js` came out identical as before. No problem.