### PR TITLE
iOS: recommend latest version of ios-deploy (not beta)

### DIFF
--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -20,7 +20,7 @@ esac
 if ! which ios-deploy > /dev/null 2>&1; then
     echo "ERROR: Unable to find the 'ios-deploy' command." >&2
     echo -e "\nYou can install ios-deploy using NPM:" >&2
-    echo -e "\n    npm install ios-deploy@beta -g\n" >&2
+    echo -e "\n    npm install ios-deploy -g\n" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Before it was important to install the beta version because a needed
fix was only included in beta version (related to deploying apps on
a recent version of iOS I believe). This fix is now included in recent
stable versions of ios-deploy so we can safely drop the beta-tag.