### PR TITLE
Add android-emu build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Uno is a collection of compiler and platform abstraction technologies.
 
 Uno is used on Linux, macOS and Windows, and makes native apps for the following platforms:
 
-| Platform  | Build targets       |
-|:----------|:--------------------|
-| Android   | `android`           |
-| iOS       | `ios`, `ios-sim`    |
-| Linux     | `native`, `dotnet`  |
-| macOS     | `native`, `dotnet`  |
-| Windows   | `native`, `dotnet`  |
+| Platform  | Build targets            |
+|:----------|:-------------------------|
+| Android   | `android`, `android-emu` |
+| iOS       | `ios`, `ios-sim`         |
+| Linux     | `native`, `dotnet`       |
+| macOS     | `native`, `dotnet`       |
+| Windows   | `native`, `dotnet`       |
 
 [Fuse Open]: https://fuseopen.com/
 

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -128,6 +128,7 @@ C++ options
 
 Available build targets
   * android            C++/JNI/GLES2 code and APK. Runs on device.
+  * android-emu        C++/JNI/GLES2 code and APK. Runs on emulator (x86_64).
   * native             C++/GL code, CMake project and native executable.
   * ios                (Objective-)C++/GLES2 code and Xcode project. (macOS only)
   * ios-sim            (Objective-)C++/GLES2 code and Xcode project. Runs in Simulator. (macOS only)
@@ -299,6 +300,7 @@ Available options
   -a, --activity=NAME   Android activity name
   -p, --package=NAME    Java package name
   -s, --sym-dir=PATH    Symbol directory, for stack traces [optional]
+  -e, --emulator        Consider emulator(s) only
   -i, --install         Install only, then exit
   -C, --no-clear        Don't clear logcat logs before launch
   -L, --no-log          Don't run logcat, just launch

--- a/lib/UnoCore/Targets/Android/app/build.gradle
+++ b/lib/UnoCore/Targets/Android/app/build.gradle
@@ -54,7 +54,9 @@ android {
         multiDexEnabled @(Project.Android.MultiDexEnabled:IsSet:Test(@(Project.Android.MultiDexEnabled:Bool),true))
 
         ndk {
-#if @(DEBUG:Defined)
+#if @(ANDROID_EMU:Defined)
+            abiFilters = ["x86_64"]
+#elif @(DEBUG:Defined)
             abiFilters = [@(Project.Android.Architectures.Debug:Join(', ', '\'', '\''))]
 #else
             abiFilters = [@(Project.Android.Architectures.Release:Join(', ', '\'', '\''))]

--- a/lib/UnoCore/Targets/Android/run.bat
+++ b/lib/UnoCore/Targets/Android/run.bat
@@ -26,6 +26,7 @@ if "%1" == "uninstall" (
     --package=@(Activity.Package) ^
     --activity=@(Activity.Name) ^
     --sym-dir="%~dp0src\main\.uno" ^
+    @(ANDROID_EMU:Defined:Test('--emulator', '')) ^
     %*
 exit /b %ERRORLEVEL%
 #endif

--- a/lib/UnoCore/Targets/Android/run.sh
+++ b/lib/UnoCore/Targets/Android/run.sh
@@ -25,5 +25,6 @@ exit 1
     --package=@(Activity.Package) \
     --activity=@(Activity.Name) \
     --sym-dir="app/src/main/.uno" \
+    @(ANDROID_EMU:Defined:Test('--emulator', '')) \
     "$@"
 #endif

--- a/src/tool/engine/Adb/AdbRunner.cs
+++ b/src/tool/engine/Adb/AdbRunner.cs
@@ -29,7 +29,7 @@ namespace Uno.Build.Adb
             return _shell.Run(Location, args);
         }
 
-        public List<AdbDevice> GetDevices()
+        public List<AdbDevice> GetDevices(bool emulatorsOnly)
         {
             var devices = new List<AdbDevice>();
             var output = _shell.GetOutput(Location, "devices");
@@ -38,6 +38,7 @@ namespace Uno.Build.Adb
             {
                 var parts = line.Cut();
                 if (parts.Count == 2 && parts[1] == "device" &&
+                        (!emulatorsOnly || parts[0].Contains("emulator")) &&
                         (!IgnoreNetworkDevices || !IsIpAndPort(parts[0])))
                     devices.Add(new AdbDevice(_shell, Location, parts[0]));
             }

--- a/src/tool/engine/BuildTargets.cs
+++ b/src/tool/engine/BuildTargets.cs
@@ -15,6 +15,7 @@ namespace Uno.Build
         public static readonly BuildTarget[] All =
         {
             new AndroidBuild(),
+            new AndroidEmulatorBuild(),
             new NativeBuild(),
             new iOSBuild(),
             new iOSSimulatorBuild(),

--- a/src/tool/engine/Targets/AndroidEmulatorBuild.cs
+++ b/src/tool/engine/Targets/AndroidEmulatorBuild.cs
@@ -1,0 +1,16 @@
+using Uno.Compiler.API;
+
+namespace Uno.Build.Targets
+{
+    public class AndroidEmulatorBuild : AndroidBuild
+    {
+        public override string Identifier => "android-emu";
+        public override string Description => "C++/JNI/GLES2 code and APK. Runs on emulator (x86_64).";
+
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("ANDROID");
+            env.Define("ANDROID_EMU");
+        }
+    }
+}

--- a/src/tool/engine/Uno.Build.csproj
+++ b/src/tool/engine/Uno.Build.csproj
@@ -82,6 +82,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Targets\AndroidBuild.cs" />
+    <Compile Include="Targets\AndroidEmulatorBuild.cs" />
     <Compile Include="BuildTargets.cs" />
     <Compile Include="Targets\DocsBuild.cs" />
     <Compile Include="Targets\DotNetBuild.cs" />


### PR DESCRIPTION
This adds a new build target specifically for emulators (x86_64).

While the regular `android` target builds ARM code by default (not
compatible with emulators), this one builds x86_64 code and makes sure
we run resulting apps on an emulator.

Example:

    uno build android-emu --run

Similar to #395