### PR TITLE
C++ clean-up

### DIFF
--- a/lib/UnoCore/Backends/CIL/CIL.uxl
+++ b/lib/UnoCore/Backends/CIL/CIL.uxl
@@ -26,7 +26,4 @@
     <Require Assembly="System" />
     <Require Assembly="System.Core" />
 
-    <!-- Deprecated -->
-    <Deprecate AssemblyReference="Assembly" />
-
 </Extensions>

--- a/lib/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
+++ b/lib/UnoCore/Backends/CPlusPlus/CPlusPlus.uxl
@@ -63,34 +63,6 @@
     <Set Mobile.DisableBatterySaver="@('@(MOBILE:Defined) && @(Project.Mobile.KeepAlive)':Test(1, 0))" />
     <Set Mobile.DisableBackgroundProcess="@('@(MOBILE:Defined) && !@(Project.Mobile.RunsInBackground)':Test(1, 0))" />
 
-    <!-- Deprecated -->
-    <Deprecate Android.Activity.Class.Declaration="Activity.Class.Declaration" />
-    <Deprecate Android.Activity.File.Declaration="Activity.File.Declaration" />
-    <Deprecate Android.Manifest.ApplicationElement="AndroidManifest.ApplicationElement" />
-    <Deprecate Android.Manifest.RootElement="AndroidManifest.RootElement" />
-    <Deprecate Android.Runtime.CatchCppExceptions="Runtime.CatchCppExceptions" />
-    <Deprecate Android.Runtime.CppMainLoop="Runtime.CppMainLoop" />
-    <Deprecate Android.Runtime.DebugPauseMilliseconds="Runtime.DebugPauseMilliseconds" />
-    <Deprecate Android.Runtime.KillActivityOnDestroy="Runtime.KillActivityOnDestroy" />
-    <Deprecate Android.Runtime.KillOnBackButton="Runtime.KillOnBackButton" />
-    <Deprecate Android.Runtime.SeperateUnoThread="Runtime.SeperateUnoThread" />
-    <Deprecate AndroidBuildBat.PreBuildLines="BuildBat.PreBuild" />
-    <Deprecate AndroidBuildSh.PreBuildLines="BuildSh.PreBuild" />
-    <Deprecate AndroidProjectFile.Properties="Project.Property" />
-    <Deprecate Build.HeaderFile="HeaderFile" />
-    <Deprecate Build.IncludeDirectory="IncludeDirectory" />
-    <Deprecate Build.LinkDirectory="LinkDirectory" />
-    <Deprecate Build.LinkLibrary="LinkLibrary" />
-    <Deprecate Build.PreprocessorDefinition="PreprocessorDefinition" />
-    <Deprecate Build.SourceFile="SourceFile" />
-    <Deprecate InstanceTypeName="TypeName" />
-    <Deprecate iOS.BackgroundModes="Project.iOS.PList.UIBackgroundModes" />
-    <Deprecate iOS.Build.Framework="Xcode.Framework" />
-    <Deprecate iOS.Framework="Xcode.Framework" />
-    <Deprecate iOS.PrefixHeader.Declaration="Xcode.PrefixHeader.Declaration" />
-    <Deprecate Java.Extern.RegisterFunctions="Java.Extern.RegisterFunction" />
-    <Deprecate Source.FileExtension="FileExtension" />
-
     <!-- Keywords -->
     <Set Keywords>
         alignas alignof and and_eq asm auto bitand bitor bool

--- a/lib/UnoCore/Backends/CPlusPlus/Uno.cpp.uxl
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno.cpp.uxl
@@ -21,7 +21,6 @@
     <ProcessFile SourceFile="Uno/SupportApple.mm" Condition="APPLE" />
     <ProcessFile HeaderFile="Uno/Uno.h" />
     <ProcessFile HeaderFile="Uno/WinAPIHelper.h" />
-    <ProcessFile HeaderFile="Uno/XliInterop.h" />
     <ProcessFile SourceFile="Uno/Reflection.cpp" Condition="REFLECTION" />
     <ProcessFile HeaderFile="Uno/Reflection.h" Condition="REFLECTION" />
 

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
@@ -13,7 +13,6 @@
 #include <XliPlatform/MessageBox.h>
 #include <mutex>
 @{byte:IncludeDirective}
-@{Uno.Buffer:IncludeDirective}
 
 #if ANDROID
 #include <android/log.h>
@@ -193,18 +192,6 @@ uBase::Vector2i uInt2ToXliVector2i(const @{int2}& vec)
 uBase::Vector2 uFloat2ToXliVector2(const @{float2}& vec)
 {
     return *(uBase::Vector2*)&vec;
-}
-
-@{Uno.Buffer} uBufferFromXliDataAccessor(const uBase::DataAccessor* data)
-{
-    if (!data)
-    {
-        uThrowable::ThrowNullReference(U_FUNCTION, __LINE__);
-        return NULL;
-    }
-
-    uArray* arr = uArray::New(@{byte[]:TypeOf}, data->GetSizeInBytes(), data->GetPtr());
-    return @{Uno.Buffer(byte[],int,int):New(arr, 0, arr->Length())};
 }
 
 uImage::Texture* uLoadXliTexture(const uBase::String& filename, uArray* data)

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.h
@@ -62,35 +62,3 @@ struct uGLTextureInfo
 uImage::Texture* uLoadXliTexture(const uBase::String& filename, uArray* data);
 unsigned int uCreateGLTexture(uImage::Texture* texData, bool generateMipmap = true, uGLTextureInfo* outInfo = 0);
 /** @} */
-
-/**
-    \addtogroup BufferUtils
-    @{
-*/
-#define U_BUFFER_PTR(buffer) ((uint8_t*)(buffer)->_data->_ptr + (buffer)->_offset)
-#define U_BUFFER_SIZE(buffer) (buffer)->_sizeInBytes
-
-void DEPRECATED("This method will be removed in a future version") uReverseBytes(uint8_t* ptr, size_t size);
-
-template<class T>
-void DEPRECATED("This method will be removed in a future version") uReverseBytes(T& ref) {
-    uReverseBytes((uint8_t*)&ref, sizeof(T));
-}
-template<class T>
-T DEPRECATED("This method will be removed in a future version") uLoadBytes(uint8_t* ptr, bool littleEndian) {
-    T result;
-    memcpy(&result, ptr, sizeof(T));
-
-    if (!littleEndian)
-        uReverseBytes(result);
-
-    return result;
-}
-template<class T>
-void DEPRECATED("This method will be removed in a future version") uStoreBytes(uint8_t* ptr, T value, bool littleEndian) {
-    if (!littleEndian)
-        uReverseBytes(value);
-
-    memcpy(ptr, &value, sizeof(T));
-}
-/** @} */

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.h
@@ -6,7 +6,6 @@
 #include <uBase/Vector2.h>
 @{int2:IncludeDirective}
 @{float2:IncludeDirective}
-@{Uno.Buffer:ForwardDeclaration}
 
 namespace uBase { class DataAccessor; }
 namespace uBase { class Stream; }
@@ -42,8 +41,6 @@ uBase::Vector2i uInt2ToXliVector2i(const @{int2}& vec);
 
 @{float2} uFloat2FromXliVector2(const uBase::Vector2& vec);
 uBase::Vector2 uFloat2ToXliVector2(const @{float2}& vec);
-
-@{Uno.Buffer} uBufferFromXliDataAccessor(const uBase::DataAccessor* data);
 /** @} */
 
 /**

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/XliInterop.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/XliInterop.h
@@ -1,4 +1,0 @@
-// @(MSG_ORIGIN)
-// @(MSG_EDIT_WARNING)
-//#pragma message ( "Deprecated: Please use <Uno/Support.h>" )
-#include <Uno/Support.h>

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -80,9 +80,6 @@ T uAssertPtr(T ptr, const char* src, const char* msg) {
 #define DEPRECATED(msg)
 #endif
 
-// Legacy char type
-typedef DEPRECATED("use char16_t instead") char16_t uChar;
-
 // Disable free()
 #if DEBUG_ARC >= 4
 #define free(X) void()

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -65,8 +65,6 @@ T uAssertPtr(T ptr, const char* src, const char* msg) {
 #else
 #include <alloca.h>
 #endif
-// Deprecated -- use alloca() directly instead.
-#define U_ALLOCA(SIZE) alloca(SIZE)
 
 // C++11 compatibility
 #ifdef _MSC_VER

--- a/lib/UnoCore/Targets/Native/Native.uxl
+++ b/lib/UnoCore/Targets/Native/Native.uxl
@@ -10,8 +10,6 @@
 
     <!-- Environment -->
     <Define MSVC="HOST_WIN32" />
-    <!-- Deprecated -->
-    <Define MSVC12="HOST_WIN32" />
 
     <!-- Architecture (override by -DX86 or -DX64) -->
     <Define ARM="HOST_ARM" />

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -40,7 +40,6 @@
     "Backends/CPlusPlus/Uno/SupportApple.mm:File",
     "Backends/CPlusPlus/Uno/Uno.h:File",
     "Backends/CPlusPlus/Uno/WinAPIHelper.h:File",
-    "Backends/CPlusPlus/Uno/XliInterop.h:File",
     "prebuilt/uno-base.stuff:Stuff",
     "prebuilt/uno-base.uxl:Extensions",
     "prebuilt/uno-base-pinvoke.uxl:Extensions",


### PR DESCRIPTION
This removes legacy code from 2.0.

Fuselibs and other things I have tried still compile fine because these APIs are not used directly.