### PR TITLE
UnoCore: replace legacy includes

### DIFF
--- a/lib/Uno.Graphics.Utils/Cpp/CppTexture.uno
+++ b/lib/Uno.Graphics.Utils/Cpp/CppTexture.uno
@@ -7,10 +7,10 @@ namespace Uno.Graphics.Utils.Cpp
 {
     [extern(CPLUSPLUS) Require("Source.Include", "@{texture2D:Include}")]
     [extern(CPLUSPLUS) Require("Source.Include", "@{Exception:Include}")]
+    [extern(CPLUSPLUS) Require("Source.Include", "Uno/GLHelper.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uBase/Buffer.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uBase/BufferStream.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uBase/Memory.h")]
-    [extern(CPLUSPLUS) Require("Source.Include", "XliPlatform/GL.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uImage/Jpeg.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uImage/Png.h")]
     [extern(CPLUSPLUS) Require("Source.Include", "uImage/Texture.h")]

--- a/lib/UnoCore/Backends/CPlusPlus/Uno.cpp.uxl
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno.cpp.uxl
@@ -10,6 +10,7 @@
     <ProcessFile SourceFile="Uno/_main.cpp" Condition="!MOBILE"/>
     <ProcessFile SourceFile="Uno/_mainMobile.cpp" Condition="MOBILE" />
     <ProcessFile HeaderFile="Uno/GraphicsContext.h" />
+    <ProcessFile HeaderFile="Uno/GLHelper.h" Condition="OPENGL" />
     <ProcessFile SourceFile="Uno/Memory.cpp" />
     <ProcessFile HeaderFile="Uno/Memory.h" />
     <ProcessFile SourceFile="Uno/NativeStackTrace.cpp" />
@@ -20,7 +21,7 @@
     <ProcessFile HeaderFile="Uno/Support.h" />
     <ProcessFile SourceFile="Uno/SupportApple.mm" Condition="APPLE" />
     <ProcessFile HeaderFile="Uno/Uno.h" />
-    <ProcessFile HeaderFile="Uno/WinAPIHelper.h" />
+    <ProcessFile HeaderFile="Uno/WinAPIHelper.h" Condition="WIN32" />
     <ProcessFile SourceFile="Uno/Reflection.cpp" Condition="REFLECTION" />
     <ProcessFile HeaderFile="Uno/Reflection.h" Condition="REFLECTION" />
 

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/GLHelper.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/GLHelper.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#ifdef WIN32
+# ifndef GLEW_STATIC
+#   define GLEW_STATIC
+# endif
+# include <GL/glew.h>
+# include <GL/gl.h>
+# define U_GL_DESKTOP
+
+#elif defined(ANDROID)
+# include <GLES2/gl2.h>
+# include <GLES2/gl2ext.h>
+# define U_GL_ES2
+
+#elif defined(__APPLE__)
+# include <TargetConditionals.h>
+# if TARGET_OS_IPHONE
+#  include <OpenGLES/ES2/gl.h>
+#  include <OpenGLES/ES2/glext.h>
+#  define U_GL_ES2
+# else
+#  ifndef GLEW_STATIC
+#    define GLEW_STATIC
+#  endif
+#  include <GL/glew.h>
+#  include <OpenGL/gl.h>
+#  define U_GL_DESKTOP
+# endif
+
+#elif defined(__linux)
+# ifdef __arm__
+#  include <GLES2/gl2.h>
+#  include <GLES2/gl2ext.h>
+#  define U_GL_ES2
+# else
+#  include <GL/glew.h>
+#  include <GL/gl.h>
+#  define U_GL_DESKTOP
+# endif
+
+#else
+# error "Unsupported platform"
+#endif

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
@@ -14,9 +14,10 @@
 #include <mutex>
 @{byte:IncludeDirective}
 
-#if ANDROID
+#ifdef ANDROID
 #include <android/log.h>
-#elif IOS
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
 void uLogApple(const char* prefix, const char* format, va_list args);
 #else
 #include <cstdio>
@@ -47,7 +48,7 @@ void uLogv(int level, const char* format, va_list args)
     else if (level > uLogLevelFatal)
         level = uLogLevelFatal;
 
-#if ANDROID
+#ifdef ANDROID
     int logs[] = {
         ANDROID_LOG_DEBUG,  // uLogLevelDebug
         ANDROID_LOG_INFO,   // uLogLevelInformation
@@ -64,7 +65,7 @@ void uLogv(int level, const char* format, va_list args)
         "Error: ",      // uLogLevelError
         "Fatal: "       // uLogLevelFatal
     };
-#if IOS
+#if TARGET_OS_IPHONE
     // Defined in ObjC file to call NSLog()
     uLogApple(strings[level], format, args);
 #else

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
@@ -10,7 +10,6 @@
 #include <uImage/Png.h>
 #include <uImage/Texture.h>
 #include <XliPlatform/GL.h>
-#include <XliPlatform/MessageBox.h>
 #include <mutex>
 @{byte:IncludeDirective}
 
@@ -95,7 +94,6 @@ void uFatal(const char* src, const char* msg)
     uLog(uLogLevelFatal, "Runtime Error in %s: %s",
         src && strlen(src) ? src : "(unknown)",
         msg && strlen(msg) ? msg : "(no message)");
-    Xli::MessageBox::Show(NULL, "The application has crashed.", "Fatal Error", Xli::DialogButtonsOK, Xli::DialogHintsError);
     abort();
 }
 

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <stdint.h>
 #include <stdarg.h>
-#include <uBase/Config.h>
 
 // Debugging
 //#define DEBUG_ARC 0 // 0..4
@@ -14,8 +13,17 @@
 //#define DEBUG_UNSAFE 1
 //#define DEBUG_GENERICS 1
 
+// Attributes
+#ifdef _MSC_VER
+# define U_FUNCTION __FUNCTION__
+# define U_NORETURN __declspec(noreturn)
+#else
+# define U_FUNCTION __PRETTY_FUNCTION__
+# define U_NORETURN __attribute__((noreturn))
+#endif
+
 // Constants
-#if MSVC
+#ifdef _MSC_VER
 #pragma warning( disable : 4756 ) // overflow in constant arithmetic
 #endif
 const double DBL_INF = (double)(DBL_MAX + DBL_MAX);
@@ -60,7 +68,7 @@ T uAssertPtr(T ptr, const char* src, const char* msg) {
 #endif
 
 // Stack alloc
-#if MSVC
+#ifdef _MSC_VER
 #include <malloc.h>
 #else
 #include <alloca.h>

--- a/lib/UnoCore/Source/OpenGL/GL.uno
+++ b/lib/UnoCore/Source/OpenGL/GL.uno
@@ -5,7 +5,7 @@ using Uno.Runtime.InteropServices;
 
 namespace OpenGL
 {
-    [extern(CPLUSPLUS) Require("Source.Include", "XliPlatform/GL.h")]
+    [extern(CPLUSPLUS) Require("Source.Include", "Uno/GLHelper.h")]
     extern(OPENGL) public static class GL
     {
         // Setting and getting state [5.14.3]

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -26,6 +26,7 @@
     "Backends/CPlusPlus/Uno/_invoke.cpp:File",
     "Backends/CPlusPlus/Uno/_main.cpp:File",
     "Backends/CPlusPlus/Uno/_mainMobile.cpp:File",
+    "Backends/CPlusPlus/Uno/GLHelper.h:File",
     "Backends/CPlusPlus/Uno/GraphicsContext.h:File",
     "Backends/CPlusPlus/Uno/Memory.cpp:File",
     "Backends/CPlusPlus/Uno/Memory.h:File",


### PR DESCRIPTION
We want to eliminate legacy C++ libraries eventually in v2.X, and this
is a step in that direction.