### PR TITLE
appveyor: use nodejs v14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ version: '{build}'
 image: Visual Studio 2019
 
 environment:
+  nodejs_version: 14
   matrix:
   - TARGET: dotnet
   - TARGET: native
@@ -13,6 +14,7 @@ environment:
   #   SKIP_LIB_TESTS: 1
 
 install:
+  - ps: Install-Product node $env:nodejs_version
   - ps: |
       if ($env:TARGET -eq "android") {
         Invoke-Expression "npm install android-build-tools@1.x -g"


### PR DESCRIPTION
We're still using the old lock-file version so this will avoid seeing warnings in the build log.