### PR TITLE
Use nullptr in C++-code

### DIFF
--- a/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.cpp.uxl
+++ b/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.cpp.uxl
@@ -52,7 +52,7 @@ return result;
         <Method Signature="InstallCache_IMPL_44279(Android.Base.Wrappers.IJWrapper,long):bool">
             <Body>
 INIT_JNI;
-jobject _obArg0 = ((!$0) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
+jobject _obArg0 = ((!$0) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
 @{bool} result;
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{InstallCache_44279_ID},@{_javaClass},"InstallCache","(Landroid/app/Activity;J)Z",GetStaticMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.InstallCache could not be cached",93);
@@ -66,7 +66,7 @@ return result;
         <Method Signature="CacheRenew_IMPL_44280(Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg0 = ((!$0) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
+jobject _obArg0 = ((!$0) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{CacheRenew_44280_ID},@{_javaClass},"CacheRenew","(Landroid/app/Activity;)V",GetStaticMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.CacheRenew could not be cached",91);
 U_JNIVAR->CallStaticVoidMethod(@{_javaClass}, @{CacheRenew_44280_ID}, _obArg0);
@@ -125,9 +125,9 @@ if ($0) {
     CLASS_INIT(@{_javaProxyClass},@{_InitProxy():Call()});
     CACHE_METHOD(@{HttpRequest_44284_ID_c_prox},@{_javaProxyClass},"<init>","(JLandroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V",GetMethodID,"Proxy Id for method Android_com_fuse_ExperimentalHttp_HttpRequest.HttpRequest_44284_ID_c_prox could not be cached",113);
 }
-jobject _obArg1 = ((!$1) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($1)._GetJavaObject():Call()});
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
-jobject _obArg3 = ((!$3) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
+jobject _obArg1 = ((!$1) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($1)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg3 = ((!$3) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
 jobject result;
 jobject _tmp;
 if (!$0) {
@@ -166,8 +166,8 @@ else
         <Method Signature="SetHeader_IMPL_44293(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
-jobject _obArg3 = ((!$3) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg3 = ((!$3) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{SetHeader_44293_ID},@{_javaClass},"SetHeader","(Ljava/lang/String;Ljava/lang/String;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.SetHeader could not be cached",90);
 if ($0) {
@@ -221,7 +221,7 @@ else
         <Method Signature="CacheResponseString_IMPL_44296(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{CacheResponseString_44296_ID},@{_javaClass},"CacheResponseString","(Ljava/lang/String;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.CacheResponseString could not be cached",100);
 if ($0) {
@@ -277,7 +277,7 @@ else
         <Method Signature="SendAsyncBuf_IMPL_44300(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{SendAsyncBuf_44300_ID},@{_javaClass},"SendAsyncBuf","(Ljava/nio/ByteBuffer;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.SendAsyncBuf could not be cached",93);
 if ($0) {
@@ -295,7 +295,7 @@ else
         <Method Signature="SendAsyncStr_IMPL_44301(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{SendAsyncStr_44301_ID},@{_javaClass},"SendAsyncStr","(Ljava/lang/String;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.SendAsyncStr could not be cached",93);
 if ($0) {
@@ -313,9 +313,9 @@ else
         <Method Signature="UploadDone_IMPL_44302(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper,Android.Base.Wrappers.IJWrapper,int,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
-jobject _obArg3 = ((!$3) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
-jobject _obArg5 = ((!$5) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($5)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg3 = ((!$3) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($3)._GetJavaObject():Call()});
+jobject _obArg5 = ((!$5) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($5)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{UploadDone_44302_ID},@{_javaClass},"UploadDone","(Ljava/io/BufferedInputStream;Ljava/util/HashMap;ILjava/lang/String;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.UploadDone could not be cached",91);
 if ($0) {
@@ -351,7 +351,7 @@ else
         <Method Signature="StartDownload_IMPL_44304(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper)">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{StartDownload_44304_ID},@{_javaClass},"StartDownload","(Ljava/io/InputStream;)V",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.StartDownload could not be cached",94);
 if ($0) {
@@ -407,7 +407,7 @@ return result;
         <Method Signature="GetResponseHeader_IMPL_44307(bool,Android.Base.Primitives.ujobject,Android.Base.Wrappers.IJWrapper):Android.Base.Wrappers.IJWrapper">
             <Body>
 INIT_JNI;
-jobject _obArg2 = ((!$2) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$2) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($2)._GetJavaObject():Call()});
 @{Android.Base.Wrappers.IJWrapper} result;
 CLASS_INIT(@{_javaClass},@{_Init():Call()});
 CACHE_METHOD(@{GetResponseHeader_44307_ID},@{_javaClass},"GetResponseHeader","(Ljava/lang/String;)Ljava/lang/String;",GetMethodID,"Id for fallback method com.fuse.ExperimentalHttp.HttpRequest.GetResponseHeader could not be cached",98);

--- a/lib/Uno.Net.Http/Implementation/Xli/XliHttpEventHandler.h
+++ b/lib/Uno.Net.Http/Implementation/Xli/XliHttpEventHandler.h
@@ -16,7 +16,7 @@ class uXliHttpEventHandler: public Xli::HttpEventHandler
 
     static void CompleteUnoRequest(Xli::HttpRequest *request)
     {
-        request->SetUserData(NULL);
+        request->SetUserData(nullptr);
     }
 
 public:
@@ -29,7 +29,7 @@ public:
                 @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
                     = GetUnoRequest(request);
 
-                if (unoRequest == NULL)
+                if (unoRequest == nullptr)
                     return;
 
                 uAutoReleasePool pool;
@@ -43,7 +43,7 @@ public:
                 @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
                     = GetUnoRequest(request);
 
-                if (unoRequest == NULL)
+                if (unoRequest == nullptr)
                     return;
 
                 uAutoReleasePool pool;
@@ -62,7 +62,7 @@ public:
         @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
             = GetUnoRequest(request);
 
-        if (unoRequest == NULL)
+        if (unoRequest == nullptr)
             return;
 
         uAutoReleasePool pool;
@@ -74,7 +74,7 @@ public:
         @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
             = GetUnoRequest(request);
 
-        if (unoRequest == NULL)
+        if (unoRequest == nullptr)
             return;
 
         uAutoReleasePool pool;
@@ -87,7 +87,7 @@ public:
         @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
             = GetUnoRequest(request);
 
-        if (unoRequest == NULL)
+        if (unoRequest == nullptr)
             return;
 
         uAutoReleasePool pool;
@@ -100,7 +100,7 @@ public:
         @{Uno.Net.Http.HttpMessageHandlerRequest} unoRequest
             = GetUnoRequest(request);
 
-        if (unoRequest == NULL)
+        if (unoRequest == nullptr)
             return;
 
         uAutoReleasePool pool;

--- a/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.cpp.uxl
+++ b/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.cpp.uxl
@@ -30,7 +30,7 @@
                 if (@{$$._requestHandle}->TryGetResponseHeader(uCString($0).Ptr, result))
                     return uString::Utf8(result.Ptr());
                 else
-                    return NULL;
+                    return nullptr;
             </Body>
         </Method>
 

--- a/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.uno
+++ b/lib/Uno.Net.Http/Implementation/Xli/XliHttpRequest.uno
@@ -52,7 +52,7 @@ namespace Uno.Net.Http.Implementation
         public void Dispose()
         {
             extern(_requestHandle) "$0->Release()";
-            _requestHandle = extern<XliHttpRequestHandle> "NULL";
+            _requestHandle = extern<XliHttpRequestHandle> "nullptr";
             _request = null; // AutoRelease request object so it's deleted later
         }
 

--- a/lib/Uno.Net.Http/Implementation/iOS/HttpRequest.mm
+++ b/lib/Uno.Net.Http/Implementation/iOS/HttpRequest.mm
@@ -17,7 +17,7 @@ namespace {
 
     NSString *uString2NSString(uString *str)
     {
-        if (str == NULL)
+        if (str == nullptr)
             return nil;
 
         return [NSString stringWithCharacters:(const unichar *)str->_ptr length:str->_length];
@@ -26,7 +26,7 @@ namespace {
     uString *NSString2uString(NSString *str)
     {
         if (str == nil)
-            return NULL;
+            return nullptr;
 
         NSUInteger length = str.length;
 
@@ -257,7 +257,7 @@ uString *HttpRequest::GetResponseHeaders() const
     }];
 
     if (resultLength == 0)
-        return NULL;
+        return nullptr;
 
     uString *result = uString::New((int) (resultLength - 1));
     __block char16_t *ptr = result->_ptr;

--- a/lib/Uno.Net.Http/Implementation/iOS/iOSHttpRequest.uno
+++ b/lib/Uno.Net.Http/Implementation/iOS/iOSHttpRequest.uno
@@ -21,7 +21,7 @@ namespace Uno.Net.Http.Implementation
         public void Dispose()
         {
             extern(_requestHandle) "delete $0";
-            _requestHandle = extern<iOSHttpRequestHandle> "NULL";
+            _requestHandle = extern<iOSHttpRequestHandle> "nullptr";
         }
 
         public void EnableCache(bool enableCache)
@@ -52,7 +52,7 @@ namespace Uno.Net.Http.Implementation
 
         public void SendAsync()
         {
-            extern(_requestHandle) "$0->SendAsync(NULL, 0)";
+            extern(_requestHandle) "$0->SendAsync(nullptr, 0)";
         }
 
         public void Abort()

--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -19,7 +19,7 @@ namespace Uno.Net
         @{
             ifaddrs *addr, *curr;
             if (getifaddrs(&addr) != 0)
-                return NULL;
+                return nullptr;
 
             std::vector<@{IPAddress}> addresses;
             for (curr = addr; curr; curr = curr->ifa_next)
@@ -100,10 +100,10 @@ namespace Uno.Net
         @{
             char *tmp = uAllocCStr(hostNameOrAddress);
             struct addrinfo *addr, *curr;
-            int error = getaddrinfo(tmp, NULL, NULL, &addr);
+            int error = getaddrinfo(tmp, nullptr, nullptr, &addr);
             free(tmp);
             if (error != 0)
-                return NULL;
+                return nullptr;
 
             std::vector<@{IPAddress}> addresses;
             for (curr = addr; curr; curr = curr->ai_next)

--- a/lib/Uno.Net.Sockets/IPAddress.uno
+++ b/lib/Uno.Net.Sockets/IPAddress.uno
@@ -142,7 +142,7 @@ namespace Uno.Net
             free(tmp);
 
             if (err != 1)
-                return NULL;
+                return nullptr;
 
             return uArray::New(@{byte[]:TypeOf}, int(sizeof(struct in6_addr)), buf);
         @}
@@ -212,8 +212,8 @@ namespace Uno.Net
 
             char buf[INET6_ADDRSTRLEN];
             const char *ret = inet_ntop(AF_INET6, &addr, buf, INET6_ADDRSTRLEN);
-            if (ret == NULL)
-                return NULL;
+            if (ret == nullptr)
+                return nullptr;
 
             return uString::Utf8(ret);
         @}

--- a/lib/Uno.Net.Sockets/NetworkHelpers.uno
+++ b/lib/Uno.Net.Sockets/NetworkHelpers.uno
@@ -13,9 +13,9 @@ namespace Uno.Net
             if (err == 0)
                 return uString::Utf8("Unknown error");
 
-            LPSTR buf = NULL;
+            LPSTR buf = nullptr;
             DWORD size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                                        NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&buf, 0, NULL);
+                                        nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&buf, 0, nullptr);
             if (size == 0)
                 return uString::Utf8("Unknown error (FormatMessage failed)");
 

--- a/lib/Uno.Net.Sockets/Socket.uno
+++ b/lib/Uno.Net.Sockets/Socket.uno
@@ -101,7 +101,7 @@ namespace Uno.Net.Sockets
 
             int result = getsockname(sock, (sockaddr *)&ss, &len);
             if (result < 0)
-                return NULL;
+                return nullptr;
 
             sockaddr_in *sa = (sockaddr_in *)&ss;
             @{IPAddress} ipAddress;
@@ -126,7 +126,7 @@ namespace Uno.Net.Sockets
 
             int result = getpeername(sock, (sockaddr *)&ss, &len);
             if (result < 0)
-                return NULL;
+                return nullptr;
 
             sockaddr_in *sa = (sockaddr_in *)&ss;
             @{IPAddress} ipAddress;
@@ -208,16 +208,16 @@ namespace Uno.Net.Sockets
 
             switch (mode)
             {
-                case @{SelectMode.Read}:  return select((int)sock + 1, &fds, NULL, NULL, &timeout);
-                case @{SelectMode.Write}: return select((int)sock + 1, NULL, &fds, NULL, &timeout);
-                case @{SelectMode.Error}: return select((int)sock + 1, NULL, NULL, &fds, &timeout);
+                case @{SelectMode.Read}:  return select((int)sock + 1, &fds, nullptr, nullptr, &timeout);
+                case @{SelectMode.Write}: return select((int)sock + 1, nullptr, &fds, nullptr, &timeout);
+                case @{SelectMode.Error}: return select((int)sock + 1, nullptr, nullptr, &fds, &timeout);
                 default: U_THROW(@{Uno.Exception(string):New(uString::Utf8("Invalid value for ProtocolType"))});
             }
         @}
 
         public static Socket.SocketHandle Accept(Socket.SocketHandle sock)
         @{
-            return accept(sock, NULL, NULL);
+            return accept(sock, nullptr, nullptr);
         @}
 
         extern(MSVC) public static int Ioctl(Socket.SocketHandle sock, int request, out int arg)

--- a/lib/Uno.Threading/Implementation/Posix/PthreadHelpers.uno
+++ b/lib/Uno.Threading/Implementation/Posix/PthreadHelpers.uno
@@ -46,7 +46,7 @@ namespace Uno.Threading
         @{
             uPosixSemaphore* semaphoreHandle = uPosixCreateSemaphore(initialCount, maxCount);
 
-            if (semaphoreHandle == NULL)
+            if (semaphoreHandle == nullptr)
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("uPosixCreateSemaphore() failed!"))});
 
             return semaphoreHandle;
@@ -83,7 +83,7 @@ namespace Uno.Threading
         @{
             uPosixResetEvent *resetEventHandle = uPosixCreateResetEvent(initialState, autoReset);
 
-            if (resetEventHandle == NULL)
+            if (resetEventHandle == nullptr)
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("uPosixCreateResetEvent() failed!"))});
 
             return resetEventHandle;

--- a/lib/Uno.Threading/Implementation/Posix/posix_reset_event.cpp
+++ b/lib/Uno.Threading/Implementation/Posix/posix_reset_event.cpp
@@ -7,8 +7,8 @@ uPosixResetEvent* uPosixCreateResetEvent(bool initialState, bool autoReset)
 {
     uPosixResetEvent* resetEvent = new uPosixResetEvent();
 
-    pthread_mutex_init(&resetEvent->mutex, NULL);
-    pthread_cond_init(&resetEvent->cond, NULL);
+    pthread_mutex_init(&resetEvent->mutex, nullptr);
+    pthread_cond_init(&resetEvent->cond, nullptr);
     resetEvent->flag = initialState;
     resetEvent->autoReset = autoReset;
 
@@ -40,7 +40,7 @@ bool uPosixWaitOneResetEvent(uPosixResetEvent* resetEvent, int timeoutMillis)
     pthread_mutex_lock(&resetEvent->mutex);
 
     struct timeval now;
-    gettimeofday(&now, NULL);
+    gettimeofday(&now, nullptr);
     uint64_t nanoseconds = (now.tv_sec * 1000000000ull) + (now.tv_usec * 1000);
     uint64_t timeoutNanoseconds = (timeoutMillis * 1000000ull) + nanoseconds;
 

--- a/lib/Uno.Threading/Implementation/Posix/posix_semaphore.cpp
+++ b/lib/Uno.Threading/Implementation/Posix/posix_semaphore.cpp
@@ -8,11 +8,11 @@ uPosixSemaphore* uPosixCreateSemaphore(int initialCount, int maxCount)
 {
     uPosixSemaphore *ret = new uPosixSemaphore();
 
-    if (pthread_mutex_init(&ret->mutex, NULL) != 0 ||
-        pthread_cond_init(&ret->cond, NULL) != 0)
+    if (pthread_mutex_init(&ret->mutex, nullptr) != 0 ||
+        pthread_cond_init(&ret->cond, nullptr) != 0)
     {
         delete ret;
-        return NULL;
+        return nullptr;
     }
 
     ret->count = initialCount;
@@ -30,7 +30,7 @@ void uPosixDisposeSemaphore(uPosixSemaphore* semaphoreHandle)
 bool uPosixWaitOneSemaphore(uPosixSemaphore* semaphoreHandle, int timeoutMillis)
 {
     struct timeval now;
-    gettimeofday(&now, NULL);
+    gettimeofday(&now, nullptr);
     uint64_t nanoseconds = (now.tv_sec * 1000000000ull) + (now.tv_usec * 1000);
     uint64_t timeoutNanoseconds = (timeoutMillis * 1000000ull) + nanoseconds;
 

--- a/lib/Uno.Threading/Implementation/Win32/Win32Helpers.uno
+++ b/lib/Uno.Threading/Implementation/Win32/Win32Helpers.uno
@@ -26,9 +26,9 @@ namespace Uno.Threading
         [Require("Source.Include", "@{Uno.Exception:Include}")]
         public static MutexHandle CreateMutex()
         @{
-            HANDLE mutexHandle = ::CreateMutexW(NULL, false, NULL);
+            HANDLE mutexHandle = ::CreateMutexW(nullptr, false, nullptr);
 
-            if (mutexHandle == NULL)
+            if (mutexHandle == nullptr)
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("CreateMutex failed!"))});
 
             return mutexHandle;
@@ -55,9 +55,9 @@ namespace Uno.Threading
         [Require("Source.Include", "Uno/WinAPIHelper.h")]
         public static SemaphoreHandle CreateSemaphore(int initialCount, int maxCount)
         @{
-            HANDLE semaphoreHandle = ::CreateSemaphoreW(NULL, $0, $1, NULL);
+            HANDLE semaphoreHandle = ::CreateSemaphoreW(nullptr, $0, $1, nullptr);
 
-            if (semaphoreHandle == NULL)
+            if (semaphoreHandle == nullptr)
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("CreateSemaphoreW failed!"))});
 
             return semaphoreHandle;
@@ -90,9 +90,9 @@ namespace Uno.Threading
         [Require("Source.Include", "Uno/WinAPIHelper.h")]
         public static ResetEventHandle CreateResetEvent(bool initialState, bool autoReset)
         @{
-            HANDLE resetEventHandle = ::CreateEvent(NULL, autoReset, initialState, NULL);
+            HANDLE resetEventHandle = ::CreateEvent(nullptr, autoReset, initialState, nullptr);
 
-            if (resetEventHandle == NULL)
+            if (resetEventHandle == nullptr)
                 U_THROW(@{Uno.Exception(string):New(uString::Utf8("CreateEvent failed!"))});
 
             return resetEventHandle;

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/GraphicsContext.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/GraphicsContext.h
@@ -17,7 +17,7 @@ struct uGraphicsContext
 
     uGraphicsContext()
     {
-        this->context = NULL;
+        this->context = nullptr;
     }
 
     GLuint GetBackbufferGLHandle()

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
@@ -97,8 +97,8 @@ uStackFrame::~uStackFrame()
 #endif
     _thread->CallStackPtr--;
 #ifdef DEBUG_UNSAFE
-    frame->Type = NULL;
-    frame->Function = NULL;
+    frame->Type = nullptr;
+    frame->Function = nullptr;
 #endif
 }
 
@@ -258,11 +258,11 @@ void uReleaseStruct(uType* type, void* address)
     {
         uObject*& ptr = *(uObject**)((uint8_t*)address + type->Refs.Strong[i]);
         uRelease(ptr);
-        ptr = NULL;
+        ptr = nullptr;
     }
 
     for (size_t i = 0; i < type->Refs.WeakCount; i++)
-        uStoreWeak((uWeakObject**)((uint8_t*)address + type->Refs.Weak[i]), NULL);
+        uStoreWeak((uWeakObject**)((uint8_t*)address + type->Refs.Weak[i]), nullptr);
 }
 
 void uAutoReleaseStruct(uType* type, void* address)
@@ -594,7 +594,7 @@ static bool uTryClearWeak_inner(uObject* object)
     }
 
     object->__weakptr->ZombieState = uWeakObject::Dead;
-    object->__weakptr->Object = NULL;
+    object->__weakptr->Object = nullptr;
     return true;
 }
 
@@ -611,7 +611,7 @@ static bool uTryClearWeak(uObject* object)
         if (--object->__weakptr->RefCount == 0)
             free(object->__weakptr);
 
-        object->__weakptr = NULL;
+        object->__weakptr = nullptr;
     }
 
     return true;
@@ -637,7 +637,7 @@ void uStoreWeak(uWeakObject** address, uObject* object)
 
     if (!object)
     {
-        *address = NULL;
+        *address = nullptr;
         return;
     }
 
@@ -655,8 +655,8 @@ static uObject* uLoadWeak_inner(uWeakObject* weak)
         if (!weak->ZombieStateIntercept(uWeakStateIntercept::OnLoad, weak->Object))
         {
             weak->ZombieState = uWeakObject::Dead;
-            weak->Object = NULL;
-            return NULL;
+            weak->Object = nullptr;
+            return nullptr;
         }
 
         weak->ZombieState = uWeakObject::Infected;
@@ -669,7 +669,7 @@ static uObject* uLoadWeak_inner(uWeakObject* weak)
 uObject* uLoadWeak(uWeakObject* weak)
 {
     if (!weak)
-        return NULL;
+        return nullptr;
 
     uObject* object = uCallWithWeakRefLock(&uLoadWeak_inner, weak);
     uAutoRelease(object);
@@ -900,7 +900,7 @@ static void uDumpStaticStrongRefs(FILE* fp, uType* type)
         if (U_IS_OBJECT(fieldInfo.Type) && ((fieldInfo.Flags & uFieldFlagsWeak) == 0) &&
             ((fieldInfo.Flags & uFieldFlagsStatic) != 0))
         {
-            uObject* target = field->GetValue(NULL);
+            uObject* target = field->GetValue(nullptr);
             if (target)
             {
                 uCString fieldName(field->Name);

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.h
@@ -110,7 +110,7 @@ struct uWeakStateIntercept
     //      count reaches zero the callback will be invoked again, per point 1.
     //
     //      Returning false from the callback signals that object deletion is
-    //      pending; uLoadWeak will return NULL.
+    //      pending; uLoadWeak will return nullptr.
     //
     //
     //  For a given object, the callback will be invoked at least once with
@@ -244,7 +244,7 @@ struct uSWeak
     uSWeak() {
     }
     uSWeak(T object)
-        : _object(NULL) {
+        : _object(nullptr) {
         uStoreWeak(&_object, (uObject*)object);
     }
     uSWeak<T>& operator =(T object) {
@@ -289,7 +289,7 @@ struct uStrong : uSStrong<T>
     using uSStrong<T>::operator =;
 
     uStrong() {
-        _object = NULL;
+        _object = nullptr;
     }
     uStrong(T object)
         : uSStrong<T>(object) {
@@ -309,13 +309,13 @@ struct uWeak : uSWeak<T>
     using uSWeak<T>::operator =;
 
     uWeak() {
-        _object = NULL;
+        _object = nullptr;
     }
     uWeak(T object)
         : uSWeak<T>(object) {
     }
     ~uWeak() {
-        uStoreWeak(&_object, NULL);
+        uStoreWeak(&_object, nullptr);
     }
 };
 /** @} */

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/NativeStackTrace.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/NativeStackTrace.cpp
@@ -64,16 +64,16 @@ uArray* uGetNativeStackTrace(int skipFrames)
 uArray* uGetNativeStackTrace(int skipFrames)
 {
     void* callStack[64];
-    int callStackDepth = CaptureStackBackTrace(skipFrames, sizeof(callStack) / sizeof(callStack[0]), callStack, NULL);
+    int callStackDepth = CaptureStackBackTrace(skipFrames, sizeof(callStack) / sizeof(callStack[0]), callStack, nullptr);
     return uArray::New(@{Uno.IntPtr[]:TypeOf}, callStackDepth, callStack);
 }
 
 #else
 
-// last resort, we don't have any way of getting a native stack-trace, return NULL :(
+// last resort, we don't have any way of getting a native stack-trace, return nullptr :(
 uArray* uGetNativeStackTrace(int skipFrames)
 {
-    return NULL;
+    return nullptr;
 }
 
 #endif

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
@@ -57,7 +57,7 @@ static void uBuildOperators(uType* type);
 static uType* uGetGenericType(size_t index);
 uType* uSwapThreadType(uType* type);
 
-void uInvoke(const void* func, void** args = NULL, size_t count = 0);
+void uInvoke(const void* func, void** args = nullptr, size_t count = 0);
 void uBuildMemory(uType* type);
 #if @(REFLECTION:Defined)
 void uBuildReflection(uType* type);
@@ -636,7 +636,7 @@ static void uVerifyBuild(uType* type)
             ? (uint8_t*)type + sizeof(uClassType) :
         type->Type == uTypeTypeStruct
             ? (uint8_t*)type + sizeof(uStructType)
-            : NULL;
+            : nullptr;
 
     // Verify that v-table is fully assigned (non-abstract type)
     if (vtable)
@@ -711,7 +711,7 @@ uType* uType::MakeMethod(size_t index, uType* first, ...)
     for (size_t i = 1; i < count; i++)
         key.Arguments[GenericCount + i] = U_ASSERT_PTR(va_arg(ap, uType*));
 
-    U_ASSERT(va_arg(ap, uType*) == NULL);
+    U_ASSERT(va_arg(ap, uType*) == nullptr);
     va_end(ap);
     return uGetParameterization(key);
 }
@@ -727,7 +727,7 @@ uType* uType::MakeType(uType* first, ...)
     for (size_t i = 1; i < GenericCount; i++)
         key.Arguments[i] = U_ASSERT_PTR(va_arg(ap, uType*));
 
-    U_ASSERT(va_arg(ap, uType*) == NULL);
+    U_ASSERT(va_arg(ap, uType*) == nullptr);
     va_end(ap);
     return uGetParameterization(key);
 }
@@ -965,7 +965,7 @@ uString* uString::Ansi(const char* cstr)
 {
     return cstr
         ? Ansi(cstr, strlen(cstr))
-        : NULL;
+        : nullptr;
 }
 
 uString* uString::Utf8(const char* mutf8, size_t length)
@@ -1033,7 +1033,7 @@ uString* uString::Utf8(const char* mutf8)
 {
     return mutf8
         ? Utf8(mutf8, strlen(mutf8))
-        : NULL;
+        : nullptr;
 }
 
 uString* uString::Utf16(const char16_t* utf16, size_t length)
@@ -1054,7 +1054,7 @@ uString* uString::Utf16(const char16_t* nullTerminatedUtf16)
         return Utf16(nullTerminatedUtf16, (size_t)length);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 uString* uString::CharArray(const uArray* array)
@@ -1126,7 +1126,7 @@ char* uAllocCStr(const uString* string, size_t* length)
     {
         if (length)
             *length = 0;
-        return NULL;
+        return nullptr;
     }
 
     // Convert UTF-16 to UTF-8
@@ -1411,7 +1411,7 @@ uObject* uBoxPtr(uType* type, const void* src, void* stack, bool ref)
         return object;
     }
     case uTypeTypeVoid:
-        return NULL;
+        return nullptr;
     default:
         return ref
             ? *U_ASSERT_PTR((uObject**)src)
@@ -1516,7 +1516,7 @@ void uDelegateType::SetSignature(uType* returnType, ...)
 
 void uDelegate::InvokeVoid()
 {
-    if (_prev != NULL)
+    if (_prev != nullptr)
         _prev->InvokeVoid();
 
     uDelegateType* type = (uDelegateType*)__type;
@@ -1536,7 +1536,7 @@ void uDelegate::InvokeVoid()
 
 void uDelegate::InvokeVoid(void* arg)
 {
-    if (_prev != NULL)
+    if (_prev != nullptr)
         _prev->InvokeVoid(arg);
 
     uDelegateType* type = (uDelegateType*)__type;
@@ -1556,7 +1556,7 @@ void uDelegate::InvokeVoid(void* arg)
 
 void uDelegate::Invoke(uTRef retval, void** args, size_t count)
 {
-    if (_prev != NULL)
+    if (_prev != nullptr)
         _prev->Invoke(retval, args, count);
 
     uDelegateType* type = (uDelegateType*)__type;
@@ -1595,7 +1595,7 @@ void uDelegate::Invoke(uTRef retval, size_t count, ...)
     va_start(ap, count);
     void** args = count > 0
         ? (void**)U_ALLOCA(count * sizeof(void*))
-        : NULL;
+        : nullptr;
 
     for (size_t i = 0; i < count; i++)
         args[i] = va_arg(ap, void*);
@@ -1609,7 +1609,7 @@ uObject* uDelegate::Invoke(uArray* array)
     uDelegateType* type = (uDelegateType*)GetType();
     size_t count = type->ParameterCount;
     uType** params = type->ParameterTypes;
-    void** args = NULL;
+    void** args = nullptr;
 
     if (array)
     {
@@ -1621,7 +1621,7 @@ uObject* uDelegate::Invoke(uArray* array)
         uObject** objects = (uObject**)array->Ptr();
         void** ptr = args = count > 0
             ? (void**)U_ALLOCA(count * sizeof(void*))
-            : NULL;
+            : nullptr;
 
         for (size_t i = 0; i < count; i++)
         {
@@ -1654,10 +1654,10 @@ uObject* uDelegate::Invoke(uArray* array)
     uType* returnType = type->ReturnType;
     void* retval = !U_IS_VOID(returnType)
         ? U_ALLOCA(returnType->ValueSize)
-        : NULL;
+        : nullptr;
 
     Invoke(retval, args, count);
-    return uBoxPtr(returnType, retval, NULL, true);
+    return uBoxPtr(returnType, retval, nullptr, true);
 }
 
 uObject* uDelegate::Invoke(size_t count, ...)
@@ -1666,7 +1666,7 @@ uObject* uDelegate::Invoke(size_t count, ...)
     va_start(ap, count);
     void** args = count > 0
         ? (void**)U_ALLOCA(count * sizeof(void*))
-        : NULL;
+        : nullptr;
 
     for (size_t i = 0; i < count; i++)
         args[i] = va_arg(ap, void*);
@@ -1675,10 +1675,10 @@ uObject* uDelegate::Invoke(size_t count, ...)
     uType* returnType = ((uDelegateType*)__type)->ReturnType;
     void* retval = !U_IS_VOID(returnType)
         ? U_ALLOCA(returnType->ValueSize)
-        : NULL;
+        : nullptr;
 
     Invoke(retval, args, count);
-    return uBoxPtr(returnType, retval, NULL, true);
+    return uBoxPtr(returnType, retval, nullptr, true);
 }
 
 uDelegate* uDelegate::Copy()

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -298,7 +298,7 @@ inline bool uIs(const uObject* object, const uType* type) {
 template<class T>
 T uAs(uObject* object, const uType* type) {
     U_ASSERT(sizeof(T) == type->ValueSize);
-    return object && object->__type->Is(type) ? (T)object : NULL;
+    return object && object->__type->Is(type) ? (T)object : nullptr;
 }
 template<class T>
 T uCast(uObject* object, const uType* type) {
@@ -390,13 +390,13 @@ struct uDelegate : uObject
     void InvokeVoid(void* arg);
     void Invoke(uTRef retval, void** args, size_t count);
     void Invoke(uTRef retval, size_t count = 0, ...);
-    uObject* Invoke(uArray* args = NULL);
+    uObject* Invoke(uArray* args = nullptr);
     uObject* Invoke(size_t count, ...);
     uDelegate* Copy();
 
-    static uDelegate* New(uType* type, const void* func, uObject* object = NULL, uType* generic = NULL);
-    static uDelegate* New(uType* type, uObject* object, size_t offset, uType* generic = NULL);
-    static uDelegate* New(uType* type, const uInterface& iface, size_t offset, uType* generic = NULL);
+    static uDelegate* New(uType* type, const void* func, uObject* object = nullptr, uType* generic = nullptr);
+    static uDelegate* New(uType* type, uObject* object, size_t offset, uType* generic = nullptr);
+    static uDelegate* New(uType* type, const uInterface& iface, size_t offset, uType* generic = nullptr);
 };
 /** @} */
 
@@ -414,11 +414,11 @@ struct uStructType : uType
     void(*fp_ToString_struct)(void*, uType*, uString**);
 };
 
-uObject* uBoxPtr(uType* type, const void* src, void* stack = NULL, bool ref = false);
+uObject* uBoxPtr(uType* type, const void* src, void* stack = nullptr, bool ref = false);
 void uUnboxPtr(uType* type, uObject* object, void* dst);
 
 template<class T>
-uObject* uBox(uType* type, const T& value, void* stack = NULL) {
+uObject* uBox(uType* type, const T& value, void* stack = nullptr) {
     U_ASSERT(type && type->ValueSize == sizeof(T));
     return uBoxPtr(type, &value, stack, true);
 }
@@ -514,7 +514,7 @@ struct uArray : uObject
         return ((uStrong<T>*)_ptr)[index];
     }
 
-    static uArray* New(uType* type, size_t length, const void* optionalData = NULL);
+    static uArray* New(uType* type, size_t length, const void* optionalData = nullptr);
     static uArray* InitT(uType* type, size_t length, ...);
 
     template<class T>
@@ -567,7 +567,7 @@ struct uString : uObject
 };
 
 // Leak warning: The returned string must be deleted using free()
-char* uAllocCStr(const uString* string, size_t* length = NULL);
+char* uAllocCStr(const uString* string, size_t* length = nullptr);
 // Deprecated: Use free() instead - the parameter type shouldn't be const
 void DEPRECATED("Use free() instead") uFreeCStr(const char* cstr);
 

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.cpp
@@ -11,7 +11,7 @@
 @{Uno.Type:IncludeDirective}
 
 uType* uGetParameterized(uType* type, uType* root);
-void uInvoke(const void* func, void** args = NULL, size_t count = 0);
+void uInvoke(const void* func, void** args = nullptr, size_t count = 0);
 
 static std::unordered_map<std::string, uType*>* _Types;
 
@@ -33,9 +33,9 @@ void uRegisterType(uType* type)
 void uRegisterIntrinsics()
 {
     @{object:TypeOf}->Reflection.SetFunctions(3,
-        new uFunction("Equals", NULL, NULL, offsetof(uType, fp_Equals), false, @{bool:TypeOf}, 1, @{object:TypeOf}),
-        new uFunction("GetHashCode", NULL, NULL, offsetof(uType, fp_GetHashCode), false, @{int:TypeOf}),
-        new uFunction("ToString", NULL, NULL, offsetof(uType, fp_ToString), false, @{string:TypeOf}));
+        new uFunction("Equals", nullptr, nullptr, offsetof(uType, fp_Equals), false, @{bool:TypeOf}, 1, @{object:TypeOf}),
+        new uFunction("GetHashCode", nullptr, nullptr, offsetof(uType, fp_GetHashCode), false, @{int:TypeOf}),
+        new uFunction("ToString", nullptr, nullptr, offsetof(uType, fp_ToString), false, @{string:TypeOf}));
 
     uRegisterType(@{object:TypeOf});
     uRegisterType(@{void:TypeOf});
@@ -76,7 +76,7 @@ void uBuildReflection(uType* type)
                 ? f->Generic->GenericCount > type->GenericCount
                     ? type->NewMethodType(f->Generic->GenericCount - type->GenericCount - 1)
                     : type
-                : NULL,
+                : nullptr,
             f->Flags,
             f->_func,
             uGetParameterized(f->ReturnType, type),
@@ -90,7 +90,7 @@ uType* uReflection::GetType(uString* name)
     auto it = _Types->find(cstr.Ptr);
     return it != _Types->end()
         ? it->second
-        : NULL;
+        : nullptr;
 }
 
 uArray* uReflection::GetTypes()
@@ -109,7 +109,7 @@ uArray* uReflection::GetTypes()
 uField* uReflection::GetField(uString* name)
 {
     if (!name)
-        return NULL;
+        return nullptr;
 
     uType* type = TYPE_PTR;
     U_ASSERT(type);
@@ -123,13 +123,13 @@ uField* uReflection::GetField(uString* name)
 
     return type->Base
         ? type->Base->Reflection.GetField(name)
-        : NULL;
+        : nullptr;
 }
 
 uFunction* uReflection::GetFunction(uString* name, uArray* parameterTypes)
 {
     if (!name)
-        return NULL;
+        return nullptr;
 
     uType* type = TYPE_PTR;
     U_ASSERT(type);
@@ -149,7 +149,7 @@ uFunction* uReflection::GetFunction(uString* name, uArray* parameterTypes)
 
     return type->Base
         ? type->Base->Reflection.GetFunction(name, parameterTypes)
-        : NULL;
+        : nullptr;
 }
 
 void uReflection::SetFields(size_t count, uField* first, ...)
@@ -196,7 +196,7 @@ void uReflection::SetFunctions(size_t count, uFunction* first, ...)
 
 uField::uField(const char* name, size_t index)
 {
-    DeclaringType = NULL; // Assigned by uReflection::SetFunctions()
+    DeclaringType = nullptr; // Assigned by uReflection::SetFunctions()
     Name = uString::Const(name);
     _index = index;
 }
@@ -223,7 +223,7 @@ uObject* uField::GetValue(uObject* object)
     U_ASSERT(DeclaringType);
     DeclaringType->Init();
     const uFieldInfo& field = Info();
-    return uBoxPtr(field.Type, FIELD_PTR, NULL, true);
+    return uBoxPtr(field.Type, FIELD_PTR, nullptr, true);
 }
 
 void uField::SetValue(uObject* object, uObject* value)
@@ -242,7 +242,7 @@ void uField::SetValue(uObject* object, uObject* value)
 uFunction::uFunction(const char* name, uType* generic, const void* func, size_t offset, bool isStatic, uType* returnType, size_t paramCount, ...)
 {
     U_ASSERT(name && returnType);
-    DeclaringType = NULL; // Assigned by uReflection::SetFunctions()
+    DeclaringType = nullptr; // Assigned by uReflection::SetFunctions()
     Name = uString::Const(name);
     Generic = generic;
     ReturnType = returnType;
@@ -320,14 +320,14 @@ uDelegate* uFunction::CreateDelegate(uType* type, uObject* object)
             ? uDelegate::New(type, uInterface(object, DeclaringType), _offset, Generic) :
         Flags & uFunctionFlagsVirtual
             ? uDelegate::New(type, object, _offset, Generic)
-            : uDelegate::New(type, _func, Flags & uFunctionFlagsStatic ? NULL : uPtr(object), Generic);
+            : uDelegate::New(type, _func, Flags & uFunctionFlagsStatic ? nullptr : uPtr(object), Generic);
 }
 
 uObject* uFunction::Invoke(uObject* object, uArray* args)
 {
     size_t count = ParameterTypes->Length();
 
-    void* retval = NULL;
+    void* retval = nullptr;
     if (!U_IS_VOID(ReturnType))
     {
         retval = U_ALLOCA(ReturnType->ValueSize);
@@ -345,7 +345,7 @@ uObject* uFunction::Invoke(uObject* object, uArray* args)
     void** stack;
     void** ptr = stack = count > 0
             ? (void**)U_ALLOCA(count * sizeof(void*))
-            : NULL;
+            : nullptr;
 
     if (!(Flags & uFunctionFlagsStatic))
         *ptr++ = !(Flags & uFunctionFlagsVirtual) && U_IS_VALUE(DeclaringType)
@@ -404,5 +404,5 @@ uObject* uFunction::Invoke(uObject* object, uArray* args)
             : _func,
         stack,
         count);
-    return uBoxPtr(ReturnType, retval, NULL, true);
+    return uBoxPtr(ReturnType, retval, nullptr, true);
 }

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.h
@@ -48,8 +48,8 @@ struct uFunction
               size_t flags, const void* funcOrOffset,
               uType* returnType, uArray* paramTypes);
 
-    uDelegate* CreateDelegate(uType* type, uObject* object = NULL);
-    uObject* Invoke(uObject* object = NULL, uArray* args = NULL);
+    uDelegate* CreateDelegate(uType* type, uObject* object = nullptr);
+    uObject* Invoke(uObject* object = nullptr, uArray* args = nullptr);
 };
 
 struct uReflection
@@ -62,7 +62,7 @@ struct uReflection
     size_t FunctionCount;
     uFunction** Functions;
     void SetFunctions(size_t count, uFunction* first, ...);
-    uFunction* GetFunction(uString* name, uArray* params = NULL);
+    uFunction* GetFunction(uString* name, uArray* params = nullptr);
 
     static uArray* GetTypes();
     static uType* GetType(uString* name);

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -42,7 +42,7 @@ void uLogv(int level, const char* format, va_list args);
 #define U_ERROR(...) uLog(uLogLevelError, __VA_ARGS__)
 
 // Kill switch
-U_NORETURN void uFatal(const char* src = NULL, const char* msg = NULL);
+U_NORETURN void uFatal(const char* src = nullptr, const char* msg = nullptr);
 #define U_FATAL(...) uFatal(U_SOURCE, "" __VA_ARGS__)
 
 // Asserts

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_internal.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_internal.h
@@ -39,7 +39,7 @@ struct uThreadData
         , AutoReleaseEnd(AutoReleaseStack + sizeof(AutoReleaseStack) / sizeof(AutoReleaseStack[0]))
         , CallStackPtr(CallStack - 1)
         , CallStackEnd(CallStack + sizeof(CallStack) / sizeof(CallStack[0]))
-        , CurrentType(NULL)
+        , CurrentType(nullptr)
     {
     }
 };
@@ -75,8 +75,8 @@ struct uTypeKey
     uType** Arguments;
 
     uTypeKey()
-        : Definition(NULL)
-        , Arguments(NULL)
+        : Definition(nullptr)
+        , Arguments(nullptr)
     {
     }
     uTypeKey(uType* def)
@@ -96,7 +96,7 @@ struct uTypeKey
         : Definition(copy.Definition)
     {
         if (!Definition)
-            Arguments = NULL;
+            Arguments = nullptr;
         else
         {
             U_ASSERT(copy.Arguments);
@@ -117,7 +117,7 @@ struct uTypeKey
         Definition = copy.Definition;
 
         if (!Definition)
-            Arguments = NULL;
+            Arguments = nullptr;
         else
         {
             Arguments = (uType**)malloc(Definition->GenericCount * sizeof(uType*));

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_main.cpp
@@ -302,7 +302,7 @@ struct uMainLoop : Xli::WindowEventHandler
     }
 };
 
-static void uUnhandledException(const char* msg, const char* function = NULL, int line = 0)
+static void uUnhandledException(const char* msg, const char* function = nullptr, int line = 0)
 {
     std::stringstream ss;
     ss << msg;
@@ -311,7 +311,7 @@ static void uUnhandledException(const char* msg, const char* function = NULL, in
 
     std::string str = ss.str();
     uLog(uLogLevelFatal, "Unhandled Exception: %s", str.c_str());
-    Xli::MessageBox::Show(NULL, str.c_str(), "Unhandled Exception", Xli::DialogButtonsOK, Xli::DialogHintsError);
+    Xli::MessageBox::Show(nullptr, str.c_str(), "Unhandled Exception", Xli::DialogButtonsOK, Xli::DialogHintsError);
 }
 
 int main(int argc, char** argv)
@@ -378,7 +378,7 @@ void uInitRtti()
     static uType*(*factories[])() =
     {
         @(TypeObjects.FunctionPointer:JoinSorted('\n        ', '', ','))
-        NULL
+        nullptr
     };
 
     uInitRtti(factories);

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_mainMobile.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_mainMobile.cpp
@@ -11,7 +11,7 @@ void uInitRtti()
     static uType*(*factories[])() =
     {
         @(TypeObjects.FunctionPointer:JoinSorted('\n        ', '', ','))
-        NULL
+        nullptr
     };
 
     uInitRtti(factories);

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/UnoArrayEntrypoints.uno
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/Android/UnoArrayEntrypoints.uno
@@ -190,7 +190,7 @@ namespace Uno.Compiler.ExportTargetInterop.Foreign.Android
                 _stringClass = global::Android.Base.JNI.NewGlobalRef(global::Android.Base.JNI.LoadClass("java/lang/String", true));
 
             var arr = ((string[])array);
-            var jarr = extern<global::Android.Base.Primitives.ujobject>(env, _stringClass, arr.Length) "$0->NewObjectArray((jsize)$2, $1, NULL)";
+            var jarr = extern<global::Android.Base.Primitives.ujobject>(env, _stringClass, arr.Length) "$0->NewObjectArray((jsize)$2, $1, nullptr)";
             for (int i=0; i<arr.Length; i++)
             {
                 var s = global::Android.Base.Types.String.UnoToJava(arr[i]);
@@ -210,7 +210,7 @@ namespace Uno.Compiler.ExportTargetInterop.Foreign.Android
                 _objectClass = global::Android.Base.JNI.NewGlobalRef(global::Android.Base.JNI.LoadClass("java/lang/Object", true));
 
             var arr = ((object[])array);
-            var jarr = extern<global::Android.Base.Primitives.ujobject>(env, _stringClass, arr.Length) "$0->NewObjectArray((jsize)$2, $1, NULL)";
+            var jarr = extern<global::Android.Base.Primitives.ujobject>(env, _stringClass, arr.Length) "$0->NewObjectArray((jsize)$2, $1, nullptr)";
             for (int i=0; i<arr.Length; i++)
             {
                 var o = JavaUnoObject.Box((object)arr[i]);

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/ObjC.uno
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/ObjC.uno
@@ -5,7 +5,7 @@ namespace ObjC
 {
     [Set("FileExtension", "mm")]
     [Set("TypeName", "::id")]
-    [Set("DefaultValue", "NULL")]
+    [Set("DefaultValue", "nullptr")]
     [Set("Include", "objc/objc.h")]
     public extern(FOREIGN_OBJC_SUPPORTED) struct ID
     {

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.mm
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.mm
@@ -14,7 +14,7 @@ namespace uObjC
 	{
 		if (!string)
 		{
-			return NULL;
+			return nullptr;
 		}
 		
 		NSUInteger bytes = [string
@@ -30,7 +30,7 @@ namespace uObjC
 			encoding: NativeUTF16Encoding
 			options: 0
 			range: NSMakeRange(0, [string length])
-			remainingRange: NULL])
+			remainingRange: nullptr])
 		{
 			if (usedBytes != bytes)
 			{
@@ -40,14 +40,14 @@ namespace uObjC
 			return result;
 		}
 	
-		return NULL;
+		return nullptr;
 	}
 	
 	NSString* NativeString(uString* string)
 	{
 		if (!string)
 		{
-			return NULL;
+			return nullptr;
 		}
 	
 		return [[NSString alloc]

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.mm
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.mm
@@ -14,7 +14,7 @@
 	getAt:(id (^) (uArray*, int))get
 	setAt:(void (^) (uArray*, int, id))set
 {
-	if (array == NULL)
+	if (array == nullptr)
 	{
 		return nil;
 	}
@@ -43,7 +43,7 @@
 
 - (id)init
 {
-	return [self initWithUnoArray: NULL getAt: nil setAt: nil];
+	return [self initWithUnoArray: nullptr getAt: nil setAt: nil];
 }
 
 - (instancetype)copyWithZone:(NSZone*)zone
@@ -88,7 +88,7 @@
 - (void)dealloc
 {
 	uRelease(_unoArray);
-	_unoArray = NULL;
+	_unoArray = nullptr;
 	self.getAt = nil;
 	self.setAt = nil;
 }

--- a/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoObject.mm
+++ b/lib/UnoCore/Source/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoObject.mm
@@ -11,7 +11,7 @@
 
 + (instancetype)strongUnoObjectWithUnoObject:(uObject*)object
 {
-	if (object == NULL)
+	if (object == nullptr)
 	{
 		return nil;
 	}
@@ -33,7 +33,7 @@
 
 - (id)init
 {
-	return [self initWithUnoObject: NULL];
+	return [self initWithUnoObject: nullptr];
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone
@@ -66,7 +66,7 @@
 - (void)dealloc
 {
 	uRelease(_unoObject);
-	_unoObject = NULL;
+	_unoObject = nullptr;
 }
 @end
 
@@ -79,7 +79,7 @@
 
 + (instancetype)weakUnoObjectWithUnoObject:(uObject*)object
 {
-	if (object == NULL)
+	if (object == nullptr)
 	{
 		return nil;
 	}
@@ -91,7 +91,7 @@
 	self = [super init];
 	if (self)
 	{
-		_weakObject = NULL;
+		_weakObject = nullptr;
 		uStoreWeak(&_weakObject, object);
 	}
 	return self;
@@ -99,14 +99,14 @@
 
 - (id)init
 {
-	return [self initWithUnoObject: NULL];
+	return [self initWithUnoObject: nullptr];
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {
 	WeakUnoObject *newRef = [[[self class] allocWithZone:zone] init];
 
-	newRef->_weakObject = NULL;
+	newRef->_weakObject = nullptr;
 
 	uObject *object = uLoadWeak(_weakObject);
 	uStoreWeak(&newRef->_weakObject, object);
@@ -127,7 +127,7 @@
 
 - (void)dealloc
 {
-	uStoreWeak(&_weakObject, NULL);
+	uStoreWeak(&_weakObject, nullptr);
 }
 @end
 
@@ -138,7 +138,7 @@
 
 + (instancetype)unsafeUnoObjectWithUnoObject:(uObject*)object
 {
-	if (object == NULL)
+	if (object == nullptr)
 	{
 		return nil;
 	}
@@ -157,7 +157,7 @@
 
 - (id)init
 {
-	return [self initWithUnoObject: NULL];
+	return [self initWithUnoObject: nullptr];
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone

--- a/lib/UnoCore/Source/Uno/Delegate.uno
+++ b/lib/UnoCore/Source/Uno/Delegate.uno
@@ -25,7 +25,7 @@ namespace Uno
                 uDelegate copy;
                 uDelegate *prev = &copy;
 
-                for (uDelegate* d = $1; d != NULL; d = d->_prev)
+                for (uDelegate* d = $1; d != nullptr; d = d->_prev)
                     prev = prev->_prev = d->Copy();
 
                 prev->_prev = $0;
@@ -39,19 +39,19 @@ namespace Uno
         {
             if defined(CPLUSPLUS)
             @{
-                if ($0 == NULL || $1 == NULL)
+                if ($0 == nullptr || $1 == nullptr)
                     return $0;
                 if ($1->__type != $0->__type)
                     U_THROW_ICE();
 
-                for (uDelegate *first = $0; first != NULL; first = first->_prev)
+                for (uDelegate *first = $0; first != nullptr; first = first->_prev)
                 {
                     bool match = true;
                     uDelegate *last = first;
 
-                    for (uDelegate *d = $1; d != NULL; d = d->_prev, last = last->_prev)
+                    for (uDelegate *d = $1; d != nullptr; d = d->_prev, last = last->_prev)
                     {
-                        if (last == NULL ||
+                        if (last == nullptr ||
                             d->_func != last->_func ||
                             d->_this != last->_this)
                         {
@@ -84,7 +84,7 @@ namespace Uno
             if defined(CPLUSPLUS)
             @{
                 return $0 == $1 || (
-                        $0 != NULL && $1 != NULL &&
+                        $0 != nullptr && $1 != nullptr &&
                         $0->__type == $1->__type &&
                         $0->_func == $1->_func &&
                         $0->_this == $1->_this &&

--- a/lib/UnoCore/Source/Uno/Double.uno
+++ b/lib/UnoCore/Source/Uno/Double.uno
@@ -47,7 +47,7 @@ namespace Uno
                     // Some snprintf implementations return -1 and sets errno to
                     // ERANGE instead of returning the desired length, so let's
                     // reconstruct the value we want here.
-                    len = snprintf(NULL, 0, "%f", *$$);
+                    len = snprintf(nullptr, 0, "%f", *$$);
                     U_ASSERT(len > sizeof(buf));
                 }
 

--- a/lib/UnoCore/Source/Uno/IO/Bundle.uno
+++ b/lib/UnoCore/Source/Uno/IO/Bundle.uno
@@ -464,7 +464,7 @@ namespace Uno.IO
             if (!@{$$._fp})
                 return;
             AAsset_close(@{$$._fp});
-            @{$$._fp} = NULL;
+            @{$$._fp} = nullptr;
         @}
 
         void CheckDisposed()

--- a/lib/UnoCore/Source/Uno/IO/Directory.uno
+++ b/lib/UnoCore/Source/Uno/IO/Directory.uno
@@ -462,7 +462,7 @@ namespace Uno.IO
                 if defined(WIN32)
                 @{
                     delete (WIN32_FIND_DATA*) @{$$._findData};
-                    @{$$._findData} = NULL;
+                    @{$$._findData} = nullptr;
                 @}
             }
 
@@ -473,12 +473,12 @@ namespace Uno.IO
                 if defined(WIN32)
                 @{
                     FindClose((HANDLE) @{$$._handle});
-                    @{$$._handle} = NULL;
+                    @{$$._handle} = nullptr;
                 @}
                 else if defined(UNIX)
                 @{
                     closedir((DIR*) @{$$._handle});
-                    @{$$._handle} = NULL;
+                    @{$$._handle} = nullptr;
                 @}
             }
 

--- a/lib/UnoCore/Source/Uno/IO/File.uno
+++ b/lib/UnoCore/Source/Uno/IO/File.uno
@@ -232,11 +232,11 @@ namespace Uno.IO
                 FORMAT_MESSAGE_ALLOCATE_BUFFER |
                 FORMAT_MESSAGE_FROM_SYSTEM |
                 FORMAT_MESSAGE_IGNORE_INSERTS,
-                NULL,
+                nullptr,
                 GetLastError(),
                 MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT),
                 (LPWSTR)&lpMsgBuf, // Cast because callee is allocating buffer
-                0, NULL);
+                0, nullptr);
 
             uString* msg = uString::Utf16((const char16_t*) lpMsgBuf);
             LocalFree(lpMsgBuf);

--- a/lib/UnoCore/Source/Uno/IO/FileStream.uno
+++ b/lib/UnoCore/Source/Uno/IO/FileStream.uno
@@ -243,7 +243,7 @@ namespace Uno.IO
                 if (!@{$$._fp})
                     return;
                 fclose(@{$$._fp});
-                @{$$._fp} = NULL;
+                @{$$._fp} = nullptr;
             @}
         }
 

--- a/lib/UnoCore/Source/Uno/IntPtr.uno
+++ b/lib/UnoCore/Source/Uno/IntPtr.uno
@@ -4,7 +4,7 @@ namespace Uno
 {
     [extern(DOTNET) DotNetType("System.IntPtr")]
     [extern(CPLUSPLUS) Set("TypeName", "void*")]
-    [extern(CPLUSPLUS) Set("DefaultValue", "NULL")]
+    [extern(CPLUSPLUS) Set("DefaultValue", "nullptr")]
     /** A platform-specific type that is used to represent a pointer or a handle. */
     public intrinsic struct IntPtr
     {

--- a/lib/UnoCore/Source/Uno/Reflection/CppReflection.uno
+++ b/lib/UnoCore/Source/Uno/Reflection/CppReflection.uno
@@ -33,12 +33,12 @@ namespace Uno.Reflection
     {
         public static CppField Null
         {
-             get { return extern<CppField> "NULL"; }
+             get { return extern<CppField> "nullptr"; }
         }
 
         public bool IsNull
         {
-            get { return extern<bool> "*$$ == NULL"; }
+            get { return extern<bool> "*$$ == nullptr"; }
         }
 
         public bool IsStatic
@@ -79,12 +79,12 @@ namespace Uno.Reflection
     {
         public static CppFunction Null
         {
-            get { return extern<CppFunction> "NULL"; }
+            get { return extern<CppFunction> "nullptr"; }
         }
 
         public bool IsNull
         {
-            get { return extern<bool> "*$$ == NULL"; }
+            get { return extern<bool> "*$$ == nullptr"; }
         }
 
         public bool IsStatic
@@ -156,7 +156,7 @@ namespace Uno.Reflection
 
         public static CppField FindFieldFromObject(object obj, string name)
         {
-            return extern<CppField> "$0 != NULL ? $0->GetType()->Reflection.GetField($1) : NULL";
+            return extern<CppField> "$0 != nullptr ? $0->GetType()->Reflection.GetField($1) : nullptr";
         }
 
         public static CppFunction FindFunction(Type type, string name, params Type[] parameterTypes)
@@ -166,7 +166,7 @@ namespace Uno.Reflection
 
         public static CppFunction FindFunctionFromObject(object obj, string name, params Type[] parameterTypes)
         {
-            return extern<CppFunction> "$0 != NULL ? $0->GetType()->Reflection.GetFunction($1, $2) : NULL";
+            return extern<CppFunction> "$0 != nullptr ? $0->GetType()->Reflection.GetFunction($1, $2) : nullptr";
         }
     }
 }

--- a/lib/UnoCore/Source/Uno/Runtime/Implementation/Internal/NumericFormatter.uno
+++ b/lib/UnoCore/Source/Uno/Runtime/Implementation/Internal/NumericFormatter.uno
@@ -171,7 +171,7 @@ namespace Uno.Runtime.Implementation.Internal
                     // Some snprintf implementations return -1 and sets errno to
                     // ERANGE instead of returning the desired length, so let's
                     // reconstruct the value we want here.
-                    len = snprintf(NULL, 0, "%.*f", desiredDigits, d);
+                    len = snprintf(nullptr, 0, "%.*f", desiredDigits, d);
                     U_ASSERT(len > sizeof(buf));
                 }
 

--- a/lib/UnoCore/Source/Uno/String.uno
+++ b/lib/UnoCore/Source/Uno/String.uno
@@ -112,7 +112,7 @@ namespace Uno
 
         public override bool Equals(object other)
         @{
-            if ($0 != NULL && $$->__type == $0->__type)
+            if ($0 != nullptr && $$->__type == $0->__type)
             {
                 uString* str = (uString*)$0;
                 return $$->_length == str->_length &&

--- a/lib/UnoCore/Source/Uno/Threading/Thread.uno
+++ b/lib/UnoCore/Source/Uno/Threading/Thread.uno
@@ -32,12 +32,12 @@ namespace Uno.Threading
     }
 
     [DotNetType("System.Threading.Thread")]
-    [extern(UNIX) Require("Source.Declaration", "static void* _ThreadFunc(void* arg) { @{ThreadMain(Thread):Call((@{Thread}) arg)}; return NULL; }")]
+    [extern(UNIX) Require("Source.Declaration", "static void* _ThreadFunc(void* arg) { @{ThreadMain(Thread):Call((@{Thread}) arg)}; return nullptr; }")]
     [extern(WIN32) Require("Source.Declaration", "static DWORD WINAPI _ThreadFunc(LPVOID lpParam) { @{ThreadMain(Thread):Call((@{Thread}) lpParam)}; return 0; }")]
     [extern(WIN32) Require("Source.Include", "Uno/WinAPIHelper.h")]
     public sealed class Thread
     {
-        extern(CPLUSPLUS) static ThreadLocal _currentThread = extern<ThreadLocal> "uCreateThreadLocal(NULL)";
+        extern(CPLUSPLUS) static ThreadLocal _currentThread = extern<ThreadLocal> "uCreateThreadLocal(nullptr)";
 
         extern(CPLUSPLUS) static void ThreadMain(Thread thread)
         {
@@ -99,7 +99,7 @@ namespace Uno.Threading
 
             if defined(UNIX)
             {
-                if (extern<int> "pthread_create(&@{$$._threadHandle}, NULL, _ThreadFunc, (void*)$$)" != 0)
+                if (extern<int> "pthread_create(&@{$$._threadHandle}, nullptr, _ThreadFunc, (void*)$$)" != 0)
                 {
                     extern "uRelease($$)";
                     throw new InvalidOperationException("pthread_create() failed!");
@@ -107,7 +107,7 @@ namespace Uno.Threading
             }
             else if defined(WIN32)
             {
-                extern "@{$$._threadHandle} = ::CreateThread(NULL, 0, _ThreadFunc, (LPVOID)$$, 0, NULL)";
+                extern "@{$$._threadHandle} = ::CreateThread(nullptr, 0, _ThreadFunc, (LPVOID)$$, 0, nullptr)";
 
                 if (extern<bool>(_threadHandle) "!$0" )
                 {
@@ -123,7 +123,7 @@ namespace Uno.Threading
                 throw new ThreadStateException("Thread has not been started.");
 
             if defined(UNIX)
-                extern(_threadHandle) "pthread_join($0, NULL)";
+                extern(_threadHandle) "pthread_join($0, nullptr)";
             else if defined(WIN32)
                 extern(_threadHandle) "::WaitForSingleObject($0, INFINITE)";
         }

--- a/lib/UnoCore/Source/Uno/ValueType.uno
+++ b/lib/UnoCore/Source/Uno/ValueType.uno
@@ -28,7 +28,7 @@ namespace Uno
             if defined(CPLUSPLUS)
             @{
                 return $$ == $0 || (
-                        $0 != NULL && (
+                        $0 != nullptr && (
                             $0->__type == $$->__type || (
                                 $0->__type->Type == uTypeTypeEnum &&
                                 $0->__type->Base == $$->__type

--- a/lib/UnoCore/Targets/Android/Uno/Base/JNI.cpp.uxl
+++ b/lib/UnoCore/Targets/Android/Uno/Base/JNI.cpp.uxl
@@ -48,7 +48,7 @@
             <Body>
 
                      JNIEnv* jni;
-                     JniHelper::GetVM()->AttachCurrentThread(&jni, NULL);
+                     JniHelper::GetVM()->AttachCurrentThread(&jni, nullptr);
                      return jni;
 
             </Body>
@@ -204,7 +204,7 @@
             <Body>
 
                      @{JNIEnvPtr} jni = @{Android.Base.JNI.GetEnvPtr():Call()};
-                     jobject rtn = jni->NewObjectArray((jsize)$1, $0, NULL);
+                     jobject rtn = jni->NewObjectArray((jsize)$1, $0, nullptr);
                      jobject newArray = reinterpret_cast<jobject>(jni->NewGlobalRef(rtn));
                      jni->DeleteLocalRef(rtn);
                      return newArray;
@@ -442,7 +442,7 @@
 
         #define CLASS_INIT(CLASS,INITCALL) if (uEnterCriticalIfNull(&CLASS)) { INITCALL; uExitCritical(); }
 
-        #define JARG_TO_UNO(ARG,UNOTYPE,NEWUNO) UNOTYPE tmp ## ARG = (ARG==0 ? NULL : (ARG == -1 ? NEWUNO : (UNOTYPE)uLoadWeak((uWeakObject*)ARG)));
+        #define JARG_TO_UNO(ARG,UNOTYPE,NEWUNO) UNOTYPE tmp ## ARG = (ARG==0 ? nullptr : (ARG == -1 ? NEWUNO : (UNOTYPE)uLoadWeak((uWeakObject*)ARG)));
 
         #define JNFUN(RETURNTYPE,FUNCNAME,...) RETURNTYPE JNICALL FUNCNAME(JNIEnv *env, jclass clazz, ##__VA_ARGS__)
 

--- a/lib/UnoCore/Targets/Android/Uno/Base/JNI.uno
+++ b/lib/UnoCore/Targets/Android/Uno/Base/JNI.uno
@@ -186,7 +186,7 @@ namespace Android.Base
         public static Exception TryGetException(JNIEnvPtr jni, string appendMessage=null)
         {
             extern(jni) "jthrowable err = $0->ExceptionOccurred()";
-            if (extern<bool>"(err != NULL)")
+            if (extern<bool>"(err != nullptr)")
             {
                 extern(jni) "$0->ExceptionDescribe()";
                 extern(jni) "$0->ExceptionClear()";

--- a/lib/UnoCore/Targets/Android/Uno/Base/Primitives.uno
+++ b/lib/UnoCore/Targets/Android/Uno/Base/Primitives.uno
@@ -148,7 +148,7 @@ namespace Android.Base.Primitives
     {
         public static ujclass Null
         {
-            get { return extern<ujclass> "NULL"; }
+            get { return extern<ujclass> "nullptr"; }
         }
 
         public static bool operator == (ujclass lhs, ujclass rhs)
@@ -167,7 +167,7 @@ namespace Android.Base.Primitives
     {
         public static ujstring Null
         {
-            get { return extern<ujstring> "NULL"; }
+            get { return extern<ujstring> "nullptr"; }
         }
     }
 
@@ -176,7 +176,7 @@ namespace Android.Base.Primitives
     {
         public static ujobject Null
         {
-            get { return extern<ujobject> "NULL"; }
+            get { return extern<ujobject> "nullptr"; }
         }
 
         public static implicit operator ujobject(ujclass v)

--- a/lib/UnoCore/Targets/Android/Uno/Base/Types.cpp.uxl
+++ b/lib/UnoCore/Targets/Android/Uno/Base/Types.cpp.uxl
@@ -95,7 +95,7 @@
         <Method Signature="NewDirectByteBuffer(byte[]):ujobject">
             <Body>
 
-                         if (!$0) return NULL;
+                         if (!$0) return nullptr;
                          return @{JNI.GetEnvPtr():Call()}->NewDirectByteBuffer($0->Ptr(), (jlong)$0->Length());
 
             </Body>
@@ -104,7 +104,7 @@
         <Method Signature="NewDirectByteBuffer(sbyte[]):ujobject">
             <Body>
 
-                         if (!$0) return NULL;
+                         if (!$0) return nullptr;
                          return @{JNI.GetEnvPtr():Call()}->NewDirectByteBuffer($0->Ptr(), (jlong)$0->Length());
 
             </Body>
@@ -113,7 +113,7 @@
         <Method Signature="NewDirectByteBuffer(Uno.IntPtr,long):ujobject">
             <Body>
 
-                         if (!$0) return NULL;
+                         if (!$0) return nullptr;
                          return @{JNI.GetEnvPtr():Call()}->NewDirectByteBuffer($0, (jlong)$1);
 
             </Body>
@@ -122,7 +122,7 @@
         <Method Signature="ValidDirectByteBuffer(ujobject):bool">
             <Body>
 
-                         return (@{JNI.GetEnvPtr():Call()}->GetDirectBufferAddress($0) != NULL);
+                         return (@{JNI.GetEnvPtr():Call()}->GetDirectBufferAddress($0) != nullptr);
 
             </Body>
         </Method>
@@ -130,7 +130,7 @@
         <Method Signature="GetDirectBufferAddress(ujobject):Uno.IntPtr">
             <Body>
 
-                         if (!$0) return NULL;
+                         if (!$0) return nullptr;
                          return (@{Uno.IntPtr})@{JNI.GetEnvPtr():Call()}->GetDirectBufferAddress($0);
 
             </Body>
@@ -152,9 +152,9 @@
         <Method Signature="JavaToUno(JNIEnvPtr,ujobject):string">
             <Body>
 
-                         if (!$1) { return NULL; }
+                         if (!$1) { return nullptr; }
                          jobject str = $0->NewLocalRef($1);
-                         const jchar* raw =  $0->GetStringChars((jstring)str, NULL);
+                         const jchar* raw =  $0->GetStringChars((jstring)str, nullptr);
                          int len = $0->GetStringLength((jstring)str);
                          int size = len * sizeof(jchar);
                          uString* result = uString::New(len);
@@ -182,7 +182,7 @@
         <Method Signature="JavaToUnoBoolArray(ujobject,long):bool[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jbooleanArray jarr = (jbooleanArray)$0;
                      long len = $1;
@@ -195,7 +195,7 @@
         <Method Signature="JavaToUnoSByteArray(ujobject,long):sbyte[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jbyteArray jarr = (jbyteArray)$0;
                      long len = $1;
@@ -208,7 +208,7 @@
         <Method Signature="JavaToUnoByteArray(ujobject,long):byte[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jbyteArray jarr = (jbyteArray)$0;
                      long len = $1;
@@ -221,7 +221,7 @@
         <Method Signature="JavaToUnoCharArray(ujobject,long):char[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jcharArray jarr = (jcharArray)$0;
                      long len = $1;
@@ -234,7 +234,7 @@
         <Method Signature="JavaToUnoShortArray(ujobject,long):short[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jshortArray jarr = (jshortArray)$0;
                      long len = $1;
@@ -247,7 +247,7 @@
         <Method Signature="JavaToUnoIntArray(ujobject,long):int[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jintArray jarr = (jintArray)$0;
                      long len = $1;
@@ -260,7 +260,7 @@
         <Method Signature="JavaToUnoLongArray(ujobject,long):long[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jlongArray jarr = (jlongArray)$0;
                      long len = $1;
@@ -273,7 +273,7 @@
         <Method Signature="JavaToUnoFloatArray(ujobject,long):float[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jfloatArray jarr = (jfloatArray)$0;
                      long len = $1;
@@ -286,7 +286,7 @@
         <Method Signature="JavaToUnoDoubleArray(ujobject,long):double[]">
             <Body>
 
-                     if (!$0) return NULL;
+                     if (!$0) return nullptr;
                      @{JNIEnvPtr} jni = @{JNI.GetEnvPtr():Call()};
                      jdoubleArray jarr = (jdoubleArray)$0;
                      long len = $1;

--- a/lib/UnoCore/Targets/Android/Uno/Base/Wrappers.cpp.uxl
+++ b/lib/UnoCore/Targets/Android/Uno/Base/Wrappers.cpp.uxl
@@ -39,13 +39,13 @@
         <Require Header.Include="@{Android.Base.AndroidBindingMacros:Include}" />
         <Require Header.Declaration>
         //~
-        #define MAYBEPROXIFYARG(NUM,ID,NEW) bool subclassed ## NUM = (!ID) ? false : (@{Android.Base.Wrappers.IJWrapper:Of(ID)._IsSubclassed():Call()}); jobject _iProx ## NUM = (!ID) ? NULL : (subclassed ## NUM ? NEW : @{Android.Base.Wrappers.IJWrapper:Of(ID)._GetJavaObject():Call()});
+        #define MAYBEPROXIFYARG(NUM,ID,NEW) bool subclassed ## NUM = (!ID) ? false : (@{Android.Base.Wrappers.IJWrapper:Of(ID)._IsSubclassed():Call()}); jobject _iProx ## NUM = (!ID) ? nullptr : (subclassed ## NUM ? NEW : @{Android.Base.Wrappers.IJWrapper:Of(ID)._GetJavaObject():Call()});
 
         #define FREEPROXIED(NUM)if (subclassed ## NUM) { U_JNIVAR->DeleteLocalRef(_iProx ## NUM); }
 
-        #define UNOCALLANDRETURN(CALL) @{Android.Base.Primitives.JNIEnvPtr} _cb_jni = @{Android.Base.JNI.GetEnvPtr():Call()};@{Android.Base.Wrappers.JWrapper} _res = (@{Android.Base.Wrappers.JWrapper})CALL;if (_res) { return _cb_jni->NewLocalRef(@{Android.Base.Wrappers.JWrapper:Of(_res)._javaObject}); } else { return NULL; }
+        #define UNOCALLANDRETURN(CALL) @{Android.Base.Primitives.JNIEnvPtr} _cb_jni = @{Android.Base.JNI.GetEnvPtr():Call()};@{Android.Base.Wrappers.JWrapper} _res = (@{Android.Base.Wrappers.JWrapper})CALL;if (_res) { return _cb_jni->NewLocalRef(@{Android.Base.Wrappers.JWrapper:Of(_res)._javaObject}); } else { return nullptr; }
 
-        #define NEW_UNO(LINE,RETURNVAR,TYPEOF,UNOTYPE,FALLBACK,RESOLVE) U_JOBJECT tmpRes = LINE; @{Android.Base.JNI.CheckException():Call()}; @{long} unoRef = @{Android.Base.JNI.GetUnoRef(Android.Base.Primitives.ujobject):Call(tmpRes)}; if (unoRef==0) { RETURNVAR = NULL; } else if (unoRef>0) { RETURNVAR = (UNOTYPE)uLoadWeak((uWeakObject*)unoRef); @{Android.Base.Primitives.JNIEnvPtr} __cb_jni = @{Android.Base.JNI.GetEnvPtr():Call()}; if (__cb_jni->GetObjectRefType(tmpRes)==JNILocalRefType) { __cb_jni->DeleteLocalRef(tmpRes); }} else { RETURNVAR = ((UNOTYPE)@{Android.Base.Wrappers.JWrapper(Android.Base.Primitives.ujobject,Uno.Type,bool,bool):New(tmpRes, (@{Uno.Type})TYPEOF, FALLBACK, RESOLVE)}); }
+        #define NEW_UNO(LINE,RETURNVAR,TYPEOF,UNOTYPE,FALLBACK,RESOLVE) U_JOBJECT tmpRes = LINE; @{Android.Base.JNI.CheckException():Call()}; @{long} unoRef = @{Android.Base.JNI.GetUnoRef(Android.Base.Primitives.ujobject):Call(tmpRes)}; if (unoRef==0) { RETURNVAR = nullptr; } else if (unoRef>0) { RETURNVAR = (UNOTYPE)uLoadWeak((uWeakObject*)unoRef); @{Android.Base.Primitives.JNIEnvPtr} __cb_jni = @{Android.Base.JNI.GetEnvPtr():Call()}; if (__cb_jni->GetObjectRefType(tmpRes)==JNILocalRefType) { __cb_jni->DeleteLocalRef(tmpRes); }} else { RETURNVAR = ((UNOTYPE)@{Android.Base.Wrappers.JWrapper(Android.Base.Primitives.ujobject,Uno.Type,bool,bool):New(tmpRes, (@{Uno.Type})TYPEOF, FALLBACK, RESOLVE)}); }
         </Require>
 
         <Method Signature="_DisposeJavaObject()">
@@ -72,7 +72,7 @@ if (!@{_jlangObjectClass}) { THROW_UNO_EXCEPTION("Unable to cache class 'java.la
             <Body>
 
 INIT_JNI;
-jobject _obArg2 = ((!$0) ? NULL : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
+jobject _obArg2 = ((!$0) ? nullptr : @{Android.Base.Wrappers.IJWrapper:Of($0)._GetJavaObject():Call()});
 CLASS_INIT(@{_jlangObjectClass},@{_Init():Call()});
 CACHE_METHOD(@{_jlangObjectEqualsMid},@{_jlangObjectClass},"equals","(Ljava/lang/Object;)Z",GetMethodID,"Id for method java.lang.Object.equals could not be cached for jwrapper",79);
 @{bool} result = ((@{bool})U_JNIVAR->CallBooleanMethod(@{$$._javaObject}, @{_jlangObjectEqualsMid}, _obArg2));

--- a/lib/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
+++ b/lib/UnoCore/Targets/Android/Uno/Graphics/GLHelper.cpp
@@ -17,7 +17,7 @@ EGLContext GLHelper::_eglWorkerThreadContext = EGL_NO_CONTEXT;
 
 GLuint GLHelper::_dummyTexture;
 jobject GLHelper::_dummyJavaSurface;
-ANativeWindow* GLHelper::_dummyNativeWindow = NULL;
+ANativeWindow* GLHelper::_dummyNativeWindow = nullptr;
 EGLSurface GLHelper::_eglDummySurface;
 
 const EGLint GLHelper::_contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
@@ -182,7 +182,7 @@ void GLHelper::CreateEGLSurfaceFromANativeWindow(ANativeWindow* nativeWindow, EG
     EGLint format;
     eglGetConfigAttrib(GLHelper::_eglDisplay, config, EGL_NATIVE_VISUAL_ID, &format);
     ANativeWindow_setBuffersGeometry(nativeWindow, 0, 0, format);
-    newSurface = eglCreateWindowSurface(GLHelper::_eglDisplay, config, nativeWindow, NULL);
+    newSurface = eglCreateWindowSurface(GLHelper::_eglDisplay, config, nativeWindow, nullptr);
     if (newSurface == EGL_NO_SURFACE) throw uBase::Exception("Unable to create EGL Surface");
 }
 

--- a/lib/UnoCore/Targets/Android/Uno/JNIHelper.cpp
+++ b/lib/UnoCore/Targets/Android/Uno/JNIHelper.cpp
@@ -11,7 +11,7 @@ void JniHelper::JniDestroyThread(void* value)
 {
     JNIEnv* env = (JNIEnv*)value;
     VM->DetachCurrentThread();
-    pthread_setspecific(JniThreadKey, NULL);
+    pthread_setspecific(JniThreadKey, nullptr);
 }
 
 void JniHelper::Init(JavaVM* vm, JNIEnv* env, jclass activityClass, jclass nativeExternClass)
@@ -32,7 +32,7 @@ JniHelper::JniHelper()
     int status_ = (int)VM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
     if (status_ != JNI_OK)
     {
-        status_ = (int)VM->AttachCurrentThread(&env, NULL);
+        status_ = (int)VM->AttachCurrentThread(&env, nullptr);
         if (status_ != JNI_OK)
             U_FATAL("JNI ERROR: Failed to attach current thread");
     }
@@ -71,9 +71,9 @@ JNIEnv* JniHelper::operator->()
 @{string} JniHelper::JavaToUnoString(jstring jstr)
 {
     JniHelper jni;
-    if (!jstr) { return NULL; }
+    if (!jstr) { return nullptr; }
     jobject str = jni->NewLocalRef(jstr);
-    const jchar* raw =  jni->GetStringChars((jstring)str, NULL);
+    const jchar* raw =  jni->GetStringChars((jstring)str, nullptr);
     int len = jni->GetStringLength((jstring)str);
     int size = len * sizeof(jchar);
     uString* result = uString::New(len);
@@ -86,7 +86,7 @@ JNIEnv* JniHelper::operator->()
 jstring JniHelper::UnoToJavaString(@{string} ustr)
 {
     if (!ustr)
-        return NULL;
+        return nullptr;
 
     JniHelper jni;
     return (jni->NewString((const jchar*) ustr->_ptr, ustr->_length));

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/Uno-iOS.mm
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/Uno-iOS.mm
@@ -34,7 +34,7 @@ namespace uPlatform { namespace iOS {
 
     uObject *GetAssociatedUnoObject(id nativeObject)
     {
-        uObject *result = NULL;
+        uObject *result = nullptr;
 
         id<UnoObject> value = (id<UnoObject>)
             objc_getAssociatedObject(nativeObject, &UnoObjectAssociationKey);
@@ -55,7 +55,7 @@ namespace uPlatform { namespace iOS {
     uString *ToUno(NSString *str)
     {
         if (!str)
-            return NULL;
+            return nullptr;
 
         NSUInteger bytes = [str
             lengthOfBytesUsingEncoding:NativeUTF16Encoding];
@@ -70,7 +70,7 @@ namespace uPlatform { namespace iOS {
                 encoding:NativeUTF16Encoding
                 options:0
                 range:NSMakeRange(0, [str length])
-                remainingRange:NULL])
+                remainingRange:nullptr])
         {
             if (usedBytes != bytes) {
                 result->_length = int(usedBytes / sizeof(char16_t));
@@ -79,6 +79,6 @@ namespace uPlatform { namespace iOS {
             return result;
         }
 
-        return NULL;
+        return nullptr;
     }
 }} // namespace uPlatform::iOS

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
@@ -412,7 +412,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                             ) + index + ")";
 
                     Log.Error("C++: Failed to get typeof(" + dt.VerboseName + ") in " + ((object) func ?? parent).Quote());
-                    return "NULL";
+                    return "nullptr";
                 }
                 default:
                 {
@@ -445,7 +445,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                             foreach (var a in dt.GenericArguments)
                                 sb.Append(", " + GetTypeOf(a, parent, type, func, cache));
 
-                            sb.Append(", NULL)");
+                            sb.Append(", nullptr)");
                             return sb.ToString();
                         }
                         else
@@ -468,7 +468,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                                 comma = true;
                             }
 
-                            sb.Append(", NULL)");
+                            sb.Append(", nullptr)");
                             return sb.ToString();
                         }
                     }
@@ -624,7 +624,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
             return Environment.TryGetValue(dt, "DefaultValue", out result)
                     ? result.String :
                 dt.IsReferenceType
-                    ? "NULL" :
+                    ? "nullptr" :
                 IsConstrained(dt)
                     ? (u == ExpressionUsage.VarArg ? "(void*)" : null) +
                         "uT(" + GetTypeOf(dt, parent, func, cache) +

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppGenerator.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppGenerator.cs
@@ -432,11 +432,11 @@ namespace Uno.Compiler.Backends.CPlusPlus
                                        ", " + (
                                            _backend.HasTypeParameter(f)
                                                ? _backend.GetTypeOf(f.GenericType ?? f.DeclaringType, dt, obj, null, typeCache)
-                                               : "NULL"
+                                               : "nullptr"
                                        ) +
                                        ", " + (
                                            f.IsVirtual
-                                               ? "NULL, offsetof(" + type.TypeOfType + ", fp_" + f.Name + ")"
+                                               ? "nullptr, offsetof(" + type.TypeOfType + ", fp_" + f.Name + ")"
                                                : "(void*)" + _backend.GetFunctionPointer(f, dt) + ", 0"
                                        ) +
                                        ", " + f.IsStatic.ToLiteral() +
@@ -458,7 +458,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 _cpp.WriteLine(type.TypeOfType + "* " + type.TypeOfFunction + "()");
                 _cpp.BeginScope();
                 _cpp.WriteLine("static uSStrong" + _backend.GetTemplateString(type.TypeOfType + "*") + " type;");
-                _cpp.WriteLine("if (type != NULL) return type;");
+                _cpp.WriteLine("if (type != nullptr) return type;");
                 _cpp.Skip();
 
                 _cpp.WriteLine("uTypeOptions options;");
@@ -603,7 +603,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
             _cpp.WriteLine("uInterfaceType* " + type.TypeOfFunction + "()");
             _cpp.BeginScope();
             _cpp.WriteLine("static uSStrong<uInterfaceType*> type;");
-            _cpp.WriteLine("if (type != NULL) return type;");
+            _cpp.WriteLine("if (type != nullptr) return type;");
             _cpp.Skip();
             _cpp.WriteLine("type = uInterfaceType::New(" + type.ReflectedName.ToLiteral() +
                 ", " + (dt.IsFlattenedDefinition ? dt.FlattenedParameters.Length : 0) +
@@ -628,11 +628,11 @@ namespace Uno.Compiler.Backends.CPlusPlus
                                    ", " + (
                                         _backend.HasTypeParameter(f)
                                             ? _backend.GetTypeOf(f.GenericType ?? f.DeclaringType, dt, obj)
-                                            : "NULL"
+                                            : "nullptr"
                                    ) +
                                    ", " + (
                                         f.IsVirtual
-                                            ? "NULL, offsetof(" + type.StructName + ", fp_" + f.Name + ")"
+                                            ? "nullptr, offsetof(" + type.StructName + ", fp_" + f.Name + ")"
                                             : "(void*)" + _backend.GetFunctionPointer(f, dt) + ", 0"
                                    ) +
                                    ", " + f.IsStatic.ToLiteral() +
@@ -700,7 +700,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
             _cpp.WriteLine("uDelegateType* " + type.TypeOfFunction + "()");
             _cpp.BeginScope();
             _cpp.WriteLine("static uSStrong<uDelegateType*> type;");
-            _cpp.WriteLine("if (type != NULL) return type;");
+            _cpp.WriteLine("if (type != nullptr) return type;");
             _cpp.Skip();
 
             _cpp.WriteLine("type = uDelegateType::New(" + type.ReflectedName.ToLiteral() +
@@ -734,7 +734,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
             _cpp.WriteLine("uEnumType* " + type.TypeOfFunction + "()");
             _cpp.BeginScope();
             _cpp.WriteLine("static uSStrong<uEnumType*> type;");
-            _cpp.WriteLine("if (type != NULL) return type;");
+            _cpp.WriteLine("if (type != nullptr) return type;");
             _cpp.Skip();
 
             _cpp.WriteLine("type = uEnumType::New(" + type.ReflectedName.ToLiteral() + ", " + _backend.GetTypeOf(dt.Base, dt, "type") + ", " + dt.Literals.Count + ");");

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/ForeignObjCPass.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/ForeignObjCPass.cs
@@ -359,7 +359,7 @@ namespace Uno.Compiler.Extensions.Foreign.ObjC
                 dt,
                 typeName,
                 x => "(" + typeName + ")" + Helpers.CallStatic(_getHandle, Helpers.StringExpr(_objCObject, x)),
-                x => "[](" + typeName + " x) -> " + ct + " { if (x == nil) return NULL; " +
+                x => "[](" + typeName + " x) -> " + ct + " { if (x == nil) return nullptr; " +
                     // TODO How to not have to touch :New in a comment to get it not to strip?
                     ct + " r = \\@{" + fullName + "():New()}; /* @{" + fullName + "():New()} */ \\@{" + fullName +
                     ":Of(r).Handle:Set(x)}; return r; }(" + x + ")");

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Converters/TypeConverter.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/Converters/TypeConverter.cs
@@ -238,7 +238,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java.Converters
 				}
 				else if (convert.Type.IsJavaObject(dt))
 				{
-					cast = "(" + unoTmpVarName + "==NULL ? NULL : U_JNIVAR->NewLocalRef(@{global::Android.Base.Wrappers.IJWrapper:Of((@{global::Android.Base.Wrappers.IJWrapper})" + unoTmpVarName + ")._GetJavaObject():Call()}))";
+					cast = "(" + unoTmpVarName + "==nullptr ? nullptr : U_JNIVAR->NewLocalRef(@{global::Android.Base.Wrappers.IJWrapper:Of((@{global::Android.Base.Wrappers.IJWrapper})" + unoTmpVarName + ")._GetJavaObject():Call()}))";
 				}
 				else if (dt.IsSubclassOfOrEqual(essentials.Delegate))
 				{
@@ -263,13 +263,13 @@ namespace Uno.Compiler.Extensions.Foreign.Java.Converters
 					switch (free)
 					{
 						case JniFreeingTechnique.Default:
-							Free = "if (" + JniVarName + "!=NULL) { U_JNIVAR->DeleteLocalRef(" + JniVarName + "); }";
+							Free = "if (" + JniVarName + "!=nullptr) { U_JNIVAR->DeleteLocalRef(" + JniVarName + "); }";
 							break;
 						case JniFreeingTechnique.WithScope:
 							if (dt.IsStruct) // no null check needed if is uno struct
 								cast = "U_JNIVAR->NewLocalRef((" + cast + "))";
 							else
-								cast = "(" + unoTmpVarName + "==NULL ? NULL : U_JNIVAR->NewLocalRef((" + cast + ")))";
+								cast = "(" + unoTmpVarName + "==nullptr ? nullptr : U_JNIVAR->NewLocalRef((" + cast + ")))";
 							Free = "";
 							break;
 						case JniFreeingTechnique.None:

--- a/src/compiler/Uno.Compiler.Extensions/Foreign/Java/UnoCallToForeignMethod.cs
+++ b/src/compiler/Uno.Compiler.Extensions/Foreign/Java/UnoCallToForeignMethod.cs
@@ -47,7 +47,7 @@ namespace Uno.Compiler.Extensions.Foreign.Java
 			}
 
 			if (fm.UnoReturnType == convert.Essentials.String)
-				tearDown.Add("if (__jresult!=NULL && U_JNIVAR->GetObjectRefType(__jresult) == JNILocalRefType) U_JNIVAR->DeleteLocalRef(__jresult);");
+				tearDown.Add("if (__jresult!=nullptr && U_JNIVAR->GetObjectRefType(__jresult) == JNILocalRefType) U_JNIVAR->DeleteLocalRef(__jresult);");
 
 			//--------------------------
 


### PR DESCRIPTION
This PR updates our C++ code to use `nullptr` instead of `NULL`.

> `nullptr` was introduced in C++11 and is a more type-safe `NULL` that is implicitly convertible and comparable to any pointer type. Unlike `NULL`, it is not implicitly convertible or comparable to integral types.