### PR TITLE
Android: drop legacy packages

### DIFF
--- a/lib/UnoCore/android/dependencies.uxl
+++ b/lib/UnoCore/android/dependencies.uxl
@@ -9,8 +9,6 @@
     <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:4.2.0" />
     <Require Gradle.Dependency.Implementation="androidx.appcompat:appcompat:1.3.1" />
     <Require Gradle.Dependency.Implementation="com.google.android.material:material:1.4.0" />
-    <Require Gradle.Dependency.Implementation="androidx.legacy:legacy-support-v4:1.0.0" />
-    <Require Gradle.Dependency.Implementation="androidx.multidex:multidex:2.0.1" />
 
     <!-- Kotlin support. -->
     <Require Condition="KOTLIN" Gradle.Dependency.Implementation="androidx.core:core-ktx:+" />


### PR DESCRIPTION
These packages are no longer needed since apps still build fine without.