### PR TITLE
Android: add AndroidManifest.ManifestAttribute for UXL

### DIFF
--- a/lib/UnoCore/Targets/Android/Android.uxl
+++ b/lib/UnoCore/Targets/Android/Android.uxl
@@ -38,8 +38,11 @@
     <Declare Element="Activity.OnNewIntent.Declaration" />
     <Declare Element="Activity.OnWindowFocusChanged.Declaration" />
     <Declare Element="Android.ResStrings.Declaration" />
+    <Declare Element="AndroidManifest.ActivityAttribute" />
     <Declare Element="AndroidManifest.ActivityElement" />
+    <Declare Element="AndroidManifest.ApplicationAttribute" />
     <Declare Element="AndroidManifest.ApplicationElement" />
+    <Declare Element="AndroidManifest.ManifestAttribute" />
     <Declare Element="AndroidManifest.Permission" />
     <Declare Element="AndroidManifest.RootElement" />
     <Declare Element="AndroidManifest.Activity.ViewIntentFilter" />

--- a/lib/UnoCore/Targets/Android/app/src/main/AndroidManifest.xml
+++ b/lib/UnoCore/Targets/Android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
+          @(AndroidManifest.ManifestAttribute:Join('\n          '))
           package="@(Activity.Package)">
 
     #if @(Project.Android.SupportsScreens.Resizable:IsSet) || @(Project.Android.SupportsScreens.SmallScreens:IsSet) || @(Project.Android.SupportsScreens.NormalScreens:IsSet) || @(Project.Android.SupportsScreens.LargeScreens:IsSet) || @(Project.Android.SupportsScreens.XLargeScreens:IsSet) || @(Project.Android.SupportsScreens.AnyDensity:IsSet) || @(Project.Android.SupportsScreens.RequiresSmallestWidthDp:IsSet) || @(Project.Android.SupportsScreens.CompatibleWidthLimitDp:IsSet) || @(Project.Android.SupportsScreens.LargestWidthLimitDp:IsSet)
@@ -97,6 +98,7 @@
                  android:usesCleartextTraffic="@(Project.Android.UsesCleartextTraffic:IsSet:Test(@(Project.Android.UsesCleartextTraffic:Bool),false))"
                  android:hardwareAccelerated="@(Project.Android.HardwareAccelerated:IsSet:Test(@(Project.Android.HardwareAccelerated:Bool),true))"
                  android:extractNativeLibs="@(Project.Android.ExtractNativeLibs:IsSet:Test(@(Project.Android.ExtractNativeLibs:Bool),true))"
+                 @(AndroidManifest.ApplicationAttribute:Join('\n                 '))
                  >
 
         <activity android:name="@(Activity.Name:EscapeXml)"
@@ -122,7 +124,9 @@
 #else
                   android:screenOrientation="user"
 #endif
-                  android:windowActionBar="false">
+                  android:windowActionBar="false"
+                  @(AndroidManifest.ActivityAttribute:Join('\n                  '))
+                  >
             <meta-data android:name="android.app.lib_name" android:value="@(Activity.Name:EscapeXml)" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This makes it possible to add more attributes to the manifest element.

Needed to integrate a thirdparty library in Fuselibs.

Also adds AndroidManifest.ApplicationAttribute and
AndroidManifest.ActivityAttribute for application and activity elements.