### PR TITLE
remove VersionDirectory from libraries (beta-3.0)

### DIFF
--- a/src/tool/engine/Packages/LibraryBuilder.cs
+++ b/src/tool/engine/Packages/LibraryBuilder.cs
@@ -120,12 +120,7 @@ namespace Uno.Build.Packages
             }
             else if (Directory.Exists(lib.PackageDirectory))
             {
-                // Remove old versions
-                foreach (var dir in Directory.EnumerateDirectories(lib.PackageDirectory))
-                    if (dir != lib.VersionDirectory)
-                        Disk.DeleteDirectory(dir, true);
-
-                Disk.DeleteDirectory(Path.Combine(lib.CacheDirectory));
+                Disk.DeleteDirectory(lib.CacheDirectory);
             }
 
             var fail = TryGetFailedReference(lib, failed);
@@ -142,7 +137,7 @@ namespace Uno.Build.Packages
                     new BuildOptions
                     {
                         Configuration = GetConfiguration(lib),
-                        OutputDirectory = lib.VersionDirectory,
+                        OutputDirectory = lib.PackageDirectory,
                         PackageCache = packageCache,
                         Force = true
                     })

--- a/src/tool/engine/Packages/LibraryProject.cs
+++ b/src/tool/engine/Packages/LibraryProject.cs
@@ -10,7 +10,6 @@ namespace Uno.Build.Packages
     {
         public readonly Project Project;
         public readonly string PackageDirectory;
-        public readonly string VersionDirectory;
         public readonly string CacheDirectory;
         public readonly string ConfigFile;
         public readonly string PackageFile;
@@ -22,18 +21,16 @@ namespace Uno.Build.Packages
         {
             Project = project;
             PackageDirectory = Path.Combine(sourceDir, "build", project.Name);
-            VersionDirectory = Path.Combine(PackageDirectory, project.Version);
-            CacheDirectory = Path.Combine(VersionDirectory, ".uno");
+            CacheDirectory = Path.Combine(PackageDirectory, ".uno");
             ConfigFile = Path.Combine(CacheDirectory, "config");
             PackageFile = Path.Combine(CacheDirectory, "package");
         }
 
-        LibraryProject(LibraryProject lib, string versionDir)
+        LibraryProject(LibraryProject lib)
         {
             Project = lib.Project;
             PackageDirectory = lib.PackageDirectory;
-            VersionDirectory = versionDir;
-            CacheDirectory = Path.Combine(VersionDirectory, ".uno");
+            CacheDirectory = Path.Combine(PackageDirectory, ".uno");
             ConfigFile = Path.Combine(CacheDirectory, "config");
             PackageFile = Path.Combine(CacheDirectory, "package");
         }
@@ -44,11 +41,7 @@ namespace Uno.Build.Packages
             if (!Directory.Exists(PackageDirectory))
                 return false;
 
-            var versions = Directory.EnumerateDirectories(PackageDirectory).ToArray();
-            if (versions.Length != 1)
-                return false;
-
-            existing = new LibraryProject(this, versions[0]);
+            existing = new LibraryProject(this);
             return true;
         }
 

--- a/src/tool/engine/Packages/PackageFile.cs
+++ b/src/tool/engine/Packages/PackageFile.cs
@@ -40,8 +40,11 @@ namespace Uno.Build.Packages
         public readonly string RootDirectory;
         public string CacheDirectory => Path.Combine(RootDirectory, ".uno");
         public string Filename => GetName(RootDirectory);
-        public string Version => RootDirectory.GetPathComponent(-1);
-        public string Name => RootDirectory.GetPathComponent(-2);
+        public string Version => _version ?? RootDirectory.GetPathComponent(-1);
+        public string Name => _name ?? RootDirectory.GetPathComponent(-2);
+
+        readonly string _name;
+        readonly string _version;
 
         PackageFile(string dir)
         {
@@ -51,6 +54,8 @@ namespace Uno.Build.Packages
         PackageFile(StuffObject stuff, string dir)
             : this(dir)
         {
+            stuff.TryGetValue(nameof(Name), out _name);
+            stuff.TryGetValue(nameof(Version), out _version);
             stuff.TryGetValue(nameof(BuildCondition), out BuildCondition);
             stuff.TryGetValue(nameof(SourceDirectory), out SourceDirectory);
             stuff.TryGetValue(nameof(IsTransitive), out IsTransitive);
@@ -74,6 +79,8 @@ namespace Uno.Build.Packages
         public PackageFile(SourcePackage upk, string dir)
             : this(dir)
         {
+            _name = upk.Name;
+            _version = upk.Version;
             BuildCondition = upk.BuildCondition;
             IsTransitive = upk.IsTransitive;
 
@@ -95,6 +102,8 @@ namespace Uno.Build.Packages
         public void Save()
         {
             new StuffObject {
+                {nameof(Name), Name},
+                {nameof(Version), Version},
                 {nameof(BuildCondition), BuildCondition},
                 {nameof(SourceDirectory), SourceDirectory},
                 {nameof(IsTransitive), IsTransitive},

--- a/src/tool/engine/Packages/PackageSearchPaths.cs
+++ b/src/tool/engine/Packages/PackageSearchPaths.cs
@@ -27,10 +27,14 @@ namespace Uno.Build.Packages
         public IEnumerable<DirectoryInfo> EnumerateVersionDirectories(string name = "*", string version = null)
         {
             version = version ?? "*";
-            foreach (var package in EnumeratePackageDirectories(name))
-                foreach (var dir in package.EnumerateDirectories(version))
-                    if (PackageFile.Exists(dir.FullName))
-                        yield return dir;
+            foreach (var package in EnumeratePackageDirectories(name)) {
+                if (PackageFile.Exists(package.FullName))
+                    yield return package;
+                else
+                    foreach (var dir in package.EnumerateDirectories(version))
+                        if (PackageFile.Exists(dir.FullName))
+                            yield return dir;
+            }
         }
 
         public DirectoryInfo[] GetOrderedVersionDirectories(string name = "*", string version = null)


### PR DESCRIPTION
Before when building libraries, output files were placed inside a directory named after the current version of the library, e.g.

    lib/build/UnoCore/1.2.3/

This is a relic from a time where it was possible to install multiple versions of the same library side by side using Uno Package Manager.

Uno Package Manager was removed in favor of NPM in 2019, so we no longer have this requirement and can remove the last directory part, e.g.

    lib/build/UnoCore/

We should still be able to load libraries built by older versions of Uno using the version directory.