### PR TITLE
iOS Plist add definition for location usage description

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name)/@(Project.Name)-Info.plist
@@ -130,6 +130,8 @@
 #if @(Project.iOS.PList.NSLocationAlwaysUsageDescription:IsSet)
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>@(Project.iOS.PList.NSLocationAlwaysUsageDescription)</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>@(Project.iOS.PList.NSLocationAlwaysUsageDescription)</string>
 #endif
 
 #if @(Project.iOS.PList.NSLocationUsageDescription:IsSet)


### PR DESCRIPTION
Starting iOS 11, we have to add another Plist property `NSLocationAlwaysAndWhenInUseUsageDescription` when using geolocation continuously on foreground and background. More info [here](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationalwaysusagedescription?language=objc)

this is a fix for the issue: https://github.com/fuse-open/fuselibs/issues/1128