### PR TITLE
Uno.Threading: fix C++ error

### DIFF
--- a/lib/UnoCore/Source/Uno/Threading/Thread.uno
+++ b/lib/UnoCore/Source/Uno/Threading/Thread.uno
@@ -39,6 +39,7 @@ namespace Uno.Threading
     {
         extern(CPLUSPLUS) static ThreadLocal _currentThread = extern<ThreadLocal> "uCreateThreadLocal(nullptr)";
 
+        [Require("Source.Include", "@{Uno.Exception:Include}")]
         extern(CPLUSPLUS) static void ThreadMain(Thread thread)
         @{
             uAutoReleasePool pool;


### PR DESCRIPTION
This fixes the following error when running 'npm test android':

    error: member access into incomplete type 'g::Uno::Exception'