### PR TITLE
engine: make target defines explicit

### DIFF
--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -139,8 +139,7 @@ namespace Uno.Build
             PrintRow("Output dir", _env.OutputDirectory);
 
             _file.Delete();
-            _env.Define(_target.Identifier, "TARGET_" + _target.Identifier,
-                _backend.Name, _backend.ShaderBackend.Name);
+            _env.Define(_backend.Name, _backend.ShaderBackend.Name);
 
             if (_compilerOptions.Debug)
                 _env.Define("DEBUG");

--- a/src/tool/engine/Targets/AndroidBuild.cs
+++ b/src/tool/engine/Targets/AndroidBuild.cs
@@ -23,6 +23,11 @@ namespace Uno.Build.Targets
             return new CppBackend(new GLBackend(), new ForeignExtension());
         }
 
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("ANDROID");
+        }
+
         public override void Configure(ICompiler compiler)
         {
             new AndroidGenerator(

--- a/src/tool/engine/Targets/DotNetBuild.cs
+++ b/src/tool/engine/Targets/DotNetBuild.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Compiler.API.Backends;
+﻿using Uno.Compiler.API;
+using Uno.Compiler.API.Backends;
 using Uno.Compiler.Backends.CIL;
 using Uno.Compiler.Graphics.OpenGL;
 
@@ -15,6 +16,11 @@ namespace Uno.Build.Targets
         public override Backend CreateBackend()
         {
             return new CilBackend(new GLBackend());
+        }
+
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("DOTNET");
         }
     }
 }

--- a/src/tool/engine/Targets/NativeBuild.cs
+++ b/src/tool/engine/Targets/NativeBuild.cs
@@ -20,6 +20,11 @@ namespace Uno.Build.Targets
             return new CppBackend(new GLBackend(), new ForeignExtension());
         }
 
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("NATIVE");
+        }
+
         public override void Configure(ICompiler compiler)
         {
             new CMakeGenerator(compiler.Environment).Configure();

--- a/src/tool/engine/Targets/iOSBuild.cs
+++ b/src/tool/engine/Targets/iOSBuild.cs
@@ -19,6 +19,11 @@ namespace Uno.Build.Targets
             return new CppBackend(new GLBackend(), new ForeignExtension());
         }
 
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("IOS");
+        }
+
         public override void Configure(ICompiler compiler)
         {
             XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles);


### PR DESCRIPTION
This is to avoid unintentional defines.