### PR TITLE
Log: trim lines passed as object

### DIFF
--- a/src/common/Logging/Log.cs
+++ b/src/common/Logging/Log.cs
@@ -337,10 +337,7 @@ namespace Uno.Logging
 
         public void WriteLine(object line, ConsoleColor? color = null)
         {
-            Flush();
-            Write(line, color);
-            lock (_state)
-                OutWriter.Inner.WriteLine();
+            WriteLine((line ?? "").ToString(), color, OutWriter);
         }
 
         public void WriteLine(string line, ConsoleColor? color = null)


### PR DESCRIPTION
Fixes subtle cases of extraneous newlines in log output.