### PR TITLE
Android: Upgrade to API 31

### DIFF
--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -22,10 +22,10 @@
     <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '16')" />
     <Set NDK.Version="@(Project.Android.NDK.Version || Config.Android.NDK.Version || '21.4.7075529')" />
     <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '30.0.3')" />
-    <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '30')" />
+    <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '31')" />
     <Set SDK.Directory="@(Config.Android.SDK:Path || Config.Android.SDK.Directory:Path || ANDROID_SDK:Env)" />
     <Set SDK.MinVersion="@(Project.Android.SDK.MinVersion || Config.Android.SDK.MinVersion || '16')" />
-    <Set SDK.TargetVersion="@(Project.Android.SDK.TargetVersion || Config.Android.SDK.TargetVersion || '30')" />
+    <Set SDK.TargetVersion="@(Project.Android.SDK.TargetVersion || Config.Android.SDK.TargetVersion || '31')" />
 
     <!-- Build properties -->
 

--- a/lib/UnoCore/android/dependencies.uxl
+++ b/lib/UnoCore/android/dependencies.uxl
@@ -6,9 +6,9 @@
     <Require Gradle.BuildScript.Repository="mavenCentral()" />
     <Require Gradle.Repository="maven { url 'https://maven.google.com' }" />
 
-    <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:4.2.0" />
-    <Require Gradle.Dependency.Implementation="androidx.appcompat:appcompat:1.3.1" />
-    <Require Gradle.Dependency.Implementation="com.google.android.material:material:1.4.0" />
+    <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:7.2.1" />
+    <Require Gradle.Dependency.Implementation="androidx.appcompat:appcompat:1.4.2" />
+    <Require Gradle.Dependency.Implementation="com.google.android.material:material:1.6.1" />
 
     <!-- Kotlin support. -->
     <Require Condition="KOTLIN" Gradle.Dependency.Implementation="androidx.core:core-ktx:+" />


### PR DESCRIPTION
Targetting API 31 (Android 12) by default because this will be required by Google Play Store starting in November 2022.

Also upgrading dependencies to more recent versions that require API 31.