### PR TITLE
Travis: iOS build

### DIFF
--- a/.travis.xcconfig
+++ b/.travis.xcconfig
@@ -1,0 +1,1 @@
+SDKROOT = iphonesimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       mono: latest
       env: TARGET=ios
       before_script:
+        - export SKIP_LIB_TESTS=1
         - export UNO_TEST_ARGS="-DDEBUG_UNSAFE --build-only"
         - export XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
     # - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 matrix:
   include:
-    - os: osx
-      osx_image: xcode9.2
-      language: csharp
-      mono: latest
-      env: TARGET=dotnet
+    # - os: osx
+    #   osx_image: xcode9.2
+    #   language: csharp
+    #   mono: latest
+    #   env: TARGET=dotnet
     - os: osx
       osx_image: xcode9.2
       language: csharp

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,17 @@ matrix:
       osx_image: xcode9.2
       language: csharp
       mono: latest
-      env: TARGET=native
+      env: TARGET=ios
       before_script:
-        - export UNO_TEST_ARGS=-DDEBUG_UNSAFE
+        - export UNO_TEST_ARGS="-DDEBUG_UNSAFE --build-only"
+        - export XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
+    # - os: osx
+    #   osx_image: xcode9.2
+    #   language: csharp
+    #   mono: latest
+    #   env: TARGET=native
+    #   before_script:
+    #     - export UNO_TEST_ARGS=-DDEBUG_UNSAFE
     - os: linux
       dist: bionic
       env: TARGET=native

--- a/lib/UnoCore/Source/Uno/Platform/WindowBackend.uno
+++ b/lib/UnoCore/Source/Uno/Platform/WindowBackend.uno
@@ -8,7 +8,7 @@ namespace Uno.Platform
     {
         internal static WindowBackend Instance;
 
-        extern(CPLUSPLUS)
+        extern(CPLUSPLUS && !MOBILE)
         static WindowBackend()
         {
             Instance = new XliWindow();

--- a/lib/UnoCore/Source/Uno/Platform/Xli/XliWindow.uno
+++ b/lib/UnoCore/Source/Uno/Platform/Xli/XliWindow.uno
@@ -6,14 +6,14 @@ namespace Uno.Platform.Xli
     [Set("TypeName", "::Xli::Window*")]
     [Set("ForwardDeclaration", "namespace Xli { class Window; }")]
     [Require("Header.Include", "XliPlatform/Window.h")]
-    extern(CPLUSPLUS) struct XliWindowPtr
+    extern(CPLUSPLUS && !MOBILE) struct XliWindowPtr
     {
     }
 
     [Require("Source.Include", "Uno/Support.h")]
     [Require("Source.Include", "XliPlatform/Display.h")]
     [Require("Source.Declaration", "extern ::Xli::Window* _XliWindowPtr;")]
-    extern(CPLUSPLUS) class XliWindow : WindowBackend
+    extern(CPLUSPLUS && !MOBILE) class XliWindow : WindowBackend
     {
         readonly XliWindowPtr _ptr;
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -31,7 +31,9 @@ function uno-compiler-test {
     return 1
 }
 
-uno-compiler-test
+if [[ "$TARGET" == dotnet ]]; then
+    uno-compiler-test
+fi
 
 # Check that all packages build without errors
 uno build $TARGET --no-strip tests/pkgtest

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,9 @@ TARGET=$1
 uno config
 
 # Run uno tests
-uno test $TARGET lib $UNO_TEST_ARGS
+if [[ "$SKIP_LIB_TESTS" != 1 ]]; then
+    uno test $TARGET lib $UNO_TEST_ARGS
+fi
 
 # Skip when testing 'native' on AppVeyor
 if [[ "$APPVEYOR" != True || "$TARGET" != native ]]; then

--- a/src/test/runner/TestProjectRunner.cs
+++ b/src/test/runner/TestProjectRunner.cs
@@ -58,6 +58,9 @@ namespace Uno.TestRunner
                     options.Defines.AddRange(_options.Defines);
                     options.Undefines.AddRange(_options.Undefines);
 
+                    if (_options.Target is iOSBuild && !proj.MutableProperties.ContainsKey("iOS.BundleIdentifier"))
+                        proj.MutableProperties["iOS.BundleIdentifier"] = "dev.testprojects." + proj.Name.ToIdentifier(true).ToLower();
+
                     var builder = new ProjectBuilder(log, target, options);
                     var result = builder.Build(proj);
                     if (result.ErrorCount != 0)


### PR DESCRIPTION
This builds our code for iOS on Travis CI.

This also disables `dotnet` and `native` builds on macOS.

Rationale: `dotnet` is already being tested on Windows and `native` on Linux and Windows, and running more builds requires more time and resources. I think we can test these targets less frequently on macOS and still live comfortably.