### PR TITLE
iOS: silence C++ warning

### DIFF
--- a/lib/UnoCore/Source/Uno/Long.uno
+++ b/lib/UnoCore/Source/Uno/Long.uno
@@ -21,7 +21,7 @@ namespace Uno
             if defined(CPLUSPLUS)
             @{
                 int hash = 27;
-                hash = (13 * hash) + (*$$ & UINT32_MAX);
+                hash = (13 * hash) + (int)(*$$ & UINT32_MAX);
                 hash = (13 * hash) + (*$$ >> 32);
                 return hash;
             @}


### PR DESCRIPTION
Seen when building using Xcode 13:

    Implicit conversion loses integer precision: 'long long' to 'int'