### PR TITLE
Add ios-sim build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Uno is used on Linux, macOS and Windows, and makes native apps for the following
 | Platform  | Build targets       |
 |:----------|:--------------------|
 | Android   | `android`           |
-| iOS       | `ios`               |
+| iOS       | `ios`, `ios-sim`    |
 | Linux     | `native`, `dotnet`  |
 | macOS     | `native`, `dotnet`  |
 | Windows   | `native`, `dotnet`  |

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -130,6 +130,7 @@ Available build targets
   * android            C++/JNI/GLES2 code and APK. Runs on device.
   * native             C++/GL code, CMake project and native executable.
   * ios                (Objective-)C++/GLES2 code and Xcode project. (macOS only)
+  * ios-sim            (Objective-)C++/GLES2 code and Xcode project. Runs in Simulator. (macOS only)
   * dotnet             .NET/GL bytecode and executable. (default)
 ```
 

--- a/lib/UnoCore/Targets/iOS/build.sh
+++ b/lib/UnoCore/Targets/iOS/build.sh
@@ -37,9 +37,15 @@ function checkForError() {
     grep "Xcode couldn't find a provisioning profile" | while read -r line; do openXcode; done
 }
 
-#if @(COCOAPODS:Defined)
-    pod install
-    xcodebuild -workspace "@(Project.Name).xcworkspace" -scheme "@(Project.Name)" -derivedDataPath build "$@" | tee >(checkForError)
+#if @(IOS_SIMULATOR:Defined)
+BUILD_ARGS="-sdk iphonesimulator"
 #else
-    xcodebuild -project "@(Project.Name).xcodeproj" "$@" | tee >(checkForError)
+BUILD_ARGS=""
+#endif
+
+#if @(COCOAPODS:Defined)
+pod install
+xcodebuild $BUILD_ARGS -workspace "@(Project.Name).xcworkspace" -scheme "@(Project.Name)" -derivedDataPath build "$@" | tee >(checkForError)
+#else
+xcodebuild $BUILD_ARGS -project "@(Project.Name).xcodeproj" "$@" | tee >(checkForError)
 #endif

--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -17,6 +17,24 @@ debug)
     ;;
 esac
 
+#if @(IOS_SIMULATOR:Defined)
+
+if ! which ios-sim > /dev/null 2>&1; then
+    echo "ERROR: Unable to find the 'ios-sim' command." >&2
+    echo -e "\nYou can install ios-sim using NPM:" >&2
+    echo -e "\n    npm install ios-sim -g\n" >&2
+    exit 1
+fi
+
+#if @(COCOAPODS:Defined)
+pod install
+ios-sim launch -diPhone-12 "build/Build/Products/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
+#else
+ios-sim launch -diPhone-12 "build/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
+#endif
+
+#else // @(IOS_SIMULATOR:Defined)
+
 if ! which ios-deploy > /dev/null 2>&1; then
     echo "ERROR: Unable to find the 'ios-deploy' command." >&2
     echo -e "\nYou can install ios-deploy using NPM:" >&2
@@ -38,3 +56,5 @@ ios-deploy --noninteractive --debug --bundle "build/Build/Products/@(Pbxproj.Con
 #else
 ios-deploy --noninteractive --debug --bundle "build/@(Pbxproj.Configuration)-iphoneos/@(Project.Name).app" "$@"
 #endif
+
+#endif // @(IOS_SIMULATOR:Defined)

--- a/src/tool/engine/BuildTargets.cs
+++ b/src/tool/engine/BuildTargets.cs
@@ -17,6 +17,7 @@ namespace Uno.Build
             new AndroidBuild(),
             new NativeBuild(),
             new iOSBuild(),
+            new iOSSimulatorBuild(),
             Default,
             new DocsBuild(),
             new MetadataBuild(),

--- a/src/tool/engine/Targets/iOSSimulatorBuild.cs
+++ b/src/tool/engine/Targets/iOSSimulatorBuild.cs
@@ -1,0 +1,33 @@
+using Uno.Build.Targets.Generators;
+using Uno.Compiler.API;
+using Uno.Compiler.API.Backends;
+using Uno.Compiler.Backends.CPlusPlus;
+using Uno.Compiler.Graphics.OpenGL;
+using Uno.Compiler.Foreign;
+using Uno.Diagnostics;
+
+namespace Uno.Build.Targets
+{
+    public class iOSSimulatorBuild : BuildTarget
+    {
+        public override string Identifier => "ios-sim";
+        public override string ProjectGroup => "iOS";
+        public override string Description => "(Objective-)C++/GLES2 code and Xcode project. Runs in Simulator. (macOS only)";
+
+        public override Backend CreateBackend()
+        {
+            return new CppBackend(new GLBackend(), new ForeignExtension());
+        }
+
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("IOS");
+            env.Define("IOS_SIMULATOR");
+        }
+
+        public override void Configure(ICompiler compiler)
+        {
+            XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles);
+        }
+    }
+}

--- a/src/tool/engine/Uno.Build.csproj
+++ b/src/tool/engine/Uno.Build.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Targets\Generators\XcodeFile.cs" />
     <Compile Include="Targets\Generators\XcodeGenerator.cs" />
     <Compile Include="Targets\iOSBuild.cs" />
+    <Compile Include="Targets\iOSSimulatorBuild.cs" />
     <Compile Include="Targets\MetadataBuild.cs" />
     <Compile Include="Targets\NativeBuild.cs" />
     <Compile Include="Targets\PackageBuild.cs" />


### PR DESCRIPTION
This adds a new build target specifically for the iOS Simulator, so we
can easily build and run apps without going via Xcode.

Example:

    uno build ios-sim --run