### PR TITLE
update default output directory (beta-3.0)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ before_test:
   - ps: |
       if ($env:TARGET -eq "native") {
         Get-ChildItem -Path lib -Recurse -Include *Test.unoproj | Select-Object -ExpandProperty DirectoryName | Foreach-Object {
-          $buildDir = Join-Path $_ build\$env:TARGET\test
+          $buildDir = Join-Path $_ build\test\$env:TARGET
           New-Item -Force -ItemType directory -Path $buildDir | Out-Null
           Copy-Item -Path mesa\opengl32.dll -Destination (Join-Path $buildDir opengl32.dll)
         }

--- a/src/runtime/generic/app-generic.csproj
+++ b/src/runtime/generic/app-generic.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\debug\dotnet\UnoCore.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/runtime/mac/app-mac.csproj
+++ b/src/runtime/mac/app-mac.csproj
@@ -22,7 +22,7 @@
       <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\Xamarin.Mac.dll</HintPath>
     </Reference>
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\debug\dotnet\UnoCore.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/runtime/win/app-win.csproj
+++ b/src/runtime/win/app-win.csproj
@@ -18,7 +18,7 @@
       <HintPath>..\..\..\node_modules\@fuse-open\opentk\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="UnoCore">
-      <HintPath>..\..\..\lib\UnoCore\build\dotnet\debug\UnoCore.dll</HintPath>
+      <HintPath>..\..\..\lib\UnoCore\build\debug\dotnet\UnoCore.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/tool/project/PropertyDefinitions.cs
+++ b/src/tool/project/PropertyDefinitions.cs
@@ -10,7 +10,7 @@ namespace Uno.ProjectFormat
             {"BuildCondition", PropertyType.String},
             {"BuildDirectory", PropertyType.Path, "build"},
             {"CacheDirectory", PropertyType.Path, ".uno"},
-            {"OutputDirectory", PropertyType.Path, "$(BuildDirectory)/@(Target)/@(Configuration:ToLower)"},
+            {"OutputDirectory", PropertyType.Path, "$(BuildDirectory)/@(Configuration:ToLower)/@(Target)"},
             {"RootNamespace", PropertyType.String, "$(QIdentifier)"},
             {"Version", PropertyType.String, Environment.GetEnvironmentVariable("npm_package_version") ?? "0.1.0"},
             {"VersionCode", PropertyType.Integer, 1},


### PR DESCRIPTION
This reverses the last two path components of Output Directory, so that Configuration comes before Target, e.g.

    project/build/debug/android/

This is similar to how it is in .NET 6.0 and feels more modern.