### PR TITLE
Handle C++ exceptions

### DIFF
--- a/lib/UnoCore/Source/Uno/Threading/Thread.uno
+++ b/lib/UnoCore/Source/Uno/Threading/Thread.uno
@@ -40,22 +40,26 @@ namespace Uno.Threading
         extern(CPLUSPLUS) static ThreadLocal _currentThread = extern<ThreadLocal> "uCreateThreadLocal(nullptr)";
 
         extern(CPLUSPLUS) static void ThreadMain(Thread thread)
-        {
-            extern "uAutoReleasePool pool";
-            extern "uSetThreadLocal(@{_currentThread}, $0)";
+        @{
+            uAutoReleasePool pool;
+            uSetThreadLocal(@{_currentThread}, $0);
 
             try
             {
-                thread._threadStart();
+                @{$0._threadStart:Call()};
             }
-            catch (Exception e)
+            catch (const uThrowable& t)
             {
                 // TODO: Use some kind of exception callback..
-                debug_log "Unhandled exception in thread: " + e;
+                U_ERROR("Unhandled exception in thread: %s", uCString(@{Exception:Of(t.Exception).ToString():Call()}).Ptr);
+            }
+            catch (const std::exception& e)
+            {
+                U_ERROR("Unhandled C++ exception in thread: %s", e.what());
             }
 
-            extern "uRelease($0)";
-        }
+            uRelease($0);
+        @}
 
         extern(CPLUSPLUS) ThreadHandle _threadHandle;
 

--- a/lib/UnoCore/Targets/Android/Uno/EntryPoints.cpp
+++ b/lib/UnoCore/Targets/Android/Uno/EntryPoints.cpp
@@ -59,9 +59,18 @@ extern "C"
     void JNICALL cppOnCreate(JNIEnv *env , jobject obj, jobject activity)
     {
         uAutoReleasePool pool;
-        @{Android.Base.JNI.Init(Android.Base.Primitives.ujobject):Call(activity)};
-        @{Uno.Compiler.ExportTargetInterop.Foreign.Android.ExternBlockHost.RegisterFunctions():Call()};
-        @{Uno.Platform.CoreApp.Start():Call()};
+
+        try
+        {
+            @{Android.Base.JNI.Init(Android.Base.Primitives.ujobject):Call(activity)};
+            @{Uno.Compiler.ExportTargetInterop.Foreign.Android.ExternBlockHost.RegisterFunctions():Call()};
+            @{Uno.Platform.CoreApp.Start():Call()};
+        }
+        catch (const uThrowable& t)
+        {
+            uLog(uLogLevelFatal, "Unhandled exception: %s", uCString(t.Exception->ToString()).Ptr);
+            throw t;
+        }
     }
 }
 


### PR DESCRIPTION
Handle more C++ exceptions to make it easier to spot crashes on startup or in background threads.