### PR TITLE
Reload config files

### DIFF
--- a/src/tool/config/UnoConfig.cs
+++ b/src/tool/config/UnoConfig.cs
@@ -13,7 +13,14 @@ namespace Uno.Configuration
     public class UnoConfig
     {
         static UnoConfig _current;
-        public static UnoConfig Current => _current ?? (_current = new UnoConfig());
+        public static UnoConfig Current => GetUpToDate(_current) ?? (_current = new UnoConfig());
+
+        public static UnoConfig GetUpToDate(UnoConfig config)
+        {
+            return config != null && config.IsUpToDate()
+                ? config
+                : null;
+        }
 
         public static UnoConfig Get(string path)
         {
@@ -57,6 +64,15 @@ namespace Uno.Configuration
                     file = _fileCache[filename] = new UnoConfigFile(filename);
 
             return file;
+        }
+
+        public bool IsUpToDate()
+        {
+            foreach (var f in _files)
+                if (!f.IsUpToDate())
+                    return false;
+
+            return true;
         }
 
         public void Clear()

--- a/src/tool/config/UnoConfig.cs
+++ b/src/tool/config/UnoConfig.cs
@@ -33,6 +33,7 @@ namespace Uno.Configuration
         readonly Dictionary<string, List<UnoConfigString>> _stringCache = new Dictionary<string, List<UnoConfigString>>();
         readonly Dictionary<string, string> _modules = new Dictionary<string, string>();
         readonly HashSet<string> _visitedDirectories = new HashSet<string>();
+        readonly DateTime _timestamp = DateTime.Now;
 
         public IReadOnlyList<UnoConfigFile> Files => _files;
         public IReadOnlyDictionary<string, string> NodeModules => _modules;
@@ -68,6 +69,10 @@ namespace Uno.Configuration
 
         public bool IsUpToDate()
         {
+            // Force invalidate every five seconds.
+            if ((DateTime.Now - _timestamp).TotalSeconds > 5.0)
+                return false;
+
             foreach (var f in _files)
                 if (!f.IsUpToDate())
                     return false;

--- a/src/tool/config/UnoConfigFile.cs
+++ b/src/tool/config/UnoConfigFile.cs
@@ -22,11 +22,26 @@ namespace Uno.Configuration
         }
 
         public readonly StuffFile Stuff;
+        public readonly DateTime Timestamp;
         StuffMap _data;
 
         internal UnoConfigFile(string filename)
         {
             Stuff = new StuffFile(filename, Defines);
+            Timestamp = File.GetLastWriteTime(filename);
+        }
+
+        public bool IsUpToDate()
+        {
+            try
+            {
+                return Timestamp == File.GetLastWriteTime(Stuff.Filename);
+            }
+            catch (IOException)
+            {
+                // File may be deleted at this point.
+                return false;
+            }
         }
 
         public StuffMap GetData()

--- a/src/tool/project/Project.cs
+++ b/src/tool/project/Project.cs
@@ -45,7 +45,7 @@ namespace Uno.ProjectFormat
         public string RootDirectory => Path.GetDirectoryName(_fullPath);
 
         public Source Source => new Source(_fullPath);
-        public UnoConfig Config => _config ?? (_config = UnoConfig.Get(_fullPath));
+        public UnoConfig Config => UnoConfig.GetUpToDate(_config) ?? (_config = UnoConfig.Get(_fullPath));
 
         public IReadOnlyList<PackageReference> PackageReferences => (IReadOnlyList<PackageReference>)_doc.OptionalPackages ?? new PackageReference[0];
         public IReadOnlyList<ProjectReference> ProjectReferences => GetFlattenedProjects();


### PR DESCRIPTION
Reload config files when changed on disk, or every five seconds.

The purpose of the five seconds test is to avoid potential bugs caused by changes in directory structure, i.e. adding or removing config files, that are not being detected by our first test.

The PR fixes a bug in Fuse Studio.