### PR TITLE
 Fix compile-time warnings on iOS

### DIFF
--- a/lib/Uno.Net.Sockets/Socket.uno
+++ b/lib/Uno.Net.Sockets/Socket.uno
@@ -164,7 +164,7 @@ namespace Uno.Net.Sockets
                 sa->sin6_family = family;
                 sa->sin6_port = htons(port);
                 memcpy(&sa->sin6_addr, address->Ptr(), 16);
-                sa->sin6_scope_id = (unsigned long)scopeId;
+                sa->sin6_scope_id = (uint32_t)scopeId;
             }
 
             return connect(sock, (sockaddr *)&ss, size);
@@ -190,7 +190,7 @@ namespace Uno.Net.Sockets
                 sa->sin6_family = family;
                 sa->sin6_port = htons(port);
                 memcpy(&sa->sin6_addr, address->Ptr(), 16);
-                sa->sin6_scope_id = (unsigned long)scopeId;
+                sa->sin6_scope_id = (uint32_t)scopeId;
             }
 
             return bind(sock, (sockaddr *)&ss, size);

--- a/lib/UnoCore/Source/Uno/Guid.uno
+++ b/lib/UnoCore/Source/Uno/Guid.uno
@@ -283,7 +283,7 @@ namespace Uno
         extern(CPLUSPLUS) uint ToUint(string str)
         @{
             uCString cstr(str);
-            unsigned long i;
+            uint32_t i;
             std::stringstream ss;
             ss << std::hex << cstr.Ptr;
             ss >> i;


### PR DESCRIPTION
This fixes compile-time warnings seen when building for iOS using latest version of Xcode.