### PR TITLE
Uno.ProjectFormat: use $npm_package_version as default version

### DIFF
--- a/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
+++ b/src/engine/Uno.ProjectFormat/PropertyDefinitions.cs
@@ -12,7 +12,7 @@ namespace Uno.ProjectFormat
             {"CacheDirectory", PropertyType.Path, ".uno"},
             {"OutputDirectory", PropertyType.Path, "$(BuildDirectory)/@(Target)/@(Configuration)"},
             {"RootNamespace", PropertyType.String, "$(QIdentifier)"},
-            {"Version", PropertyType.String, "0.1.0"},
+            {"Version", PropertyType.String, Environment.GetEnvironmentVariable("npm_package_version") ?? "0.1.0"},
             {"VersionCode", PropertyType.Integer, 1},
             {"Title", PropertyType.String, "$(Name)"},
             {"Icon", PropertyType.Path},


### PR DESCRIPTION
This will use the version number specified in package.json, if available,
when Uno is invoked via a npm-script, unless an explicit version number was
specified in the project file or on the command-line.

With this, we no longer need Bash to forward the version number from
package.json onto Uno in a cross-platform way. This should make it a little
bit easier to maintain Uno packages using NPM.

See package.json in Fuselibs for an example.