### PR TITLE
C++ API clean-ups

### DIFF
--- a/lib/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
+++ b/lib/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
@@ -105,7 +105,7 @@
         typename union unsigned using virtual void volatile wchar_t
         while xor xor_eq
 
-        NULL
+        NULL alloca calloc malloc realloc free
         int8_t int16_t int32_t int64_t uint8_t uint16_t uint32_t
         uint64_t DBL_MAX DBL_INF DBL_NAN FLT_INF FLT_NAN
         op_Implicit op_Explicit

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.cpp
@@ -543,7 +543,7 @@ void uBuildMemory(uType* type)
     }
 
 #ifdef DEBUG_UNSAFE
-    uint8_t* layout = (uint8_t*)U_ALLOCA(type->ObjectSize);
+    uint8_t* layout = (uint8_t*)alloca(type->ObjectSize);
     memset(layout, 0, type->ObjectSize);
 
     for (size_t i = 0; i < type->FieldCount; i++)

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Memory.h
@@ -224,14 +224,14 @@ struct uSStrong
     uStrongRef<T> operator &() {
         return &_object;
     }
-    operator T() {
+    operator T() const {
         return _object;
     }
-    T operator ->() {
+    T operator ->() const {
         return _object;
     }
     template<class U>
-    explicit operator U() {
+    explicit operator U() const {
         return (U)_object;
     }
 };
@@ -270,14 +270,14 @@ struct uSWeak
     uWeakRef<T> operator &() {
         return &_object;
     }
-    operator T() {
+    operator T() const {
         return (T)uLoadWeak(_object);
     }
-    T operator ->() {
+    T operator ->() const {
         return (T)uLoadWeak(_object);
     }
     template<class U>
-    explicit operator U() {
+    explicit operator U() const {
         return (U)uLoadWeak(_object);
     }
 };

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
@@ -1810,27 +1810,6 @@ uArray* uArray::New(uType* type, size_t length, const void* optionalData)
     return array;
 }
 
-uThrowable::uThrowable(@{Uno.Exception} exception, const char* func, int line)
-    : Exception(exception)
-    , Function(func)
-    , Line(line)
-{
-    uRetain(Exception);
-}
-
-uThrowable::uThrowable(const uThrowable& copy)
-    : Exception(copy.Exception)
-    , Function(copy.Function)
-    , Line(copy.Line)
-{
-    uRetain(Exception);
-}
-
-uThrowable::~uThrowable() throw()
-{
-    uRelease(Exception);
-}
-
 const char* uThrowable::what() const throw()
 {
     return Exception->__type->FullName;

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.cpp
@@ -1572,7 +1572,7 @@ void uDelegate::Invoke(uTRef retval, void** args, size_t count)
     if (retval._address)
         count++;
 
-    void** stack = (void**)U_ALLOCA(count * sizeof(void*));
+    void** stack = (void**)alloca(count * sizeof(void*));
     void** ptr = stack;
 
     if (_this)
@@ -1594,7 +1594,7 @@ void uDelegate::Invoke(uTRef retval, size_t count, ...)
     va_list ap;
     va_start(ap, count);
     void** args = count > 0
-        ? (void**)U_ALLOCA(count * sizeof(void*))
+        ? (void**)alloca(count * sizeof(void*))
         : nullptr;
 
     for (size_t i = 0; i < count; i++)
@@ -1620,7 +1620,7 @@ uObject* uDelegate::Invoke(uArray* array)
 
         uObject** objects = (uObject**)array->Ptr();
         void** ptr = args = count > 0
-            ? (void**)U_ALLOCA(count * sizeof(void*))
+            ? (void**)alloca(count * sizeof(void*))
             : nullptr;
 
         for (size_t i = 0; i < count; i++)
@@ -1653,7 +1653,7 @@ uObject* uDelegate::Invoke(uArray* array)
 
     uType* returnType = type->ReturnType;
     void* retval = !U_IS_VOID(returnType)
-        ? U_ALLOCA(returnType->ValueSize)
+        ? alloca(returnType->ValueSize)
         : nullptr;
 
     Invoke(retval, args, count);
@@ -1665,7 +1665,7 @@ uObject* uDelegate::Invoke(size_t count, ...)
     va_list ap;
     va_start(ap, count);
     void** args = count > 0
-        ? (void**)U_ALLOCA(count * sizeof(void*))
+        ? (void**)alloca(count * sizeof(void*))
         : nullptr;
 
     for (size_t i = 0; i < count; i++)
@@ -1674,7 +1674,7 @@ uObject* uDelegate::Invoke(size_t count, ...)
     va_end(ap);
     uType* returnType = ((uDelegateType*)__type)->ReturnType;
     void* retval = !U_IS_VOID(returnType)
-        ? U_ALLOCA(returnType->ValueSize)
+        ? alloca(returnType->ValueSize)
         : nullptr;
 
     Invoke(retval, args, count);

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -37,7 +37,7 @@ struct uObject
 protected:
     uObject() {}
 private:
-    uObject& operator =(const uObject&);
+    uObject& operator =(const uObject&) = delete;
     uObject(const uObject&);
 };
 
@@ -269,7 +269,7 @@ struct uThrowable : public std::exception
     static U_NORETURN void ThrowNullReference(const char* func, int line);
 
 private:
-    uThrowable& operator =(const uThrowable&);
+    uThrowable& operator =(const uThrowable&) = delete;
     uThrowable();
 };
 
@@ -659,7 +659,7 @@ struct uTRef
     }
 
 private:
-    uTRef& operator =(const uTRef&);
+    uTRef& operator =(const uTRef&) = delete;
     uTRef();
 };
 
@@ -788,7 +788,7 @@ struct uTPtr
     }
 
 private:
-    uTPtr& operator =(const uTPtr&);
+    uTPtr& operator =(const uTPtr&) = delete;
     uTPtr();
 };
 

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -251,13 +251,15 @@ uType* uVoid_typeof();
 */
 struct uThrowable : public std::exception
 {
-    @{Uno.Exception} Exception;
+    uStrong<@{Uno.Exception}> Exception;
     const char* Function;
     int Line;
 
-    uThrowable(@{Uno.Exception} exception, const char* func, int line);
-    uThrowable(const uThrowable& copy);
-    virtual ~uThrowable() throw();
+    uThrowable(@{Uno.Exception} exception, const char* func, int line)
+        : Exception(exception)
+        , Function(func)
+        , Line(line) {}
+    uThrowable(const uThrowable&) = default;
     virtual const char* what() const throw();
 
     static U_NORETURN void ThrowIndexOutOfRange(const char* func, int line);

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/ObjectModel.h
@@ -38,7 +38,7 @@ protected:
     uObject() {}
 private:
     uObject& operator =(const uObject&) = delete;
-    uObject(const uObject&);
+    uObject(const uObject&) = delete;
 };
 
 enum uTypeType
@@ -270,7 +270,7 @@ struct uThrowable : public std::exception
 
 private:
     uThrowable& operator =(const uThrowable&) = delete;
-    uThrowable();
+    uThrowable() = delete;
 };
 
 #define U_THROW(exception) throw uThrowable((exception), U_FUNCTION, __LINE__)
@@ -660,7 +660,7 @@ struct uTRef
 
 private:
     uTRef& operator =(const uTRef&) = delete;
-    uTRef();
+    uTRef() = delete;
 };
 
 struct uTStrongRef : uTBase
@@ -789,7 +789,7 @@ struct uTPtr
 
 private:
     uTPtr& operator =(const uTPtr&) = delete;
-    uTPtr();
+    uTPtr() = delete;
 };
 
 template<class T>

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Reflection.cpp
@@ -330,7 +330,7 @@ uObject* uFunction::Invoke(uObject* object, uArray* args)
     void* retval = nullptr;
     if (!U_IS_VOID(ReturnType))
     {
-        retval = U_ALLOCA(ReturnType->ValueSize);
+        retval = alloca(ReturnType->ValueSize);
         if (U_IS_VALUE(ReturnType))
             memset(retval, 0, ReturnType->ValueSize);
     }
@@ -344,7 +344,7 @@ uObject* uFunction::Invoke(uObject* object, uArray* args)
 
     void** stack;
     void** ptr = stack = count > 0
-            ? (void**)U_ALLOCA(count * sizeof(void*))
+            ? (void**)alloca(count * sizeof(void*))
             : nullptr;
 
     if (!(Flags & uFunctionFlagsStatic))

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -65,6 +65,7 @@ T uAssertPtr(T ptr, const char* src, const char* msg) {
 #else
 #include <alloca.h>
 #endif
+// Deprecated -- use alloca() directly instead.
 #define U_ALLOCA(SIZE) alloca(SIZE)
 
 // C++11 compatibility

--- a/lib/UnoCore/Targets/Native/natvis/uno.natstepfilter
+++ b/lib/UnoCore/Targets/Native/natvis/uno.natstepfilter
@@ -35,6 +35,6 @@
   <Function><Name>uSWeak&lt;.*</Name><Action>NoStepInto</Action></Function>
   <Function><Name>uStrongRef&lt;.*</Name><Action>NoStepInto</Action></Function>
   <Function><Name>.*_typeof</Name><Action>NoStepInto</Action></Function>
-  <!-- U_ALLOCA() translates to this in VC++ -->
+  <!-- alloca() translates to this in VC++ -->
   <Function><Name>_MallocaIsSizeInRange</Name><Action>NoStepInto</Action></Function>
 </StepFilter>

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppBackend.cs
@@ -628,7 +628,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 IsConstrained(dt)
                     ? (u == ExpressionUsage.VarArg ? "(void*)" : null) +
                         "uT(" + GetTypeOf(dt, parent, func, cache) +
-                        ", U_ALLOCA(" + GetTypeOf(dt, parent, func, cache) + "->ValueSize))"
+                        ", alloca(" + GetTypeOf(dt, parent, func, cache) + "->ValueSize))"
                     : "uDefault" + GetTemplateString(dt, parent) + "()";
         }
 

--- a/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppWriter.cs
+++ b/src/compiler/Uno.Compiler.Backends.CPlusPlus/CppWriter.cs
@@ -377,7 +377,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 WriteLine(GetTypeOf(f.DeclaringType) + "->Init();");
 
             foreach (var v in func.Constrained)
-                WriteLine("uT " + v.Name + "(" + GetTypeOf(v.ValueType) + ", U_ALLOCA(" + GetTypeOf(v.ValueType) + "->ValueSize));");
+                WriteLine("uT " + v.Name + "(" + GetTypeOf(v.ValueType) + ", alloca(" + GetTypeOf(v.ValueType) + "->ValueSize));");
 
             WriteFunctionBody(f, false);
             EndScope();
@@ -1440,7 +1440,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
             WriteExpression(s);
 
             if (stack)
-                Write(", U_ALLOCA(" + GetTypeOf(s.ReturnType) + "->ObjectSize)");
+                Write(", alloca(" + GetTypeOf(s.ReturnType) + "->ObjectSize)");
 
             Write(")");
         }


### PR DESCRIPTION
This deprecates a superfluous macro and comes with some syntactical improvements to core C++ APIs.