### PR TITLE
Add FaceID usage description

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
@@ -147,6 +147,11 @@
 	<string>@(Project.iOS.PList.NSMotionUsageDescription)</string>
 #endif
 
+#if @(Project.iOS.PList.NSFaceIDUsageDescription:IsSet)
+	<key>NSFaceIDUsageDescription</key>
+	<string>@(Project.iOS.PList.NSFaceIDUsageDescription)</string>
+#endif
+
 #if @(FontFile:IsRequired)
 	<key>UIAppFonts</key>
 	<array>


### PR DESCRIPTION
Now you can add `NSFaceIDUsageDescription` on your `iOS Plist` attribute in the `unoproj`