### PR TITLE
Compiler: fix bug/regression with incremental .NET builds

### DIFF
--- a/src/compiler/Uno.Compiler.API/Domain/IL/EntityStats.cs
+++ b/src/compiler/Uno.Compiler.API/Domain/IL/EntityStats.cs
@@ -14,6 +14,7 @@ namespace Uno.Compiler.API.Domain.IL
         GenericMethodType = 1 << 7,
         ImplementsInterface = 1 << 8,
         ThrowsException = 1 << 9,
-        CanLink = 1 << 10
+        CanLink = 1 << 10,
+        IsCompiled = 1 << 11,
     }
 }

--- a/src/compiler/Uno.Compiler.Core/Syntax/Builders/TypeBuilder.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Builders/TypeBuilder.cs
@@ -45,9 +45,14 @@ namespace Uno.Compiler.Core.Syntax.Builders
         void EnqueueCompiler(FunctionCompiler fc)
         {
             if (fc.Body != null)
+            {
                 _enqueuedCompilers.Add(fc);
+                fc.Function.Tag = fc;
+            }
             else if (_compiler.Backend.CanLink(fc.Function))
+            {
                 fc.Function.Stats |= EntityStats.CanLink;
+            }
         }
 
         void EnqueueType(DataType dt, Action<DataType> assignBaseType, Action<DataType> populate)

--- a/src/compiler/Uno.Compiler.Core/Syntax/Generators/Passes/ShaderProcessor.cs
+++ b/src/compiler/Uno.Compiler.Core/Syntax/Generators/Passes/ShaderProcessor.cs
@@ -8,6 +8,7 @@ using Uno.Compiler.API.Domain.IL.Statements;
 using Uno.Compiler.API.Domain.IL.Types;
 using Uno.Compiler.Core.IL;
 using Uno.Compiler.Core.IL.Utilities;
+using Uno.Compiler.Core.Syntax.Compilers;
 
 namespace Uno.Compiler.Core.Syntax.Generators.Passes
 {
@@ -151,8 +152,15 @@ namespace Uno.Compiler.Core.Syntax.Generators.Passes
 
                 if (!f.HasBody)
                 {
-                    Log.Error(e.Source, ErrorCode.E5010, f.Quote() + " is pure intrinsic and is not supported by current shader backend (in " + Generator.Path.Quote() + ")");
-                    return false;
+                    // Attempt lazy compile.
+                    var fc = f.MasterDefinition.Tag as FunctionCompiler;
+                    fc?.Compile(true);
+
+                    if (!f.HasBody)
+                    {
+                        Log.Error(e.Source, ErrorCode.E5010, f.Quote() + " is pure intrinsic and is not supported by current shader backend (in " + Generator.Path.Quote() + ")");
+                        return false;
+                    }
                 }
 
                 result = new ShaderFunction(f.Source, Shader, f.UnoName.ToIdentifier() + "_" + Generator.ShaderGlobalCounter++, f.ReturnType, null);


### PR DESCRIPTION
Attempt to lazy-compile when encountering functions that aren't compiled in
ShaderProcessor. This can happen when an up-to-date version of a function's
assembly can be loaded from disk.

Before #282 this bug triggered only on methods pre-compiled in Uno.Runtime.Core.dll,
and after the bug started triggering on any method from another package.

This PR should fix the bug for all methods.