### PR TITLE
Android: upgrade to Gradle v6.9.2

### DIFF
--- a/lib/UnoCore/Targets/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/UnoCore/Targets/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 29 18:21:17 CST 2018
+#Thu Feb 17 22:22:17 CST 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip


### PR DESCRIPTION
This makes it possible to build on machines with JDK14 installed.

https://github.com/fuse-x/studio/issues/22