### PR TITLE
Make configuration directory lower-case

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,11 @@ environment:
 
 install:
   - ps: |
-      if ($env:Target -eq "android") {
+      if ($env:TARGET -eq "android") {
         Invoke-Expression "npm install android-build-tools -g"
       }
   - ps: |
-      if ($env:Target -eq "native") {
+      if ($env:TARGET -eq "native") {
         Invoke-WebRequest https://www.nuget.org/api/v2/package/mesa3d-x64/18.3.4 -OutFile mesa.zip
         Expand-Archive mesa.zip mesa
       }
@@ -29,15 +29,15 @@ build_script:
 
 after_build:
   - ps: |
-      if ($env:Target -eq "dotnet") {
+      if ($env:TARGET -eq "dotnet") {
         Push-AppveyorArtifact "fuse-open-uno-*.tgz"
       }
 
 before_test:
   - ps: |
-      if ($env:Target -eq "native") {
+      if ($env:TARGET -eq "native") {
         Get-ChildItem -Path lib -Recurse -Include *Test.unoproj | Select-Object -ExpandProperty DirectoryName | Foreach-Object {
-          $buildDir = Join-Path $_ build\$env:Target\Test
+          $buildDir = Join-Path $_ build\$env:TARGET\test
           New-Item -Force -ItemType directory -Path $buildDir | Out-Null
           Copy-Item -Path mesa\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
         }

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -106,7 +106,7 @@ Additional options
   -s, --set:NAME=STRING       Override build system property
   -o, --out-dir=PATH          Override output directory
   -b, --build-only            Build only; don't run or open debugger
-  -g, --gen-only              Generate only; don't compile generated code.
+  -g, --gen-only              Generate only; don't compile generated code
   -f, --force                 Build even if output is up-to-date
   -l, --libs                  Rebuild package library if necessary
   -p, --print-internals       Print a list of build system properties
@@ -199,14 +199,14 @@ Examples
 
 Available options
   -l, --logfile=PATH          Write output to this file instead of stdout
-  -t, --target=STRING         Build target. Supported: android, dotnet and native
-  -v, --verbose               Verbose, always prints output from compiler and debug_log
-  -q, --quiet                 Quiet, only prints output from compiler and debug_log in case of errors.
+  -t, --target=STRING         Build target (see: Available build targets)
+  -v, --verbose               Verbose, always prints output from compiler and app
+  -q, --quiet                 Quiet, only prints output from compiler and app in case of errors
   -f, --filter=               Only run tests matching this string
   -e, --regex-filter=STRING   Only run tests matching this regular expression
       --trace                 Print trace information from unotest
-  -b, --build-only            Don't run tests; only build.
-  -g, --gen-only              Don't run tests; only generate code.
+  -b, --build-only            Don't run tests; only build
+  -g, --gen-only              Don't run tests; only generate code
       --no-uninstall          Don't uninstall tests after running on device
   -D, --define=STRING         Add define, to enable a feature
   -U, --undefine=STRING       Remove define, to disable a feature

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -92,7 +92,7 @@ Examples
   uno build native --debug    Build & open Visual C++ or Xcode, if available
 
 Common options
-  -c, --configuration=STRING  Build configuration [Debug|Release]
+  -c, --configuration=STRING  Build configuration (debug|release)
   -t, --target=STRING         Build target (see: Available build targets)
   -d, --debug                 Open IDE for debugging after successful build
   -r, --run                   Start the program after successful build
@@ -141,7 +141,7 @@ Usage: uno no-build [target] [options] [project-path]
 Invoke generated build steps without triggering a build.
 
 Common options
-  -c, --configuration=STRING  Build configuration [Debug|Release]
+  -c, --configuration=STRING  Build configuration (debug|release)
   -o, --out-dir=PATH          Specify output directory [optional]
   -b, --build                 Execute native build command
   -d, --debug                 Open IDE for debugging
@@ -167,7 +167,7 @@ Examples
 
 Available options
   -t, --target=STRING         Build target (see: Available build targets)
-  -c, --configuration=STRING  Build configuration [Debug|Release]
+  -c, --configuration=STRING  Build configuration (debug|release)
   -r, --recursive             Look for project files recursively
 
 Available build targets
@@ -232,7 +232,7 @@ Available options
   -f, --force                  Update package caches regardless of modification time
   -e, --express                Express mode. Don't rebuild packages depending on a modified package
   -z, --clean                  Clean projects before building them
-  -c, --configuration=NAME     Set build configuration (Debug|Release) [optional]
+  -c, --configuration=NAME     Set build configuration (debug|release) [optional]
   -n, --version=X.Y.Z-SUFFIX   Override version number for all packages built [optional]
   -C, --no-cache               Disable in-memory AST & IL caches
   -s, --silent                 Very quiet build log

--- a/src/runtime/generic/app-generic.csproj
+++ b/src/runtime/generic/app-generic.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\Debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />

--- a/src/runtime/mac/app-mac.csproj
+++ b/src/runtime/mac/app-mac.csproj
@@ -50,7 +50,7 @@
       <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\Debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
       <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\Xamarin.Mac.dll</HintPath>

--- a/src/runtime/win/app-win.csproj
+++ b/src/runtime/win/app-win.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\Debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="..\..\GlobalAssemblyInfo.targets" />

--- a/src/tool/cli/Packages/Doctor.cs
+++ b/src/tool/cli/Packages/Doctor.cs
@@ -22,7 +22,7 @@ namespace Uno.CLI.Packages
             WriteRow("-f, --force",                "Update package caches regardless of modification time");
             WriteRow("-e, --express",              "Express mode. Don't rebuild packages depending on a modified package");
             WriteRow("-z, --clean",                "Clean projects before building them");
-            WriteRow("-c, --configuration=NAME",   "Set build configuration (Debug|Release)", true);
+            WriteRow("-c, --configuration=NAME",   "Set build configuration (debug|release)", true);
             WriteRow("-n, --version=X.Y.Z-SUFFIX", "Override version number for all packages built", true);
             WriteRow("-C, --no-cache",             "Disable in-memory AST & IL caches");
             WriteRow("-s, --silent",               "Very quiet build log");

--- a/src/tool/cli/Projects/BuildCommand.cs
+++ b/src/tool/cli/Projects/BuildCommand.cs
@@ -23,7 +23,7 @@ namespace Uno.CLI.Projects
             WriteRow("uno build native --debug",    "Build & open Visual C++ or Xcode, if available");
 
             WriteHead("Common options", 26);
-            WriteRow("-c, --configuration=STRING",  "Build configuration [Debug|Release]");
+            WriteRow("-c, --configuration=STRING",  "Build configuration (debug|release)");
             WriteRow("-t, --target=STRING",         "Build target (see: Available build targets)");
             WriteRow("-d, --debug",                 "Open IDE for debugging after successful build");
             WriteRow("-r, --run",                   "Start the program after successful build");

--- a/src/tool/cli/Projects/BuildCommand.cs
+++ b/src/tool/cli/Projects/BuildCommand.cs
@@ -37,7 +37,7 @@ namespace Uno.CLI.Projects
             WriteRow("-s, --set:NAME=STRING",       "Override build system property");
             WriteRow("-o, --out-dir=PATH",          "Override output directory");
             WriteRow("-b, --build-only",            "Build only; don't run or open debugger");
-            WriteRow("-g, --gen-only",              "Generate only; don't compile generated code.");
+            WriteRow("-g, --gen-only",              "Generate only; don't compile generated code");
             WriteRow("-f, --force",                 "Build even if output is up-to-date");
             WriteRow("-l, --libs",                  "Rebuild package library if necessary");
             WriteRow("-p, --print-internals",       "Print a list of build system properties");

--- a/src/tool/cli/Projects/Clean.cs
+++ b/src/tool/cli/Projects/Clean.cs
@@ -21,7 +21,7 @@ namespace Uno.CLI.Projects
 
             WriteHead("Available options", 26);
             WriteRow("-t, --target=STRING",         "Build target (see: Available build targets)");
-            WriteRow("-c, --configuration=STRING",  "Build configuration [Debug|Release]");
+            WriteRow("-c, --configuration=STRING",  "Build configuration (debug|release)");
             WriteRow("-r, --recursive",             "Look for project files recursively");
 
             WriteHead("Available build targets", 19);

--- a/src/tool/cli/Projects/NoBuild.cs
+++ b/src/tool/cli/Projects/NoBuild.cs
@@ -18,7 +18,7 @@ namespace Uno.CLI.Projects
             WriteUsage("[target] [options] [project-path]");
 
             WriteHead("Common options", 26);
-            WriteRow("-c, --configuration=STRING",  "Build configuration [Debug|Release]");
+            WriteRow("-c, --configuration=STRING",  "Build configuration (debug|release)");
             WriteRow("-o, --out-dir=PATH",          "Specify output directory", true);
             WriteRow("-b, --build",                 "Execute native build command");
             WriteRow("-d, --debug",                 "Open IDE for debugging");
@@ -57,9 +57,7 @@ namespace Uno.CLI.Projects
             var project = Project.Load(input.Path(".").GetProjectFile());
 
             if (string.IsNullOrEmpty(outputDir))
-                outputDir = project.OutputDirectory
-                    .Replace("@(Target)", target.Identifier)
-                    .Replace("@(Configuration)", configuration.ToString());
+                outputDir = project.GetOutputDirectory(configuration, target);
 
             var file = new BuildFile(outputDir);
 

--- a/src/tool/cli/Projects/Test.cs
+++ b/src/tool/cli/Projects/Test.cs
@@ -33,14 +33,14 @@ namespace Uno.CLI.Projects
 
             WriteHead("Available options", 26);
             WriteRow("-l, --logfile=PATH",          "Write output to this file instead of stdout");
-            WriteRow("-t, --target=STRING",         "Build target. Supported: android, dotnet and native");
-            WriteRow("-v, --verbose",               "Verbose, always prints output from compiler and debug_log");
-            WriteRow("-q, --quiet",                 "Quiet, only prints output from compiler and debug_log in case of errors.");
+            WriteRow("-t, --target=STRING",         "Build target (see: Available build targets)");
+            WriteRow("-v, --verbose",               "Verbose, always prints output from compiler and app");
+            WriteRow("-q, --quiet",                 "Quiet, only prints output from compiler and app in case of errors");
             WriteRow("-f, --filter=",               "Only run tests matching this string");
             WriteRow("-e, --regex-filter=STRING",   "Only run tests matching this regular expression");
             WriteRow("    --trace",                 "Print trace information from unotest");
-            WriteRow("-b, --build-only",            "Don't run tests; only build.");
-            WriteRow("-g, --gen-only",              "Don't run tests; only generate code.");
+            WriteRow("-b, --build-only",            "Don't run tests; only build");
+            WriteRow("-g, --gen-only",              "Don't run tests; only generate code");
             WriteRow("    --no-uninstall",          "Don't uninstall tests after running on device");
             WriteRow("-D, --define=STRING",         "Add define, to enable a feature");
             WriteRow("-U, --undefine=STRING",       "Remove define, to disable a feature");

--- a/src/tool/project/Project.cs
+++ b/src/tool/project/Project.cs
@@ -100,6 +100,7 @@ namespace Uno.ProjectFormat
         public string GetOutputDirectory(object configuration, object target)
         {
             return OutputDirectory
+                .Replace("@(Configuration:ToLower)", configuration.ToString().ToLowerInvariant())
                 .Replace("@(Configuration)", configuration.ToString())
                 .Replace("@(Target)", target.ToString())
                 .UnixToNative();

--- a/src/tool/project/PropertyDefinitions.cs
+++ b/src/tool/project/PropertyDefinitions.cs
@@ -10,7 +10,7 @@ namespace Uno.ProjectFormat
             {"BuildCondition", PropertyType.String},
             {"BuildDirectory", PropertyType.Path, "build"},
             {"CacheDirectory", PropertyType.Path, ".uno"},
-            {"OutputDirectory", PropertyType.Path, "$(BuildDirectory)/@(Target)/@(Configuration)"},
+            {"OutputDirectory", PropertyType.Path, "$(BuildDirectory)/@(Target)/@(Configuration:ToLower)"},
             {"RootNamespace", PropertyType.String, "$(QIdentifier)"},
             {"Version", PropertyType.String, Environment.GetEnvironmentVariable("npm_package_version") ?? "0.1.0"},
             {"VersionCode", PropertyType.Integer, 1},


### PR DESCRIPTION
This makes the configuration part of the build output directory
lower-case, now making all path components of the default build
output directory lower-case.

Some users would argue that all lower-case directories appear more
modern, and look more familiar to users coming from other tooling.
Also, it's not a bad thing to update one's appearance once in a while,
and since we're preparing our next major release this seems like good
timing.

Please note that this is a breaking change (on case-sensitive
file-systems), though unlikely to affect users in practice (since
the majority of our audience are likely users of case-insensitive
file-systems, and it is rarely necessary to deal with your output
directory directly).