### PR TITLE
iOS: fix building for Simulator in Xcode 12

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = "@(CStandard)";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -430,6 +431,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = "@(CStandard)";
 				GCC_NO_COMMON_BLOCKS = YES;
 #if @(PreprocessorDefinition:IsRequired)


### PR DESCRIPTION
This fixes building for Simulator in Xcode 12, and also when using
latest Cocoapods v1.17.

* Exclude arm64 to avoid error about missing architectures when using
  Xcode 12.

* Exclude i386 to avoid error about missing architectures when using
  Cocoapods v1.17.

Closes #364