### PR TITLE
compiler: drop unused using statements

### DIFF
--- a/src/compiler/core/Syntax/Builders/TypeBuilder.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.Compiler.API.Domain;
 using Uno.Compiler.API.Domain.AST;
 using Uno.Compiler.API.Domain.IL;

--- a/src/compiler/foreign/ForeignCPlusPlusPass.cs
+++ b/src/compiler/foreign/ForeignCPlusPlusPass.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Configuration;
 using Uno.Compiler.API;
 using Uno.Compiler.API.Domain.IL;
 using Uno.Compiler.API.Domain.IL.Members;

--- a/src/compiler/foreign/ObjC/Conversion.cs
+++ b/src/compiler/foreign/ObjC/Conversion.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Remoting.Messaging;
 using Uno.Compiler.API.Domain.IL;
 using Uno.Compiler.API.Domain.IL.Members;
 


### PR DESCRIPTION
These are not used by the code and cause build errors on .NET 6.