### PR TITLE
.NET type aliases

### DIFF
--- a/lib/UnoCore/Source/Uno/AttributeTargets.uno
+++ b/lib/UnoCore/Source/Uno/AttributeTargets.uno
@@ -7,10 +7,10 @@ namespace Uno
     public enum AttributeTargets
     {
         /*
-            Note: Outcommented ones are taken from .NET, but are not useful in Uno.
+            Note: Outcommented ones are taken from .NET, but are not used in Uno (yet).
         */
 
-        //Assembly = 1
+        Assembly = 1,
         //Module = 2,
         Class = 4,
         Struct = 8,

--- a/lib/UnoCore/Source/Uno/Reflection/TypeAliasAttribute.uno
+++ b/lib/UnoCore/Source/Uno/Reflection/TypeAliasAttribute.uno
@@ -1,0 +1,16 @@
+namespace Uno.Reflection
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    extern(DOTNET && REFLECTION)
+    public class TypeAliasAttribute : Attribute
+    {
+        public readonly string Alias;
+        public readonly string Resolved;
+
+        public TypeAliasAttribute(string alias, string resolved)
+        {
+            Alias = alias;
+            Resolved = resolved;
+        }
+    }
+}

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -281,6 +281,7 @@
     "Source/Uno/Random.uno:Source",
     "Source/Uno/Rect.uno:Source",
     "Source/Uno/Reflection/CppReflection.uno:Source",
+    "Source/Uno/Reflection/TypeAliasAttribute.uno:Source",
     "Source/Uno/Runtime/Implementation/DirectBuffer.uno:Source",
     "Source/Uno/Runtime/Implementation/Internal/ArrayEnumerable.uno:Source",
     "Source/Uno/Runtime/Implementation/Internal/Bootstrapper.uno:Source",

--- a/src/compiler/backend/cil/CilBackend.cs
+++ b/src/compiler/backend/cil/CilBackend.cs
@@ -12,6 +12,9 @@ namespace Uno.Compiler.Backends.CIL
         CilLinker _linker;
         string _outputDir;
 
+        internal bool EnableReflection { get; private set; }
+        internal DataType TypeAliasAttribute { get; private set; }
+
         public override string Name => "CIL";
 
         public CilBackend(ShaderBackend shaderBackend)
@@ -31,6 +34,10 @@ namespace Uno.Compiler.Backends.CIL
                 Environment.ExpandSingleLine("@(AssemblyDirectory || '.')")).TrimPath();
             _linker = new CilLinker(Log, Essentials);
             Scheduler.AddTransform(new CilTransform(this));
+            EnableReflection = Environment.IsDefined("REFLECTION");
+            TypeAliasAttribute = EnableReflection
+                                ? ILFactory.GetType("Uno.Reflection.TypeAliasAttribute")
+                                : DataType.Invalid;
         }
 
         public override bool CanLink(SourcePackage upk)


### PR DESCRIPTION
This will emit assembly attributes containing information about how UnoCore types map to .NET Framework types, when `REFLECTION` is defined. This is helpful to make the implementation of Fuse Simulator more robust.