### PR TITLE
UnoCore: make GraphicsController.UpdateBackbuffer() public

### DIFF
--- a/lib/UnoCore/Source/Uno/Graphics/GraphicsController.uno
+++ b/lib/UnoCore/Source/Uno/Graphics/GraphicsController.uno
@@ -21,7 +21,7 @@ namespace Uno.Graphics
             UpdateBackbuffer();
         }
 
-        internal void UpdateBackbuffer()
+        public void UpdateBackbuffer()
         {
             if defined(OPENGL)
                 _backbuffer.GLFramebufferHandle = _backend.GetBackbufferGLHandle();


### PR DESCRIPTION
This method is used by Fuse Studio and needs to be public.