### PR TITLE
Android: add android:exported attribute

### DIFF
--- a/lib/UnoCore/android/app/src/main/AndroidManifest.xml
+++ b/lib/UnoCore/android/app/src/main/AndroidManifest.xml
@@ -106,6 +106,7 @@
                   android:label="@(Project.Android.ApplicationLabel:EscapeXml)"
                   android:launchMode="singleTask"
                   android:hardwareAccelerated="@(Project.Android.HardwareAccelerated:IsSet:Test(@(Project.Android.HardwareAccelerated:Bool),true))"
+                  android:exported="@(Project.Android.Exported:IsSet:Test(@(Project.Android.Exported:Bool),true))"
 #if @(AndroidManifest.DisableTheme:Defined)
                   android:theme="@style/AppTheme"
 #else


### PR DESCRIPTION
This is required on Android 12 and can be configured by setting
Android.Exported to true/false in your unoproj file.