### PR TITLE
unodoc: fix typo in output folder

### DIFF
--- a/src/compiler/backend/unodoc/UnoDocBackend.cs
+++ b/src/compiler/backend/unodoc/UnoDocBackend.cs
@@ -26,7 +26,7 @@ namespace Uno.Compiler.Backends.UnoDoc
             var skipDeleteDeprecated = Environment.ExpandSingleLine("@(ReferenceSkipDeleteDeprecated)") == "true";
 
             var apiPath = Path.Combine(renderToPath, "api");
-            var indexPath = Path.Combine(renderToPath, "indicies");
+            var indexPath = Path.Combine(renderToPath, "indices");
 
             Log.Message("Starting view model generation");
             var sw = Stopwatch.StartNew();


### PR DESCRIPTION
"indicies" is a mistake, so let's fix this typo while at it.