### PR TITLE
update pack/restore for net6.0 (beta-3.0)

### DIFF
--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -82,9 +82,9 @@ function rm-identical {
 h1 "Optimizing package"
 
 # OpenTK and Xamarin.Mac will be added back by restore.js
-rm-identical bin node_modules/@fuse-open/xamarin-mac *.dll *.dylib
-rm-identical bin/mac node_modules/@fuse-open/xamarin-mac *.dll *.dylib
-rm-identical bin/win node_modules/@fuse-open/opentk *.dll
+rm-identical bin/net6.0 node_modules/@fuse-open/xamarin-mac *.dll *.dylib
+rm-identical bin/mac/net6.0 node_modules/@fuse-open/xamarin-mac *.dll *.dylib
+rm-identical bin/win/net6.0-windows node_modules/@fuse-open/opentk *.dll
 
 # Drop superfluous build artifacts
-rm-all bin *.config *.mdb *.pdb *.xml
+rm-all bin *.config *.pdb *.xml

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -42,9 +42,9 @@ function restoreFiles(src, dst) {
 
 // Restore Xamarin.Mac binaries.
 const xamarin = findNodeModule("@fuse-open/xamarin-mac");
-restoreFiles(xamarin, path.join(__dirname, "..", "bin"));
-restoreFiles(xamarin, path.join(__dirname, "..", "bin", "mac"));
+restoreFiles(xamarin, path.join(__dirname, "..", "bin", "net6.0"));
+restoreFiles(xamarin, path.join(__dirname, "..", "bin", "mac", "net6.0"));
 
 // Restore OpenTK and ANGLE (Windows only).
 const opentk = findNodeModule("@fuse-open/opentk");
-restoreFiles(opentk, path.join(__dirname, "..", "bin", "win"));
+restoreFiles(opentk, path.join(__dirname, "..", "bin", "win", "net6.0-windows"));

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -1,50 +1,50 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require("fs")
+const path = require("path")
 
 function findup(suffix) {
     for (let dir = __dirname, parent = undefined;;
              dir = path.dirname(dir)) {
 
         if (dir == parent)
-            throw Error(`${suffix} was not found`);
+            throw Error(`${suffix} was not found`)
 
-        parent = dir;
-        const file = path.join(dir, suffix);
+        parent = dir
+        const file = path.join(dir, suffix)
 
         if (fs.existsSync(file))
-            return file;
+            return file
     }
 }
 
 function findNodeModule(name) {
-    const package = findup(`node_modules/${name}/package.json`);
-    return path.dirname(package);
+    const package = findup(`node_modules/${name}/package.json`)
+    return path.dirname(package)
 }
 
 function restoreFiles(src, dst) {
     if (!fs.existsSync(dst))
-        return;
+        return
 
     for (file of fs.readdirSync(src)) {
-        const srcf = path.join(src, file);
-        const dstf = path.join(dst, file);
-        const placeholder = dstf + ".restore";
+        const srcf = path.join(src, file)
+        const dstf = path.join(dst, file)
+        const placeholder = dstf + ".restore"
 
         if (!fs.existsSync(placeholder))
-            continue;
+            continue
 
-        const relative = path.relative(process.cwd(), dstf);
-        console.log(`restoring ${relative}`);
-        fs.copyFileSync(srcf, dstf);
-        fs.unlinkSync(placeholder);
+        const relative = path.relative(process.cwd(), dstf)
+        console.log(`restoring ${relative}`)
+        fs.copyFileSync(srcf, dstf)
+        fs.unlinkSync(placeholder)
     }
 }
 
 // Restore Xamarin.Mac binaries.
-const xamarin = findNodeModule("@fuse-open/xamarin-mac");
-restoreFiles(xamarin, path.join(__dirname, "..", "bin", "net6.0"));
-restoreFiles(xamarin, path.join(__dirname, "..", "bin", "mac", "net6.0"));
+const xamarin = findNodeModule("@fuse-open/xamarin-mac")
+restoreFiles(xamarin, path.join(__dirname, "..", "bin", "net6.0"))
+restoreFiles(xamarin, path.join(__dirname, "..", "bin", "mac", "net6.0"))
 
 // Restore OpenTK and ANGLE (Windows only).
-const opentk = findNodeModule("@fuse-open/opentk");
-restoreFiles(opentk, path.join(__dirname, "..", "bin", "win", "net6.0-windows"));
+const opentk = findNodeModule("@fuse-open/opentk")
+restoreFiles(opentk, path.join(__dirname, "..", "bin", "win", "net6.0-windows"))


### PR DESCRIPTION
### scripts: update pack/restore for net6.0

* Append /net6.0 to paths to make package size small again
* Remove *.mdb reference since not relevant on .NET 6.0

### scripts: drop semicolons in restore.js