### PR TITLE
CLI: add --gen-only

### DIFF
--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -19,9 +19,9 @@ Available commands
   update         Update packages and project(s)
   build          Build a project for given target
   clean          Delete generated build and cache directories in project(s)
-  test           Run unit test project(s) and print results
+  test           Run test project(s)
   doctor         Repair/rebuild packages found in search paths
-  config         Print information about your Uno environment
+  config         Print information about your Uno configuration
   ls             Print project items found to STDOUT
 
 Experimental commands
@@ -106,6 +106,7 @@ Additional options
   -s, --set:NAME=STRING       Override build system property
   -o, --out-dir=PATH          Override output directory
   -b, --build-only            Build only; don't run or open debugger
+  -g, --gen-only              Generate only; don't compile generated code.
   -f, --force                 Build even if output is up-to-date
   -l, --libs                  Rebuild package library if necessary
   -p, --print-internals       Print a list of build system properties
@@ -124,21 +125,12 @@ C++ options
   -DSTACKTRACE                Enable stack traces on Exception
   -DDEBUG_UNSAFE              Enable C++ asserts in unsafe code
   -DDEBUG_NATIVE              Disable C++ optimizations when debugging
-  -DDEBUG_ARC<0..4>           Log events from ARC/memory management
-  -DDEBUG_DUMPS               Dump GraphViz files to help identify cycles in memory
-
-GLSL options
-  -DDUMP_SHADERS              Dump shaders to build directory for inspection
 
 Available build targets
   * android            C++/JNI/GLES2 code and APK. Runs on device.
   * native             C++/GL code, CMake project and native executable.
   * ios                (Objective-)C++/GLES2 code and Xcode project. (macOS only)
   * dotnet             .NET/GL bytecode and executable. (default)
-  * docs               Uno documentation files.
-  * metadata           Metadata for code completion.
-  * pinvoke            PInvoke libraries.
-  * package            Uno package files.
 ```
 
 ## uno no-build
@@ -165,12 +157,24 @@ Additional options
 ## uno clean
 
 ```
-Usage: uno clean [options] [project-path ...]
+Usage: uno clean [target] [options] [project-path ...]
 
 Delete generated build and cache directories in project(s).
 
+Examples
+  uno clean                     Clean all build-files (in current directory)
+  uno clean android -c Release  Clean only Android files (Release configuration)
+
 Available options
-  -r, --recursive       Look for project files recursively
+  -t, --target=STRING         Build target (see: Available build targets)
+  -c, --configuration=STRING  Build configuration [Debug|Release]
+  -r, --recursive             Look for project files recursively
+
+Available build targets
+  * android            C++/JNI/GLES2 code and APK. Runs on device.
+  * native             C++/GL code, CMake project and native executable.
+  * ios                (Objective-)C++/GLES2 code and Xcode project. (macOS only)
+  * dotnet             .NET/GL bytecode and executable. (default)
 ```
 
 ## uno test
@@ -182,6 +186,7 @@ Run test project(s).
 
 [paths-to-search] is a list of paths to unoprojs to run tests from, and/or
 directories in which to search for test projects.
+
 When a directory is given, uno test searches recursively in that directory
 for projects named '*Test.unoproj'
 
@@ -200,11 +205,12 @@ Available options
   -f, --filter=               Only run tests matching this string
   -e, --regex-filter=STRING   Only run tests matching this regular expression
       --trace                 Print trace information from unotest
-      --build-only            Don't run compiled program.
+  -b, --build-only            Don't run tests; only build.
+  -g, --gen-only              Don't run tests; only generate code.
       --no-uninstall          Don't uninstall tests after running on device
   -D, --define=STRING         Add define, to enable a feature
   -U, --undefine=STRING       Remove define, to disable a feature
-      --out-dir=PATH          Override output directory
+  -o, --out-dir=PATH          Override output directory
 
 Available build targets
   * android            C++/JNI/GLES2 code and APK. Runs on device.
@@ -306,7 +312,7 @@ Open file(s) in external application.
 
 Available options
   -a, --app=NAME        The name of the application to open
-  -a, --exe=PATH        The path to the executable to open [optional]
+  -e, --exe=PATH        The path to the executable to open [optional]
   -t, --title=NAME      Look for an existing window with this title [optional]
   -n, --new             Create a new process
 ```

--- a/src/test/runner/TestOptions.cs
+++ b/src/test/runner/TestOptions.cs
@@ -12,6 +12,7 @@ namespace Uno.TestRunner
         public string Filter;
         public bool Trace;
         public bool OnlyBuild;
+        public bool OnlyGenerate;
         public bool NoUninstall;
         public bool Library;
         public string OutputDirectory;

--- a/src/test/runner/TestProjectRunner.cs
+++ b/src/test/runner/TestProjectRunner.cs
@@ -61,11 +61,16 @@ namespace Uno.TestRunner
                     if (_options.Target is iOSBuild && !proj.MutableProperties.ContainsKey("iOS.BundleIdentifier"))
                         proj.MutableProperties["iOS.BundleIdentifier"] = "dev.testprojects." + proj.Name.ToIdentifier(true).ToLower();
 
+                    if (_options.OnlyGenerate)
+                        options.Native = false;
+
                     var builder = new ProjectBuilder(log, target, options);
                     var result = builder.Build(proj);
+
                     if (result.ErrorCount != 0)
                         throw new Exception("Build failed.");
-                    if (_options.OnlyBuild)
+
+                    if (_options.OnlyBuild || _options.OnlyGenerate)
                         return tests;
 
                     // We don't need a window when running tests.

--- a/src/tool/cli/Projects/BuildCommand.cs
+++ b/src/tool/cli/Projects/BuildCommand.cs
@@ -37,6 +37,7 @@ namespace Uno.CLI.Projects
             WriteRow("-s, --set:NAME=STRING",       "Override build system property");
             WriteRow("-o, --out-dir=PATH",          "Override output directory");
             WriteRow("-b, --build-only",            "Build only; don't run or open debugger");
+            WriteRow("-g, --gen-only",              "Generate only; don't compile generated code.");
             WriteRow("-f, --force",                 "Build even if output is up-to-date");
             WriteRow("-l, --libs",                  "Rebuild package library if necessary");
             WriteRow("-p, --print-internals",       "Print a list of build system properties");
@@ -92,6 +93,7 @@ namespace Uno.CLI.Projects
             var runArgs = new List<string>();
             var run = false;
             var buildOnly = false;
+            var genOnly = false;
             var input = new OptionSet {
                     { "t=|target=",             value => targetName = value },
                     { "c=|configuration=",      value => options.Configuration = value.ParseEnum<BuildConfiguration>("configuration") },
@@ -114,6 +116,7 @@ namespace Uno.CLI.Projects
                     { "d|debug",                value => runArgs.Add("debug") },
                     { "r|run",                  value => run = true },
                     { "b|build-only",           value => buildOnly = true },
+                    { "g|gen-only",             value => genOnly = true },
                     { "l|libs",                 value => options.Library = true },
                     { "f|force",                value => options.Force = true },
                     { "cd=",                    value => Directory.SetCurrentDirectory(value.ParseString("cd")) },
@@ -132,8 +135,11 @@ namespace Uno.CLI.Projects
                 options.Defines.Add("DEBUG_NATIVE"); // disable native optimizations (debug build)
             }
 
-            if (buildOnly)
+            if (buildOnly || genOnly)
             {
+                if (genOnly)
+                    options.Native = false;
+
                 runArgs.Clear();
                 run = false;
             }

--- a/src/tool/cli/Projects/BuildCommand.cs
+++ b/src/tool/cli/Projects/BuildCommand.cs
@@ -69,7 +69,7 @@ namespace Uno.CLI.Projects
             WriteHead("Available build targets", 19);
 
             foreach (var c in BuildTargets.Enumerate(Log.EnableExperimental))
-                WriteRow("* " + c.Identifier.ToLowerInvariant(), c.Description);
+                WriteRow("* " + c.Identifier, c.Description);
         }
 
         public override void Execute(IEnumerable<string> args)
@@ -99,7 +99,7 @@ namespace Uno.CLI.Projects
                     { "c=|configuration=",      value => options.Configuration = value.ParseEnum<BuildConfiguration>("configuration") },
                     { "s=|set=",                value => value.ParseProperty("s|set", options.Settings) },
                     { "p|print-internals",      value => options.PrintInternals = true },
-                    { "o=|out-dir|output-dir=", value => options.OutputDirectory = value },
+                    { "o=|out-dir=|output-dir=",    value => options.OutputDirectory = value },
                     { "m=|main=|main-class=",   value => options.MainClass = value },
                     { "n=|native-args=",        nativeArgs.Add },
                     { "a=|run-args=",           runArgs.Add },

--- a/src/tool/cli/Projects/Clean.cs
+++ b/src/tool/cli/Projects/Clean.cs
@@ -27,7 +27,7 @@ namespace Uno.CLI.Projects
             WriteHead("Available build targets", 19);
 
             foreach (var c in BuildTargets.Enumerate(Log.EnableExperimental))
-                WriteRow("* " + c.Identifier.ToLowerInvariant());
+                WriteRow("* " + c.Identifier, c.Description);
         }
 
         public override void Execute(IEnumerable<string> args)

--- a/src/tool/cli/Projects/Test.cs
+++ b/src/tool/cli/Projects/Test.cs
@@ -39,6 +39,7 @@ namespace Uno.CLI.Projects
             WriteRow("-e, --regex-filter=STRING",   "Only run tests matching this regular expression");
             WriteRow("    --trace",                 "Print trace information from unotest");
             WriteRow("    --build-only",            "Don't run compiled program.");
+            WriteRow("    --gen-only",              "Don't compile generated source code.");
             WriteRow("    --no-uninstall",          "Don't uninstall tests after running on device");
             WriteRow("-D, --define=STRING",         "Add define, to enable a feature");
             WriteRow("-U, --undefine=STRING",       "Remove define, to disable a feature");
@@ -104,6 +105,7 @@ namespace Uno.CLI.Projects
                 { "startup-timeout=",       v => Log.Warning("--startup-timeout is deprecated and has no effect.") },
                 { "trace",                  v => { options.Trace = v != null; } },
                 { "build-only|only-build",  v => options.OnlyBuild = v != null },
+                { "gen-only",               v => options.On = v != null },
                 { "allow-debugger",         v => Log.Warning("--allow-debugger is deprecated and has no effect.") },
                 { "d|debug",                v => Log.Warning("--debug is deprecated and has no effect.") },
                 { "run-local",              v => Log.Warning("--run-local is deprecated and has no effect.") },

--- a/src/tool/cli/Projects/Test.cs
+++ b/src/tool/cli/Projects/Test.cs
@@ -20,15 +20,16 @@ namespace Uno.CLI.Projects
             Log.Skip();
             WriteLine("[paths-to-search] is a list of paths to unoprojs to run tests from, and/or");
             WriteLine("directories in which to search for test projects.");
+            Log.Skip();
             WriteLine("When a directory is given, uno test searches recursively in that directory");
             WriteLine("for projects named '*Test.unoproj'");
             
             WriteHead("Examples");
-            WriteLine(@"  uno test");
-            WriteLine(@"  uno test path/projects");
-            WriteLine(@"  uno test path/projects/FooTest.unoproj path/projects/BarTest.unoproj");
-            WriteLine(@"  uno test path/projects path/other-projects/FooTest.unoproj");
-            WriteLine(@"  uno test native -v path/projects");
+            WriteLine("  uno test");
+            WriteLine("  uno test path/projects");
+            WriteLine("  uno test path/projects/FooTest.unoproj path/projects/BarTest.unoproj");
+            WriteLine("  uno test path/projects path/other-projects/FooTest.unoproj");
+            WriteLine("  uno test native -v path/projects");
 
             WriteHead("Available options", 26);
             WriteRow("-l, --logfile=PATH",          "Write output to this file instead of stdout");
@@ -38,17 +39,17 @@ namespace Uno.CLI.Projects
             WriteRow("-f, --filter=",               "Only run tests matching this string");
             WriteRow("-e, --regex-filter=STRING",   "Only run tests matching this regular expression");
             WriteRow("    --trace",                 "Print trace information from unotest");
-            WriteRow("    --build-only",            "Don't run compiled program.");
-            WriteRow("    --gen-only",              "Don't compile generated source code.");
+            WriteRow("-b, --build-only",            "Don't run tests; only build.");
+            WriteRow("-g, --gen-only",              "Don't run tests; only generate code.");
             WriteRow("    --no-uninstall",          "Don't uninstall tests after running on device");
             WriteRow("-D, --define=STRING",         "Add define, to enable a feature");
             WriteRow("-U, --undefine=STRING",       "Remove define, to disable a feature");
-            WriteRow("    --out-dir=PATH",          "Override output directory");
+            WriteRow("-o, --out-dir=PATH",          "Override output directory");
 
             WriteHead("Available build targets", 19);
 
             foreach (var c in BuildTargets.Enumerate(false))
-                WriteRow("* " + c.Identifier.ToLowerInvariant(), c.Description);
+                WriteRow("* " + c.Identifier, c.Description);
         }
 
         public override void Execute(IEnumerable<string> args)
@@ -101,18 +102,18 @@ namespace Uno.CLI.Projects
                 { "q|quiet",                v => quiet = v != null },
                 { "f|filter=",              v => options.Filter = Regex.Escape(v) },
                 { "e|regex-filter=",        v => options.Filter = v },
-                { "o|timeout=",             v => Log.Warning("--timeout is deprecated and has no effect.") },
+                { "timeout=",               v => Log.Warning("--timeout is deprecated and has no effect.") },
                 { "startup-timeout=",       v => Log.Warning("--startup-timeout is deprecated and has no effect.") },
                 { "trace",                  v => { options.Trace = v != null; } },
-                { "build-only|only-build",  v => options.OnlyBuild = v != null },
-                { "gen-only",               v => options.On = v != null },
+                { "b|build-only|only-build",    v => options.OnlyBuild = v != null },
+                { "g|gen-only",             v => options.OnlyGenerate = v != null },
                 { "allow-debugger",         v => Log.Warning("--allow-debugger is deprecated and has no effect.") },
                 { "d|debug",                v => Log.Warning("--debug is deprecated and has no effect.") },
                 { "run-local",              v => Log.Warning("--run-local is deprecated and has no effect.") },
                 { "no-uninstall",           v => options.NoUninstall = v != null },
                 { "D=|define=",             options.Defines.Add },
                 { "U=|undefine=",           options.Undefines.Add },
-                { "out-dir=|output-dir=",   v => options.OutputDirectory = v },
+                { "o=|out-dir=|output-dir=",    v => options.OutputDirectory = v },
                 { "libs",                   v => options.Library = true },
             };
 

--- a/src/tool/cli/System/Open.cs
+++ b/src/tool/cli/System/Open.cs
@@ -21,7 +21,7 @@ namespace Uno.CLI.System
 
             WriteHead("Available options");
             WriteRow("-a, --app=NAME",      "The name of the application to open");
-            WriteRow("-a, --exe=PATH",      "The path to the executable to open", true);
+            WriteRow("-e, --exe=PATH",      "The path to the executable to open", true);
             WriteRow("-t, --title=NAME",    "Look for an existing window with this title", true);
             WriteRow("-n, --new",           "Create a new process");
         }


### PR DESCRIPTION
This adds a `--gen-only` switch for `uno build` and `uno test` commands, and updates documentation.