### PR TITLE
Android: Add Gradle.Properties element

### DIFF
--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -48,6 +48,7 @@
     <Declare Element="AndroidManifest.Permission" />
     <Declare Element="AndroidManifest.RootElement" />
     <Declare Element="AndroidManifest.Activity.ViewIntentFilter" />
+    <Declare Element="Gradle.Properties" />
     <Declare Element="Gradle.Settings" />
     <Declare Element="Gradle.Dependency" />
     <Declare Element="Gradle.Dependency.ClassPath" />

--- a/lib/UnoCore/android/gradle.properties
+++ b/lib/UnoCore/android/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+@(Gradle.Properties:Join('\n'))


### PR DESCRIPTION
This UXL element makes it possible to output project-specific information in the gradle.properties file.

Example.uxl:
```xml
    <Require Gradle.Properties>
        <![CDATA[
org.gradle.jvmargs=-Xmx1536M \
    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
    --add-opens=java.base/java.lang=ALL-UNNAMED \
    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
    --add-opens=java.base/java.io=ALL-UNNAMED \
    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
        ]]>
    </Require>
```