### PR TITLE
UnoCore: handle exception in Bundle.GetAssembly()

### DIFF
--- a/lib/UnoCore/Source/Uno/IO/Bundle.uno
+++ b/lib/UnoCore/Source/Uno/IO/Bundle.uno
@@ -321,9 +321,20 @@ namespace Uno.IO
                 if (!asm.GlobalAssemblyCache && asm.GetName().Name == name)
                     return asm;
 
-            // Lazy-load the assembly.
-            var e = _main ?? Assembly.GetExecutingAssembly();
-            return Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(e.Location), name + ".dll"));
+            try
+            {
+                // Lazy-load the assembly.
+                var e = _main ?? Assembly.GetExecutingAssembly();
+                return Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(e.Location), name + ".dll"));
+            }
+            catch
+            {
+                if (_main == null)
+                    Console.Error.WriteLine("Bundle: Not initialized?");
+
+                Console.Error.WriteLine("The assembly '" + name + "' could not be loaded.");
+                throw;
+            }
         }
     }
 


### PR DESCRIPTION
This adds some more debug-info if we get problems with assembly loading.