### PR TITLE
Mac: fix Xcode 10 regression

### DIFF
--- a/src/runtime/mac/UnoGLView.cs
+++ b/src/runtime/mac/UnoGLView.cs
@@ -46,7 +46,7 @@ namespace Uno.Support.MonoMac
             _openGLContext = new NSOpenGLContext(pixelFormat, null);
             _openGLContext.MakeCurrentContext();
 
-            _notificationProxy = NSNotificationCenter.DefaultCenter.AddObserver(NSView.GlobalFrameChangedNotification, HandleReshape);
+            _notificationProxy = NSNotificationCenter.DefaultCenter.AddObserver(GlobalFrameChangedNotification, HandleReshape);
 
             WantsBestResolutionOpenGLSurface = true;
 
@@ -57,7 +57,7 @@ namespace Uno.Support.MonoMac
         bool _hasDown;
         int _lastX;
         int _lastY;
-        Uno.Platform.MouseButton _lastButton;
+        MouseButton _lastButton;
 
         public void RaiseMouseUp()
         {
@@ -75,7 +75,7 @@ namespace Uno.Support.MonoMac
             }
 
             OnPreUpdate();
-            if (Uno.Application.Current != null)
+            if (Application.Current != null)
                 Bootstrapper.OnUpdate();
         }
 
@@ -84,7 +84,7 @@ namespace Uno.Support.MonoMac
             if (Window == null || !Window.IsVisible)
                 return;
 
-            if (Uno.Application.Current != null)
+            if (Application.Current != null)
             {
                 Bootstrapper.OnDraw();
                 OnPostDraw();
@@ -124,11 +124,11 @@ namespace Uno.Support.MonoMac
             if (handler != null) handler();
         }
 
-        public Uno.Int2 DrawableSize
+        public Int2 DrawableSize
         {
             get {
                 var bounds = ConvertRectToBacking(Bounds);
-                return new Uno.Int2((int)bounds.Width, (int)bounds.Height);
+                return new Int2((int)bounds.Width, (int)bounds.Height);
             }
         }
 

--- a/src/runtime/mac/UnoGLView.cs
+++ b/src/runtime/mac/UnoGLView.cs
@@ -84,6 +84,11 @@ namespace Uno.Support.MonoMac
             if (Window == null || !Window.IsVisible)
                 return;
 
+            // This fixes rendering with Xcode 10 (macOS Mojave) and newer.
+            // https://github.com/xamarin/xamarin-macios/issues/4959#issuecomment-621914507
+            if (_openGLContext.View == null)
+                _openGLContext.View = this;
+
             if (Application.Current != null)
             {
                 Bootstrapper.OnDraw();


### PR DESCRIPTION
Apparently all OpenGL apps powered by Mono on Mac stopped rendering if
built on a machine with Xcode 10 (or newer) installed.

Xcode 9.4 on macOS High Sierra is the last known to work configuration,
and apps built on this configuration would still work fine on newer
macOS and Xcode, it sounds like.

This fixes OpenGL rendering in apps built with Xcode 10 (macOS Mojave)
and newer.

https://github.com/xamarin/xamarin-macios/issues/4959
