### PR TITLE
Android: add gitignore file

### DIFF
--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -292,4 +292,8 @@
     <ProcessFile Name=".idea/runConfigurations.xml" Overwrite=false />
     <ProcessFile Name=".idea/vcs.xml" Overwrite=false />
 
+    <!-- Git ignore -->
+
+    <ProcessFile Name="gitignore" TargetName=".gitignore" />
+
 </Extensions>

--- a/lib/UnoCore/Targets/Android/gitignore
+++ b/lib/UnoCore/Targets/Android/gitignore
@@ -1,0 +1,8 @@
+/.gradle/
+/.idea/
+/.unobuild
+/app/.cxx/
+/app/build/
+/*.aab
+/*.aar
+/*.apk

--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -420,6 +420,7 @@
     "Targets/Android/com/fuse/R.java:File",
     "Targets/Android/com/uno/CppManager.java:File",
     "Targets/Android/Dependencies.uxl:Extensions",
+    "Targets/Android/gitignore:File",
     "Targets/Android/gradle.properties:File",
     "Targets/Android/gradle/wrapper/gradle-wrapper.jar:File",
     "Targets/Android/gradle/wrapper/gradle-wrapper.properties:File",


### PR DESCRIPTION
This makes it easier to add the generated Android project in Git,
without including build artifacts from Gradle etc.