### PR TITLE
UnoCore: missing files and iOS warning

### DIFF
--- a/lib/UnoCore/Source/Uno/Platform/iOS/Application.uno
+++ b/lib/UnoCore/Source/Uno/Platform/iOS/Application.uno
@@ -39,7 +39,7 @@ namespace Uno.Platform.iOS
         {
             get
             @{
-                return [UIApplication sharedApplication].applicationIconBadgeNumber;
+                return (int32_t)[UIApplication sharedApplication].applicationIconBadgeNumber;
             @}
             set
             @{

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -8,6 +8,15 @@
     "UnoCore.Test"
   ],
   "Includes": [
+    "Assets/adaptive_icon/drawable/icon_background.xml:File",
+    "Assets/adaptive_icon/drawable/icon_foreground.xml:File",
+    "Assets/adaptive_icon/mipmap-anydpi-v26/icon.xml:File",
+    "Assets/adaptive_icon/mipmap-anydpi-v26/icon_round.xml:File",
+    "Assets/adaptive_icon/mipmap-hdpi/icon_round.png:File",
+    "Assets/adaptive_icon/mipmap-mdpi/icon_round.png:File",
+    "Assets/adaptive_icon/mipmap-xhdpi/icon_round.png:File",
+    "Assets/adaptive_icon/mipmap-xxhdpi/icon_round.png:File",
+    "Assets/adaptive_icon/mipmap-xxxhdpi/icon_round.png:File",
     "Assets/Black.png:File",
     "Assets/DefaultIcon.png:File",
     "Assets/Icon.icns:File",


### PR DESCRIPTION
This adds missing files to the project (after #363) and silences a compile-time warning when building for iOS.