### PR TITLE
iOS: Metal graphics support

### DIFF
--- a/lib/UnoCore/Targets/iOS/.gitignore
+++ b/lib/UnoCore/Targets/iOS/.gitignore
@@ -1,0 +1,1 @@
+MetalANGLE.framework.*

--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 					"-Wno-dangling-else",
 					"-Wno-switch",
 					"-Wno-unguarded-availability-new",
+					"-Wno-quoted-include-in-framework-header",
 				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/lib/UnoCore/Targets/iOS/MetalANGLE.stuff
+++ b/lib/UnoCore/Targets/iOS/MetalANGLE.stuff
@@ -1,0 +1,4 @@
+if METAL {
+    MetalANGLE.framework.ios: "https://github.com/kakashidinho/metalangle/releases/download/gles3-0.0.7/MetalANGLE.framework.ios.zip",
+    MetalANGLE.framework.ios.simulator: "https://github.com/kakashidinho/metalangle/releases/download/gles3-0.0.7/MetalANGLE.framework.ios.simulator.zip",
+}

--- a/lib/UnoCore/Targets/iOS/MetalANGLE.uxl
+++ b/lib/UnoCore/Targets/iOS/MetalANGLE.uxl
@@ -1,0 +1,9 @@
+<Extensions Backend="CPlusPlus" Condition="IOS && METAL">
+
+    <Require Condition="!IOS_SIMULATOR" Xcode.Framework="@('MetalANGLE.framework.ios/MetalANGLE.framework':Path)" />
+    <Require Condition=" IOS_SIMULATOR" Xcode.Framework="@('MetalANGLE.framework.ios.simulator/MetalANGLE.framework':Path)" />
+
+    <Require Condition="!IOS_SIMULATOR" Xcode.EmbeddedFramework="@('MetalANGLE.framework.ios/MetalANGLE.framework':Path)" />
+    <Require Condition=" IOS_SIMULATOR" Xcode.EmbeddedFramework="@('MetalANGLE.framework.ios.simulator/MetalANGLE.framework':Path)" />
+
+</Extensions>

--- a/lib/UnoCore/Targets/iOS/Uno-iOS.uxl
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS.uxl
@@ -8,6 +8,6 @@
     <ProcessFile SourceFile="Uno-iOS/Uno-iOS.mm" />
 
     <Require Condition="LIBRARY" Xcode.PublicHeader="Uno-iOS/Context.h" />
-    <Require PreprocessorDefinition="GLES_SILENCE_DEPRECATION" />
+    <Require Condition="!METAL" PreprocessorDefinition="GLES_SILENCE_DEPRECATION" />
 
 </Extensions>

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.h
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.h
@@ -1,6 +1,9 @@
 #pragma once
 #ifdef __OBJC__
 #include <UIKit/UIKit.h>
+#if @(METAL:Defined)
+#include <MetalANGLE/MGLKit.h>
+#endif
 
 
 @(AppDelegate.HeaderFile.Declaration:Join())
@@ -10,7 +13,11 @@
 {
     uintptr_t primaryTouch;
 }
+#if @(METAL:Defined)
+@property (strong, nonatomic) MGLContext *context;
+#else
 @property (strong, nonatomic) EAGLContext *context;
+#endif
 @end
 
 

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.mm
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/AppDelegate.mm
@@ -34,7 +34,11 @@
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+#if @(METAL:Defined)
+    [MGLContext setCurrentContext:self.context];
+#else
     [EAGLContext setCurrentContext:self.context];
+#endif
     return [_unoContext
         application:application
         willFinishLaunchingWithOptions:launchOptions];
@@ -78,7 +82,11 @@
     if ([userActivity.activityType isEqualToString: NSUserActivityTypeBrowsingWeb]) {
         NSURL *url = userActivity.webpageURL;
 
+#if @(METAL:Defined)
+        [MGLContext setCurrentContext:self.context];
+#else
         [EAGLContext setCurrentContext:self.context];
+#endif
         return [_unoContext
                 application:application
                 continueUserActivity:url];

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/Context.h
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/Context.h
@@ -1,7 +1,11 @@
 #pragma once
 #ifdef __OBJC__
 #include <UIKit/UIKit.h>
+#if @(METAL:Defined)
+#include <MetalANGLE/MGLKit.h>
+#else
 #include <OpenGLES/EAGL.h>
+#endif
 
 @interface uContext : NSObject
 
@@ -14,7 +18,11 @@
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSURL *)url;
 
 @property (readonly) UIWindow* window;
+#if @(METAL:Defined)
+@property (readonly) MGLContext *glContext;
+#else
 @property (readonly) EAGLContext *glContext;
+#endif
 
 @end
 

--- a/lib/UnoCore/Targets/iOS/Uno-iOS/Context.mm
+++ b/lib/UnoCore/Targets/iOS/Uno-iOS/Context.mm
@@ -10,7 +10,11 @@
 {
 @private
     uRuntime* _uno;
+#if @(METAL:Defined)
+    MGLContext* _glContext;
+#else
     EAGLContext* _glContext;
+#endif
     UIWindow* (^_windowGetter)();
 }
 @end
@@ -77,8 +81,13 @@ static uContext* instance = nil;
     if (self = [super init])
     {
         _uno = new uRuntime();
+#if @(METAL:Defined)
+        _glContext = [[MGLContext alloc] initWithAPI:kMGLRenderingAPIOpenGLES2];
+        [MGLContext setCurrentContext:_glContext];
+#else
         _glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
         [EAGLContext setCurrentContext:_glContext];
+#endif
 
         NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
 

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -464,6 +464,8 @@
     "Targets/iOS/@(Schemes)/xcschememanagement.plist:File",
     "Targets/iOS/build.sh:File",
     "Targets/iOS/iOS.uxl:Extensions",
+    "Targets/iOS/MetalANGLE.stuff:Stuff",
+    "Targets/iOS/MetalANGLE.uxl:Extensions",
     "Targets/iOS/Podfile:File",
     "Targets/iOS/run.sh:File",
     "Targets/iOS/Uno-iOS.uxl:Extensions",

--- a/lib/UnoCore/prebuilt/uno-base.uxl
+++ b/lib/UnoCore/prebuilt/uno-base.uxl
@@ -84,7 +84,7 @@
     <Require Condition="IOS" Xcode.Framework="CoreGraphics" />
     <Require Condition="IOS" Xcode.Framework="CoreMotion" />
     <Require Condition="IOS" Xcode.Framework="Foundation" />
-    <Require Condition="IOS" Xcode.Framework="OpenGLES" />
+    <Require Condition="IOS && !METAL" Xcode.Framework="OpenGLES" />
     <Require Condition="IOS" Xcode.Framework="QuartzCore" />
     <Require Condition="IOS" Xcode.Framework="UIKit" />
 


### PR DESCRIPTION
This adds opt-in support for rendering using the Metal graphics API via
MetalANGLE, a framework implementing OpenGLES APIs on top of Metal.

Use this to avoid referencing deprecated OpenGLES.framework on iOS.

* Pass `-DMETAL` to activate. E.g.: `uno build ios -DMETAL`.

* Pass `-DIOS_SIMULATOR` if you want to use iOS Simulator, to make sure
  the right version of MetalANGLE.framework is used, or use the new
  `ios-sim` build target (#395).

Closes #320