### PR TITLE
Update Permissions.uno

### DIFF
--- a/lib/Uno.Permissions/Permissions.java
+++ b/lib/Uno.Permissions/Permissions.java
@@ -56,7 +56,7 @@ public final class Permissions {
     public static void startPermissionRequest(UnoObject promise, String[] permissions)
     {
         if (hasPermissions(permissions)) {
-            com.foreign.ExternedBlockHost.permissionRequestSucceeded(promise);
+            com.foreign.ExternedBlockHost.permissionRequestSucceededLegacy(promise);
         }else{
             _requests.add(new PermissionsRequest(promise, permissions, _permissionRequestID++));
             if(_currentRequest == null)
@@ -94,10 +94,10 @@ public final class Permissions {
             }
             if (ok) {
                 android.util.Log.d("Permissions", "Permissions granted");
-                com.foreign.ExternedBlockHost.permissionRequestSucceeded(_currentRequest.promise);
+                com.foreign.ExternedBlockHost.permissionRequestSucceededLegacy(_currentRequest.promise);
             } else {
                 android.util.Log.d("Permissions", "Permissions denied");
-                com.foreign.ExternedBlockHost.permissionRequestFailed(_currentRequest.promise);
+                com.foreign.ExternedBlockHost.permissionRequestFailedLegacy(_currentRequest.promise);
             }
         }
         _currentRequest = null;

--- a/lib/Uno.Permissions/Permissions.uno
+++ b/lib/Uno.Permissions/Permissions.uno
@@ -111,13 +111,13 @@ namespace Uno.Permissions
         }
 
         [Foreign(Language.Java), ForeignFixedName]
-        static void permissionRequestSucceeded(object x)
+        static void permissionRequestSucceededLegacy(object x)
         @{
             @{Succeeded(object):Call(x)};
         @}
 
         [Foreign(Language.Java), ForeignFixedName]
-        static void permissionRequestFailed(object x)
+        static void permissionRequestFailedLegacy(object x)
         @{
             @{Failed(object):Call(x)};
         @}


### PR DESCRIPTION
Compiles duplicate function names in same class as is already defined in fuselibs/Source/Fuse.Android.Permissions/Permissions.uno:

https://github.com/fuse-open/fuselibs/blob/13f31c90dd69942b722240fc6718de7e37aa7d3d/Source/Fuse.Android.Permissions/Permissions.uno#L108

https://github.com/fuse-open/fuselibs/blob/13f31c90dd69942b722240fc6718de7e37aa7d3d/Source/Fuse.Android.Permissions/Permissions.uno#L115