### PR TITLE
app-win: print warning and minor clean-ups

### DIFF
--- a/src/runtime/win/MainForm.cs
+++ b/src/runtime/win/MainForm.cs
@@ -47,7 +47,7 @@ namespace Uno.AppLoader
 
         public void MainLoop()
         {
-            var context = new System.Windows.Forms.ApplicationContext(this);
+            var context = new ApplicationContext(this);
             context.MainForm.Visible = true;
 
             var openAdapter = new D3DKMT_OPENADAPTERFROMHDC();

--- a/src/runtime/win/OpenTK/GL.cs
+++ b/src/runtime/win/OpenTK/GL.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using OpenGL;
 using OpenTK.Graphics.ES20;
+using Uno.Diagnostics;
 using TKGL = OpenTK.Graphics.ES20.GL;
 
 namespace Uno.Support.OpenTK
@@ -299,7 +300,6 @@ namespace Uno.Support.OpenTK
 
         public void UniformMatrix4(int location, bool transpose, Float4x4 value)
         {
-            // Who is always changing this function creating a temp array? Please stop committing your workarounds. Thanks
             TKGL.UniformMatrix4(location, 1, transpose, ref value.M11);
         }
 
@@ -524,8 +524,7 @@ namespace Uno.Support.OpenTK
 
         public void PointSize(float size)
         {
-            // TODO: Remove method from GL interface.
-            // glPointSize isn't supported by OpenGL ES 2.0, instead use the built-in vertex shader variable 'gl_PointSize'.
+            Log.Warning("GL.PointSize() isn't supported by OpenGL ES 2.0, instead use the built-in vertex shader variable 'gl_PointSize'.");
         }
 
         public void PolygonOffset(float factor, float units)


### PR DESCRIPTION
Some minor clean-ups to our .NET app-loader for Windows.