### PR TITLE
iOS: use iPhone-13 as default Simulator device

### DIFF
--- a/.unoconfig
+++ b/.unoconfig
@@ -19,4 +19,4 @@ Packages.SourcePaths += lib
 
 // Tooling
 Android.Emulator.Architecture: x86_64
-iOS.Simulator.Device: iPhone-12
+iOS.Simulator.Device: iPhone-13


### PR DESCRIPTION
iPhone 13 Simulator is included with Xcode 13.