### PR TITLE
Make url response cache functional on Android

### DIFF
--- a/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.java
+++ b/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/HttpRequest.java
@@ -48,9 +48,12 @@ public abstract class HttpRequest {
     {
     	try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-    			File httpCacheDir = new File(activity.getCacheDir(), "http");
-    			HttpResponseCache.install(httpCacheDir, cacheSize);
-                _cacheSize = cacheSize;
+                HttpResponseCache cache = HttpResponseCache.getInstalled();
+                if (cache == null) {
+        			File httpCacheDir = new File(activity.getCacheDir(), "http");
+        			HttpResponseCache.install(httpCacheDir, cacheSize);
+                    _cacheSize = cacheSize;
+                }
     			return true;
     		} else {
                 _cacheSize = 0;
@@ -121,6 +124,13 @@ public abstract class HttpRequest {
 
     public final void SetCaching(boolean set) throws Exception {
         _useCaching = set;
+        if (set)
+            InstallCache(_activity, 10 * 1024 * 1024); // cache size : 10 MB
+        else {
+            CacheClose();
+            CacheFlush();
+            CacheDelete();
+        }
     }
 
     public final void CacheResponseString(String content)

--- a/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/UploadTask.java
+++ b/lib/Uno.Net.Http/Implementation/Android/ExperimentalHttp/UploadTask.java
@@ -217,7 +217,10 @@ public class UploadTask extends AsyncTask<Object, Integer, Boolean> {
         		urlConnection.setConnectTimeout(timeout);
         		urlConnection.setReadTimeout(timeout);
         	}
-            urlConnection.setUseCaches(true);
+            if (useCaching){
+                urlConnection.setUseCaches(true);
+                urlConnection.addRequestProperty("Cache-Control", "max-stale=" + 60*60*24 * 28); // tolerate 4-weeks stale
+            }
             urlConnection.setDoOutput(hasPayload);
             // urlConnection.setDoInput(true);
             urlConnection.setRequestMethod(method);


### PR DESCRIPTION
Install `HttpResponseCache` when we set `setCaching` to `true` on `HttpRequest.java`