### PR TITLE
iOS: restore build settings for Context.mm

### DIFF
--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -128,7 +128,7 @@
     "ios/Uno-iOS/AppDelegate.h:File",
     "ios/Uno-iOS/AppDelegate.mm:File",
     "ios/Uno-iOS/Context.h:File",
-    "ios/Uno-iOS/Context.mm:File",
+    "ios/Uno-iOS/Context.mm:ObjCSource:iOS",
     "ios/Uno-iOS/Main.mm:File",
     "ios/Uno-iOS/Uno-iOS.h:File",
     "ios/Uno-iOS/Uno-iOS.mm:File",


### PR DESCRIPTION
This fixes build errors when archiving in Xcode, regressed in commit
59300eb27da39eb955de7625e85c155bebbef00c.