### PR TITLE
UnoCore: new Log class and deprecate assert-statements

### DIFF
--- a/lib/Uno.Testing/RemoteRunner.uno
+++ b/lib/Uno.Testing/RemoteRunner.uno
@@ -93,7 +93,7 @@ namespace Uno.Testing
                 var isLast = i + chunkLen >= uri.Length;
                 var output = "{" + chunk.Length + "|" + chunk + "}" + (isLast ? ";" : "\\");
 
-                Debug.Log(output);
+                Log.Debug(output);
 
                 if defined(iOS)
                 {
@@ -108,7 +108,7 @@ namespace Uno.Testing
                     // This won't FIX the problem completely, at least not in theory.
                     // Ideally we should fix this permanently in ios-deploy, but hopefully
                     // this workaround will be sufficient in the meantime.
-                    Debug.Log(output + " (retransmit)");
+                    Log.Debug(output + " (retransmit)");
                 }
             }
         }

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/Support.cpp
@@ -51,10 +51,10 @@ void uLogv(int level, const char* format, va_list args)
 #else
     static const char* strings[] = {
         "",             // uLogLevelDebug
-        "Info: ",       // uLogLevelInformation
-        "Warning: ",    // uLogLevelWarning
-        "Error: ",      // uLogLevelError
-        "Fatal: "       // uLogLevelFatal
+        "INFO: ",       // uLogLevelInformation
+        "WARNING: ",    // uLogLevelWarning
+        "ERROR: ",      // uLogLevelError
+        "FATAL: "       // uLogLevelFatal
     };
 #if TARGET_OS_IPHONE
     // Defined in ObjC file to call NSLog()

--- a/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
+++ b/lib/UnoCore/Backends/CPlusPlus/Uno/_config.h
@@ -38,11 +38,11 @@ const float FLT_NAN = (float)DBL_NAN;
 
 // Logging
 enum uLogLevel {
-    uLogLevelDebug = @{Uno.Diagnostics.DebugMessageType.Debug},
-    uLogLevelInformation = @{Uno.Diagnostics.DebugMessageType.Information},
-    uLogLevelWarning = @{Uno.Diagnostics.DebugMessageType.Warning},
-    uLogLevelError = @{Uno.Diagnostics.DebugMessageType.Error},
-    uLogLevelFatal = @{Uno.Diagnostics.DebugMessageType.Fatal}
+    uLogLevelDebug = @{Uno.Diagnostics.LogLevel.Debug},
+    uLogLevelInformation = @{Uno.Diagnostics.LogLevel.Information},
+    uLogLevelWarning = @{Uno.Diagnostics.LogLevel.Warning},
+    uLogLevelError = @{Uno.Diagnostics.LogLevel.Error},
+    uLogLevelFatal = @{Uno.Diagnostics.LogLevel.Fatal}
 };
 void uLog(int level, const char* format, ...);
 void uLogv(int level, const char* format, va_list args);

--- a/lib/UnoCore/Source/OpenGL/GL.uno
+++ b/lib/UnoCore/Source/OpenGL/GL.uno
@@ -1580,9 +1580,9 @@ namespace OpenGL
             if (glVersion == null || glVersion.IndexOf('.') == -1 ||
                     int.Parse(glVersion.Substring(0, glVersion.IndexOf('.'))) < 2)
             {
-                Debug.Log("GL_VERSION: " + glVersion);
-                Debug.Log("GL_VENDOR: " + gl.GetString(GLStringName.Vendor));
-                Debug.Log("GL_RENDERER: " + gl.GetString(GLStringName.Renderer));
+                Log.Debug("GL_VERSION: " + glVersion);
+                Log.Debug("GL_VENDOR: " + gl.GetString(GLStringName.Vendor));
+                Log.Debug("GL_RENDERER: " + gl.GetString(GLStringName.Renderer));
                 throw new NotSupportedException("OpenGL 2.0 is required to run this application");
             }
         }

--- a/lib/UnoCore/Source/OpenGL/GLDebugLayer.uno
+++ b/lib/UnoCore/Source/OpenGL/GLDebugLayer.uno
@@ -440,7 +440,7 @@ namespace OpenGL
             var err = _gl.GetError();
             if (err != 0)
             {
-                Debug.Log("GL error (" + err + ")", DebugMessageType.Error);
+                Log.Error("GL error (" + err + ")");
                 var frames = new StackTrace().GetFrames();
 
                 for (int i = 3; i < frames.Length; i++)
@@ -449,7 +449,7 @@ namespace OpenGL
                     if (f.GetMethod().Name == "Main")
                         break;
 
-                    Debug.Log("in " + f.GetMethod().DeclaringType + "." + f.GetMethod().Name + "()");
+                    Log.Debug("in " + f.GetMethod().DeclaringType + "." + f.GetMethod().Name + "()");
                 }
             }
         }

--- a/lib/UnoCore/Source/Uno/Diagnostics/Debug.uno
+++ b/lib/UnoCore/Source/Uno/Diagnostics/Debug.uno
@@ -14,6 +14,7 @@ namespace Uno.Diagnostics
 
     public delegate void AssertionHandler(bool value, string expression, string filename, int line, params object[] operands);
 
+    [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
     public delegate void LogHandler(string message, DebugMessageType type);
 
     public static class Debug
@@ -42,27 +43,31 @@ namespace Uno.Diagnostics
 
         static LogHandler _logHandler;
 
-        [Obsolete]
+        [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
         public static void SetLogHandler(LogHandler handler)
         {
             _logHandler = handler;
         }
 
+        [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
         public static void Log(string message, DebugMessageType type, string filename, int line)
         {
             EmitLog(message, type);
         }
 
+        [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
         public static void Log(object message, DebugMessageType type, string filename, int line)
         {
             EmitLog((message ?? string.Empty).ToString(), type);
         }
 
+        [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
         public static void Log(string message, DebugMessageType type = 0)
         {
             EmitLog(message, type);
         }
 
+        [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
         public static void Log(object message, DebugMessageType type = 0)
         {
             EmitLog(message.ToString(), type);

--- a/lib/UnoCore/Source/Uno/Diagnostics/Debug.uno
+++ b/lib/UnoCore/Source/Uno/Diagnostics/Debug.uno
@@ -3,6 +3,7 @@ using System;
 
 namespace Uno.Diagnostics
 {
+    [Obsolete("Please use Uno.Diagnostics.LogLevel instead.")]
     public enum DebugMessageType
     {
         Debug,
@@ -12,14 +13,15 @@ namespace Uno.Diagnostics
         Fatal,
     }
 
+    [Obsolete]
     public delegate void AssertionHandler(bool value, string expression, string filename, int line, params object[] operands);
 
     [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
     public delegate void LogHandler(string message, DebugMessageType type);
 
+    [Obsolete("Please use the Uno.Diagnostics.Log class instead.")]
     public static class Debug
     {
-        // TODO: Deprecated
         static AssertionHandler _assertionHandler;
 
         [Obsolete]
@@ -28,7 +30,7 @@ namespace Uno.Diagnostics
             _assertionHandler = handler;
         }
 
-        // TODO: Deprecated
+        [Obsolete("Please use the Uno.Testing.Assert class instead.")]
         public static void Assert(bool value, string expression, string filename, int line, params object[] operands)
         {
             if (_assertionHandler != null)
@@ -87,6 +89,7 @@ namespace Uno.Diagnostics
             _indentStr = _indentStr.Substring( 0, _indentStr.Length - 1 );
         }
 
+        [Obsolete]
         static void EmitLog(string message, DebugMessageType type)
         {
             if (_logHandler != null)

--- a/lib/UnoCore/Source/Uno/Diagnostics/Log.uno
+++ b/lib/UnoCore/Source/Uno/Diagnostics/Log.uno
@@ -107,10 +107,10 @@ namespace Uno.Diagnostics
             {
                 if (level == 0)
                     Console.WriteLine(message);
-                else if ((int) level < LogLevel.Warning)
-                    Console.Out.WriteLine(level + ": " + message);
+                else if (level == LogLevel.Information)
+                    Console.WriteLine("INFO: " + message);
                 else
-                    Console.Error.WriteLine(level + ": " + message);
+                    Console.Error.WriteLine(level.ToString().ToUpper() + ": " + message);
             }
             else
             {

--- a/lib/UnoCore/Source/Uno/Diagnostics/Log.uno
+++ b/lib/UnoCore/Source/Uno/Diagnostics/Log.uno
@@ -1,0 +1,121 @@
+using Uno.Compiler.ExportTargetInterop;
+using System;
+
+namespace Uno.Diagnostics
+{
+    /** An enum representing the severity of a log message. */
+    public enum LogLevel
+    {
+        Debug,
+        Information,
+        Warning,
+        Error,
+        Fatal,
+    }
+
+    /** A class for writing to the log. */
+    public static class Log
+    {
+        extern(PREVIEW)
+        static Action<LogLevel, string> _handler;
+
+        extern(PREVIEW)
+        public static void SetHandler(Action<LogLevel, string> handler)
+        {
+            _handler = handler;
+        }
+
+        /** Writes a debug message to the log. */
+        public static void Debug(string message)
+        {
+            WriteLine(LogLevel.Debug, message);
+        }
+
+        /** Writes a debug message to the log. */
+        public static void Debug(string format, params object[] args)
+        {
+            WriteLine(LogLevel.Debug, format, args);
+        }
+
+        /** Writes an informational message to the log. */
+        public static void Information(string message)
+        {
+            WriteLine(LogLevel.Information, message);
+        }
+
+        /** Writes an informational message to the log. */
+        public static void Information(string format, params object[] args)
+        {
+            WriteLine(LogLevel.Information, format, args);
+        }
+
+        /** Writes a warning message to the log. */
+        public static void Warning(string message)
+        {
+            WriteLine(LogLevel.Warning, message);
+        }
+
+        /** Writes a warning message to the log. */
+        public static void Warning(string format, params object[] args)
+        {
+            WriteLine(LogLevel.Warning, format, args);
+        }
+
+        /** Writes an error message to the log. */
+        public static void Error(string message)
+        {
+            WriteLine(LogLevel.Error, message);
+        }
+
+        /** Writes an error message to the log. */
+        public static void Error(string format, params object[] args)
+        {
+            WriteLine(LogLevel.Error, format, args);
+        }
+
+        /** Writes a fatal error message to the log. */
+        public static void Fatal(string message)
+        {
+            WriteLine(LogLevel.Fatal, message);
+        }
+
+        /** Writes a fatal error message to the log. */
+        public static void Fatal(string format, params object[] args)
+        {
+            WriteLine(LogLevel.Fatal, format, args);
+        }
+
+        /** Writes a message to the log. */
+        public static void WriteLine(LogLevel level, string format, params object[] args)
+        {
+            WriteLine(level, string.Format(format, args));
+        }
+
+        /** Writes a message to the log. */
+        public static void WriteLine(LogLevel level, string message)
+        {
+            if defined(PREVIEW)
+                if (_handler != null)
+                    _handler(level, message);
+
+            if defined(CPLUSPLUS)
+            @{
+                uCString cstr($1);
+                uLog($0, "%s", cstr.Ptr);
+            @}
+            else if defined(DOTNET)
+            {
+                if (level == 0)
+                    Console.WriteLine(message);
+                else if ((int) level < LogLevel.Warning)
+                    Console.Out.WriteLine(level + ": " + message);
+                else
+                    Console.Error.WriteLine(level + ": " + message);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/lib/UnoCore/Source/Uno/Graphics/OpenGL/GLHelper.uno
+++ b/lib/UnoCore/Source/Uno/Graphics/OpenGL/GLHelper.uno
@@ -13,7 +13,7 @@ namespace Uno.Graphics.OpenGL
             var err = GL.GetError();
 
             if (err != GLError.NoError)
-                Debug.Log("GL error (" + err.ToString() + ")", DebugMessageType.Error);
+                Log.Error("GL error (" + err.ToString() + ")");
         }
 
         public static void CheckFramebufferStatus()
@@ -21,7 +21,7 @@ namespace Uno.Graphics.OpenGL
             var status = GL.CheckFramebufferStatus(GLFramebufferTarget.Framebuffer);
 
             if (status != GLFramebufferStatus.FramebufferComplete)
-                Debug.Log("Incomplete GL framebuffer (" + status + ")", DebugMessageType.Error);
+                Log.Error("Incomplete GL framebuffer (" + status + ")");
         }
 
         public static void TexImage2DFromBytes(GLTextureTarget target, int w, int h, int mip, Format format, byte[] data)

--- a/lib/UnoCore/Source/Uno/Platform/CoreApp.uno
+++ b/lib/UnoCore/Source/Uno/Platform/CoreApp.uno
@@ -1,5 +1,6 @@
 using OpenGL;
 using Uno.Collections;
+using Uno.Diagnostics;
 using Uno.Graphics;
 using Uno.Platform;
 using Uno.Compiler.ExportTargetInterop;
@@ -87,11 +88,11 @@ namespace Uno.Platform
             switch (State)
             {
                 case ApplicationState.Terminating:
-                    debug_log "EnterForeground() called on terminating application";
+                    Log.Error("CoreApp: EnterForeground() called on terminating application");
                     return;
 
                 case ApplicationState.Uninitialized:
-                    debug_log "EnterForeground() called on uninitialized application";
+                    Log.Error("CoreApp: EnterForeground() called on uninitialized application");
                     return;
 
                 case ApplicationState.Background:
@@ -125,11 +126,11 @@ namespace Uno.Platform
             switch (State)
             {
                 case ApplicationState.Terminating:
-                    debug_log "EnterInteractive() called on terminating application";
+                    Log.Error("CoreApp: EnterInteractive() called on terminating application");
                     return;
 
                 case ApplicationState.Uninitialized:
-                    debug_log "EnterInteractive() called on uninitialized application";
+                    Log.Error("CoreApp: EnterInteractive() called on uninitialized application");
                     return;
 
                 case ApplicationState.Background:

--- a/lib/UnoCore/Source/Uno/Platform/CoreApp.uno
+++ b/lib/UnoCore/Source/Uno/Platform/CoreApp.uno
@@ -67,7 +67,8 @@ namespace Uno.Platform
 
             if defined(CPlusPlus) extern "uInitRtti()";
 
-            assert State == ApplicationState.Uninitialized;
+            if (State != ApplicationState.Uninitialized)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             if defined(CPlusPlus) extern "uStartApp()";
 
@@ -77,7 +78,8 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Background;
+            if (State != ApplicationState.Background)
+                throw new InvalidOperationException("CoreApp: Invalid state");
         }
 
         internal static void EnterForeground()
@@ -101,7 +103,8 @@ namespace Uno.Platform
                     return;
             }
 
-            assert State == ApplicationState.Background;
+            if (State != ApplicationState.Background)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             State = ApplicationState.Foreground;
 
@@ -109,7 +112,8 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Foreground;
+            if (State != ApplicationState.Foreground)
+                throw new InvalidOperationException("CoreApp: Invalid state");
         }
 
         [extern(android) Require("Source.Include", "Uno/Graphics/GLHelper.h")]
@@ -139,7 +143,8 @@ namespace Uno.Platform
                     return;
             }
 
-            assert State == ApplicationState.Foreground;
+            if (State != ApplicationState.Foreground)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             State = ApplicationState.Interactive;
 
@@ -147,7 +152,8 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Interactive;
+            if (State != ApplicationState.Interactive)
+                throw new InvalidOperationException("CoreApp: Invalid state");
         }
 
         internal static void ExitInteractive()
@@ -171,7 +177,8 @@ namespace Uno.Platform
                     break;
             }
 
-            assert State == ApplicationState.Interactive;
+            if (State != ApplicationState.Interactive)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             State = ApplicationState.Foreground;
 
@@ -179,7 +186,8 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Foreground;
+            if (State != ApplicationState.Foreground)
+                throw new InvalidOperationException("CoreApp: Invalid state");
         }
 
         internal static void EnterBackground()
@@ -203,7 +211,8 @@ namespace Uno.Platform
                     break;
             }
 
-            assert State == ApplicationState.Foreground;
+            if (State != ApplicationState.Foreground)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             State = ApplicationState.Background;
 
@@ -211,7 +220,8 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Background;
+            if (State != ApplicationState.Background)
+                throw new InvalidOperationException("CoreApp: Invalid state");
         }
 
         internal static void Terminate()
@@ -231,7 +241,8 @@ namespace Uno.Platform
                     break;
             }
 
-            assert State == ApplicationState.Background;
+            if (State != ApplicationState.Background)
+                throw new InvalidOperationException("CoreApp: Invalid state");
 
             State = ApplicationState.Terminating;
 
@@ -239,7 +250,9 @@ namespace Uno.Platform
             if (handler != null)
                 handler(State);
 
-            assert State == ApplicationState.Terminating;
+            if (State != ApplicationState.Terminating)
+                throw new InvalidOperationException("CoreApp: Invalid state");
+
             State = ApplicationState.Uninitialized;
         }
 

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -148,6 +148,7 @@
     "Source/Uno/Delegate.uno:Source",
     "Source/Uno/Diagnostics/Clock.uno:Source",
     "Source/Uno/Diagnostics/Debug.uno:Source",
+    "Source/Uno/Diagnostics/Log.uno:Source",
     "Source/Uno/Double.uno:Source",
     "Source/Uno/Enum.uno:Source",
     "Source/Uno/Environment.uno:Source",

--- a/src/compiler/core/Syntax/Compilers/FunctionCompiler.Statements.Statement.cs
+++ b/src/compiler/core/Syntax/Compilers/FunctionCompiler.Statements.Statement.cs
@@ -556,10 +556,7 @@ namespace Uno.Compiler.Core.Syntax.Compilers
                         return new NoOp(e.Source, "Stripped debug_log");
                     var s = (AstValueStatement) e;
                     var message = CompileExpression(s.Value);
-                    var messageType = ILFactory.GetExpression(s.Source, "Uno.Diagnostics.DebugMessageType.Debug");
-                    var file = new Constant(s.Source, Essentials.String, s.Source.File.ToString().Replace('\\', '/'));
-                    var line = new Constant(s.Source, Essentials.Int, s.Source.Line);
-                    return ILFactory.CallMethod(s.Source, "Uno.Diagnostics.Debug", "Log", message, messageType, file, line);
+                    return ILFactory.CallMethod(s.Source, "Uno.Diagnostics.Log", "Debug", message);
                 }
                 case AstStatementType.BuildError:
                     return CreateBuildError(e.Source, true);

--- a/src/runtime/mac/MonoMacEnums.cs
+++ b/src/runtime/mac/MonoMacEnums.cs
@@ -6,15 +6,15 @@ namespace Uno.Support.MonoMac
 {
     public static class MonoMacEnums
     {
-        public static NSAlertStyle GetAlertStyle(Uno.Diagnostics.DebugMessageType type)
+        public static NSAlertStyle GetAlertStyle(Uno.Diagnostics.LogLevel level)
         {
-            switch (type)
+            switch (level)
             {
-                case Uno.Diagnostics.DebugMessageType.Error:
+                case Uno.Diagnostics.LogLevel.Error:
                     return NSAlertStyle.Critical;
-                case Uno.Diagnostics.DebugMessageType.Warning:
+                case Uno.Diagnostics.LogLevel.Warning:
                     return NSAlertStyle.Warning;
-                case Uno.Diagnostics.DebugMessageType.Information:
+                case Uno.Diagnostics.LogLevel.Information:
                     return NSAlertStyle.Informational;
                 default:
                     return 0;

--- a/src/runtime/mac/UnoGLView.cs
+++ b/src/runtime/mac/UnoGLView.cs
@@ -150,7 +150,7 @@ namespace Uno.Support.MonoMac
             if (MonoMacEnums.TryGetUnoKey((NSKey)theEvent.KeyCode, out key))
                 Bootstrapper.OnKeyDown(_unoWindow, key);
             else
-                Debug.Log("Unsupported key code: " + theEvent.KeyCode, DebugMessageType.Error);
+                Log.Error("Unsupported key code: " + theEvent.KeyCode);
 
             if (EnableText && IsTextInputEvent (ModifierFlags))
             {
@@ -180,7 +180,7 @@ namespace Uno.Support.MonoMac
             if (MonoMacEnums.TryGetUnoKey((NSKey)theEvent.KeyCode, out key))
                 Bootstrapper.OnKeyUp(_unoWindow, key);
             else
-                Debug.Log("Unsupported key code: " + theEvent.KeyCode, DebugMessageType.Error);
+                Log.Error("Unsupported key code: " + theEvent.KeyCode);
         }
 
         public override void MouseMoved(NSEvent theEvent)
@@ -204,7 +204,7 @@ namespace Uno.Support.MonoMac
             }
             else
             {
-                Debug.Log("Unsupported mouse button: " + theEvent.ButtonNumber, DebugMessageType.Error);
+                Log.Error("Unsupported mouse button: " + theEvent.ButtonNumber);
             }
         }
 
@@ -220,7 +220,7 @@ namespace Uno.Support.MonoMac
             }
             else
             {
-                Debug.Log("Unsupported mouse button: " + theEvent.ButtonNumber, DebugMessageType.Error);
+                Log.Error("Unsupported mouse button: " + theEvent.ButtonNumber);
             }
         }
 

--- a/tests/src/StringBuilderBenchmark/App.uno
+++ b/tests/src/StringBuilderBenchmark/App.uno
@@ -38,8 +38,8 @@ public class StringBuilderBenchmark : Uno.Application
         var str = sb.ToString();
 
         var endTick = Clock.GetSeconds();
-        Debug.Log("length: " + str.Length);
-        Debug.Log("time: " + (endTick - startTick) * 1000 + " ms");
+        Log.Debug("length: " + str.Length);
+        Log.Debug("time: " + (endTick - startTick) * 1000 + " ms");
     }
 
     public static void ShortStrings(int count)
@@ -60,8 +60,8 @@ public class StringBuilderBenchmark : Uno.Application
         var str = sb.ToString();
 
         var endTick = Clock.GetSeconds();
-        Debug.Log("length: " + str.Length);
-        Debug.Log("time: " + (endTick - startTick) * 1000 + " ms");
+        Log.Debug("length: " + str.Length);
+        Log.Debug("time: " + (endTick - startTick) * 1000 + " ms");
     }
 
     public static void Chars(int count)
@@ -79,8 +79,8 @@ public class StringBuilderBenchmark : Uno.Application
         var str = sb.ToString();
 
         var endTick = Clock.GetSeconds();
-        Debug.Log("length: " + str.Length);
-        Debug.Log("time: " + (endTick - startTick) * 1000 + " ms");
+        Log.Debug("length: " + str.Length);
+        Log.Debug("time: " + (endTick - startTick) * 1000 + " ms");
     }
 
     public static void CharArrays(int count)
@@ -98,26 +98,26 @@ public class StringBuilderBenchmark : Uno.Application
         var str = sb.ToString();
 
         var endTick = Clock.GetSeconds();
-        Debug.Log("length: " + str.Length);
-        Debug.Log("time: " + (endTick - startTick) * 1000 + " ms");
+        Log.Debug("length: " + str.Length);
+        Log.Debug("time: " + (endTick - startTick) * 1000 + " ms");
     }
 
     public StringBuilderBenchmark()
     {
-        Debug.Log("LongStrings:");
+        Log.Debug("LongStrings:");
         LongStrings(10000);
-        Debug.Log("");
+        Log.Debug("");
 
-        Debug.Log("ShortStrings:");
+        Log.Debug("ShortStrings:");
         ShortStrings(10000);
-        Debug.Log("");
+        Log.Debug("");
 
-        Debug.Log("Chars:");
+        Log.Debug("Chars:");
         Chars(10000);
-        Debug.Log("");
+        Log.Debug("");
 
-        Debug.Log("CharArrays:");
+        Log.Debug("CharArrays:");
         CharArrays(10000);
-        Debug.Log("");
+        Log.Debug("");
     }
 }


### PR DESCRIPTION
This adds a new Log class with a cleaner interface to replace the old
Debug class in Uno.Diagnostics.

Also deprecates legacy assert-statements and related functionality in
Uno.Diagnostics.Debug.