### PR TITLE
Hotfix: use TLS 1.2

### DIFF
--- a/src/engine/Uno.Build/Stuff/StuffWebClient.cs
+++ b/src/engine/Uno.Build/Stuff/StuffWebClient.cs
@@ -15,5 +15,11 @@ namespace Uno.Build.Stuff
             request.UserAgent = UserAgent;
             return request;
         }
+
+        static StuffWebClient()
+        {
+            // https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+        }
     }
 }


### PR DESCRIPTION
This makes sure we use TLS 1.2 when communicating with NuGet, because
NuGet recently dropped support for TLS 1.0 and 1.1.

If upgrading your Uno installation is inconvenient, it is possible to
enable TLS 1.2 for older Uno versions in the Windows Registry.

    reg add HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.30319 /v SystemDefaultTlsVersions /t REG_DWORD /d 1 /f /reg:64
    reg add HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.30319 /v SystemDefaultTlsVersions /t REG_DWORD /d 1 /f /reg:32

https://devblogs.microsoft.com/nuget/nuget-org-will-permanently-remove-support-for-tls-1-0-and-1-1-on-june-15th/
https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/