### PR TITLE
upgrade Newtonsoft.Json to v13.0.1

### DIFF
--- a/src/compiler/backend/unodoc/Uno.Compiler.Backends.UnoDoc.csproj
+++ b/src/compiler/backend/unodoc/Uno.Compiler.Backends.UnoDoc.csproj
@@ -35,8 +35,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/compiler/backend/unodoc/packages.config
+++ b/src/compiler/backend/unodoc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/src/compiler/foreign/Uno.Compiler.Foreign.csproj
+++ b/src/compiler/foreign/Uno.Compiler.Foreign.csproj
@@ -31,8 +31,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/compiler/foreign/packages.config
+++ b/src/compiler/foreign/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/src/disasm/wpf/disasm-wpf.csproj
+++ b/src/disasm/wpf/disasm-wpf.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\..\..\packages\MahApps.Metro.1.6.5\lib\net45\MahApps.Metro.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />

--- a/src/disasm/wpf/packages.config
+++ b/src/disasm/wpf/packages.config
@@ -3,5 +3,5 @@
   <package id="AvalonEdit" version="6.0.1" targetFramework="net45" />
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net45" />
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/src/tool/engine/Uno.Build.csproj
+++ b/src/tool/engine/Uno.Build.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
       <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\Xamarin.Mac.dll</HintPath>

--- a/src/tool/engine/packages.config
+++ b/src/tool/engine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
 </packages>

--- a/src/tool/project/Uno.ProjectFormat.csproj
+++ b/src/tool/project/Uno.ProjectFormat.csproj
@@ -36,8 +36,8 @@
       <HintPath>..\..\..\packages\Minimatch.2.0.0\lib\netstandard1.0\Minimatch.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/tool/project/packages.config
+++ b/src/tool/project/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net45" />
   <package id="Minimatch" version="2.0.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This fixes potential security vulnerabilities.

    Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure
    Defaults due to improper handling of StackOverFlow exception (SOE)
    whenever nested expressions are being processed. Exploiting this
    vulnerability results in Denial Of Service (DoS), and it is
    exploitable when an attacker sends 5 requests that cause SOE in time
    frame of 5 minutes. This vulnerability affects Internet Information
    Services (IIS) Applications.