### PR TITLE
Add BuildTarget.ProjectGroup property 

### DIFF
--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -145,7 +145,7 @@ namespace Uno.Build
             if (_compilerOptions.Debug)
                 _env.Define("DEBUG");
             if (_options.Configuration != BuildConfiguration.Debug)
-                _env.Define(_options.Configuration.ToString().ToUpperInvariant());
+                _env.Define(_options.Configuration.ToString());
             if (_options.Configuration == BuildConfiguration.Preview)
                 _env.Define("REFLECTION", "SIMULATOR", "STACKTRACE");
 

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -153,7 +153,7 @@ namespace Uno.Build
                 _env.Define("HOST_" + def);
             foreach (var def in _options.Defines)
                 _env.Define(def);
-            foreach (var def in (_project.GetString(_target.Identifier + ".Defines") ?? "").Split('\n'))
+            foreach (var def in (_project.GetString(_target.ProjectGroup + ".Defines") ?? "").Split('\n'))
                 if (!string.IsNullOrEmpty(def))
                     _env.Define(def);
 

--- a/src/tool/engine/BuildTarget.cs
+++ b/src/tool/engine/BuildTarget.cs
@@ -14,6 +14,7 @@ namespace Uno.Build
     public abstract class BuildTarget
     {
         public abstract string Identifier { get; }
+        public abstract string ProjectGroup { get; }
         public virtual string FormerName => "";
         public virtual string[] FormerNames => new[] {FormerName};
         public virtual string Description => "";

--- a/src/tool/engine/Targets/AndroidBuild.cs
+++ b/src/tool/engine/Targets/AndroidBuild.cs
@@ -15,6 +15,7 @@ namespace Uno.Build.Targets
     public class AndroidBuild : BuildTarget
     {
         public override string Identifier => "android";
+        public override string ProjectGroup => "Android";
         public override string Description => "C++/JNI/GLES2 code and APK. Runs on device.";
 
         public override Backend CreateBackend()

--- a/src/tool/engine/Targets/DocsBuild.cs
+++ b/src/tool/engine/Targets/DocsBuild.cs
@@ -8,6 +8,7 @@ namespace Uno.Build.Targets
     {
         public override string Identifier => "docs";
         public override string FormerName => "unodoc";
+        public override string ProjectGroup => "UnoDoc";
         public override string Description => "Uno documentation files.";
         public override bool IsExperimental => true;
         public override bool DefaultStrip => false;

--- a/src/tool/engine/Targets/DotNetBuild.cs
+++ b/src/tool/engine/Targets/DotNetBuild.cs
@@ -8,6 +8,7 @@ namespace Uno.Build.Targets
     {
         public override string Identifier => "dotnet";
         public override string FormerName => "dotnetexe";
+        public override string ProjectGroup => "DotNet";
         public override string Description => ".NET/GL bytecode and executable. (default)";
         public override bool DefaultStrip => false;
 

--- a/src/tool/engine/Targets/MetadataBuild.cs
+++ b/src/tool/engine/Targets/MetadataBuild.cs
@@ -7,6 +7,7 @@ namespace Uno.Build.Targets
     public class MetadataBuild : BuildTarget
     {
         public override string Identifier => "metadata";
+        public override string ProjectGroup => "Metadata";
         public override string Description => "Metadata for code completion.";
         public override bool IsExperimental => true;
         public override bool DefaultStrip => false;

--- a/src/tool/engine/Targets/NativeBuild.cs
+++ b/src/tool/engine/Targets/NativeBuild.cs
@@ -12,6 +12,7 @@ namespace Uno.Build.Targets
         public override string Identifier => "native";
         public override string FormerName => "cmake";
         public override string[] FormerNames => new[] {"cmake", "msvc"};
+        public override string ProjectGroup => "Native";
         public override string Description => "C++/GL code, CMake project and native executable.";
 
         public override Backend CreateBackend()

--- a/src/tool/engine/Targets/PInvokeBuild.cs
+++ b/src/tool/engine/Targets/PInvokeBuild.cs
@@ -8,6 +8,7 @@ namespace Uno.Build.Targets
     public class PInvokeBuild : BuildTarget
     {
         public override string Identifier => "pinvoke";
+        public override string ProjectGroup => "PInvoke";
         public override string Description => "P/Invoke libraries.";
         public override bool IsExperimental => true;
         public override bool DefaultStrip => false;

--- a/src/tool/engine/Targets/PackageBuild.cs
+++ b/src/tool/engine/Targets/PackageBuild.cs
@@ -8,6 +8,7 @@ namespace Uno.Build.Targets
     {
         public override string Identifier => "package";
         public override string FormerName => "unopackage";
+        public override string ProjectGroup => "Package";
         public override string Description => "Uno package files.";
         public override bool IsExperimental => true;
         public override bool DefaultStrip => false;

--- a/src/tool/engine/Targets/iOSBuild.cs
+++ b/src/tool/engine/Targets/iOSBuild.cs
@@ -11,6 +11,7 @@ namespace Uno.Build.Targets
     public class iOSBuild : BuildTarget
     {
         public override string Identifier => "ios";
+        public override string ProjectGroup => "iOS";
         public override string Description => "(Objective-)C++/GLES2 code and Xcode project. (macOS only)";
 
         public override Backend CreateBackend()


### PR DESCRIPTION
This returns the prefix that should be used when looking up properties in the project file, for example 'iOS' in 'iOS.Defines'.

Fixes #359.