### PR TITLE
Small iOS fixes

### DIFF
--- a/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/Targets/iOS/@(Project.Name).xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 					"-Wno-switch",
 					"-Wno-unguarded-availability-new",
 					"-Wno-quoted-include-in-framework-header",
+					"-Wno-deprecated-implementations",
 				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -457,6 +458,8 @@
 					"-Wno-dangling-else",
 					"-Wno-switch",
 					"-Wno-unguarded-availability-new",
+					"-Wno-quoted-include-in-framework-header",
+					"-Wno-deprecated-implementations",
 				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/lib/UnoCore/Targets/iOS/run.sh
+++ b/lib/UnoCore/Targets/iOS/run.sh
@@ -28,9 +28,9 @@ fi
 
 #if @(COCOAPODS:Defined)
 pod install
-ios-sim launch -d"@(iOS.Simulator.Device || 'iPhone-12')" "build/Build/Products/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
+ios-sim launch -d"@(Config.iOS.Simulator.Device || 'iPhone-12')" "build/Build/Products/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
 #else
-ios-sim launch -d"@(iOS.Simulator.Device || 'iPhone-12')" "build/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
+ios-sim launch -d"@(Config.iOS.Simulator.Device || 'iPhone-12')" "build/@(Pbxproj.Configuration)-iphonesimulator/@(Project.Name).app" "$@"
 #endif
 
 #else // @(IOS_SIMULATOR:Defined)


### PR DESCRIPTION
### ios: silence warnings

This silences some warnings seen when building for iOS using Xcode 13.

### ios: get simulator device from .unoconfig

This fixes a bug where the simulator device isn't picked up from
.unoconfig as expected.