### PR TITLE
runtime/mac: switch to Microsoft.macOS.SDK (beta-3.0)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ environment:
   #   SKIP_LIB_TESTS: 1
 
 install:
+  - dotnet workload install macos
   - ps: Install-Product node $env:nodejs_version
   - ps: |
       if ($env:TARGET -eq "android") {

--- a/.unoconfig
+++ b/.unoconfig
@@ -1,12 +1,12 @@
 // Core config
-AppLoader.Mac: bin/mac/net6.0
+AppLoader.Generic: bin/generic/net6.0
+AppLoader.Mac: bin/mac/net6.0-macos
 AppLoader.Windows: bin/win/net6.0-windows
 
 if WIN32 {
     AppLoader.Assembly: bin/win/net6.0-windows/uno-app.dll
     Uno.Command: bin/net6.0/uno.exe
 } else if MAC {
-    // FIXME: Xamarin.Mac doesn't work on .NET 6.0:
     AppLoader.Assembly: bin/generic/net6.0/uno-app.dll
     Uno.Command: bin/net6.0/uno
 } else {

--- a/lib/UnoCore/cil/exe.cil.uxl
+++ b/lib/UnoCore/cil/exe.cil.uxl
@@ -14,11 +14,7 @@
     <Set AppLoader.Class="Uno.AppLoader.Program" />
     <Set AppLoader.Method="UnoGenerated" />
 
-    <Require UnmanagedLibrary="@(Config.AppLoader.Mac:Path)/OpenTK.dll" Condition="HOST_MAC" />
-    <Require UnmanagedLibrary="@(Config.AppLoader.Mac:Path)/System.Drawing.Common.dll" Condition="HOST_MAC" />
-    <Require UnmanagedLibrary="@(Config.AppLoader.Mac:Path)/Xamarin.Mac.dll" Condition="HOST_MAC" />
-    <Require UnmanagedLibrary="@(Config.AppLoader.Mac:Path)/libxammac.dylib" Condition="HOST_MAC" />
-    <CopyFile Name="@(Config.AppLoader.Mac:Path)/uno-app.runtimeconfig.json" TargetName="@(AssemblyDirectory)/@(Project.Name).app.runtimeconfig.json" Condition="HOST_MAC" />
+    <CopyFile Name="@(Config.AppLoader.Generic:Path)/uno-app.runtimeconfig.json" TargetName="@(AssemblyDirectory)/@(Project.Name).app.runtimeconfig.json" Condition="!HOST_WIN32" />
 
     <Require UnmanagedLibrary="@(Config.AppLoader.Windows:Path)/OpenTK.dll" Condition="HOST_WIN32" />
     <Require UnmanagedLibrary="@(Config.AppLoader.Windows:Path)/libEGL.dll" Condition="HOST_WIN32" />

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -43,7 +43,6 @@ function restoreFiles(src, dst) {
 // Restore Xamarin.Mac binaries.
 const xamarin = findNodeModule("@fuse-open/xamarin-mac")
 restoreFiles(xamarin, path.join(__dirname, "..", "bin", "net6.0"))
-restoreFiles(xamarin, path.join(__dirname, "..", "bin", "mac", "net6.0"))
 
 // Restore OpenTK and ANGLE (Windows only).
 const opentk = findNodeModule("@fuse-open/opentk")

--- a/src/runtime/mac/AppDelegate.cs
+++ b/src/runtime/mac/AppDelegate.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using CoreGraphics;
 using Uno.AppLoader.MonoMac;
 using Uno.Platform.Internal;
+using System.Runtime.Versioning;
 
 namespace Uno.AppLoader
 {
     [Register("UnoAppDelegate")]
+    [SupportedOSPlatform("macOS10.14")]
     public class AppDelegate : NSApplicationDelegate
     {
         NSWindow _window;

--- a/src/runtime/mac/Info.plist
+++ b/src/runtime/mac/Info.plist
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>Uno App</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.fuseopen.unomac</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.14</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© Fuse Open</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/src/runtime/mac/MonoMacEnums.cs
+++ b/src/runtime/mac/MonoMacEnums.cs
@@ -1,20 +1,21 @@
-﻿using System;
+﻿using System.Runtime.Versioning;
 using AppKit;
 using Uno.Platform;
 
 namespace Uno.AppLoader.MonoMac
 {
+    [SupportedOSPlatform("macOS10.14")]
     public static class MonoMacEnums
     {
-        public static NSAlertStyle GetAlertStyle(Uno.Diagnostics.LogLevel level)
+        public static NSAlertStyle GetAlertStyle(Diagnostics.LogLevel level)
         {
             switch (level)
             {
-                case Uno.Diagnostics.LogLevel.Error:
+                case Diagnostics.LogLevel.Error:
                     return NSAlertStyle.Critical;
-                case Uno.Diagnostics.LogLevel.Warning:
+                case Diagnostics.LogLevel.Warning:
                     return NSAlertStyle.Warning;
-                case Uno.Diagnostics.LogLevel.Information:
+                case Diagnostics.LogLevel.Information:
                     return NSAlertStyle.Informational;
                 default:
                     return 0;

--- a/src/runtime/mac/MonoMacGL.cs
+++ b/src/runtime/mac/MonoMacGL.cs
@@ -2,18 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security;
 using OpenGL;
 using OpenTK.Graphics.OpenGL;
 using MacGL = OpenTK.Graphics.OpenGL.GL;
 
-#pragma warning disable 3019
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
-
 namespace Uno.AppLoader.MonoMac
 {
+    [SupportedOSPlatform("macOS10.14")]
     public class MonoMacGL : IGL
     {
         internal const string Library = "/System/Library/Frameworks/OpenGL.framework/OpenGL";

--- a/src/runtime/mac/MonoMacGraphicsContext.cs
+++ b/src/runtime/mac/MonoMacGraphicsContext.cs
@@ -1,8 +1,10 @@
-﻿using OpenGL;
+﻿using System.Runtime.Versioning;
+using OpenGL;
 using Uno.Platform;
 
 namespace Uno.AppLoader.MonoMac
 {
+    [SupportedOSPlatform("macOS10.14")]
     class MonoMacGraphicsContext : GraphicsContextBackend
     {
         UnoGLView _view;

--- a/src/runtime/mac/MonoMacPlatformWindow.cs
+++ b/src/runtime/mac/MonoMacPlatformWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Runtime.Versioning;
 using AppKit;
 using CoreGraphics;
 using Uno.Platform;
@@ -7,12 +8,11 @@ using Uno.Platform.Internal;
 
 namespace Uno.AppLoader.MonoMac
 {
-    // Be sure what you do when changing the implementation. MonoMacGameView getters and setters is very expensive, 
-    // since they communicate with the OS
+    [SupportedOSPlatform("macOS10.14")]
     class MonoMacPlatformWindow : WindowBackend
     {
         UnoGLView _view;
-        Uno.Int2 _clientSize;
+        Int2 _clientSize;
         float _dpi;
 
         public MonoMacPlatformWindow(UnoGLView view)
@@ -89,39 +89,39 @@ namespace Uno.AppLoader.MonoMac
                 _view.Window.ToggleFullScreen(_view);
         }
 
-        public override bool GetKeyState(Uno.Platform.Key key)
+        public override bool GetKeyState(Key key)
         {
             switch (key)
             {
-                case Uno.Platform.Key.ControlKey:
+                case Key.ControlKey:
                     return (_view.ModifierFlags & NSEventModifierMask.ControlKeyMask) != 0;
-                case Uno.Platform.Key.ShiftKey:
+                case Key.ShiftKey:
                     return (_view.ModifierFlags & NSEventModifierMask.ShiftKeyMask) != 0;
-                case Uno.Platform.Key.AltKey:
+                case Key.AltKey:
                     return (_view.ModifierFlags & NSEventModifierMask.AlternateKeyMask) != 0;
-                case Uno.Platform.Key.OSKey:
-                case Uno.Platform.Key.MetaKey:
+                case Key.OSKey:
+                case Key.MetaKey:
                     return (_view.ModifierFlags & NSEventModifierMask.CommandKeyMask) != 0;
                 default:
                     return false;
             }
         }
 
-        public override void SetPointerCursor(Uno.Platform.PointerCursor p)
+        public override void SetPointerCursor(PointerCursor p)
         {
         }
 
-        public override Uno.Platform.PointerCursor GetPointerCursor()
+        public override PointerCursor GetPointerCursor()
         {
-            return Uno.Platform.PointerCursor.Default;
+            return PointerCursor.Default;
         }
 
-        public override bool GetMouseButtonState(Uno.Platform.MouseButton button)
+        public override bool GetMouseButtonState(MouseButton button)
         {
             return (_view.PressedMouseButtons & (1 << (int)button)) != 0;
         }
 
-        public override void BeginTextInput(Uno.Platform.TextInputHint hint)
+        public override void BeginTextInput(TextInputHint hint)
         {
             _view.EnableText = true;
         }

--- a/src/runtime/mac/Program.cs
+++ b/src/runtime/mac/Program.cs
@@ -4,9 +4,11 @@ using System.Threading;
 using AppKit;
 using ObjCRuntime;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Uno.AppLoader
 {
+    [SupportedOSPlatform("macOS10.14")]
     public static class Program
     {
         static Program()
@@ -52,6 +54,7 @@ namespace Uno.AppLoader
         }
     }
 
+    [SupportedOSPlatform("macOS10.14")]
     public static class ObjCExtensions
     {
         [DllImport ("/usr/lib/libobjc.dylib")]

--- a/src/runtime/mac/UnoGLView.cs
+++ b/src/runtime/mac/UnoGLView.cs
@@ -8,9 +8,11 @@ using OpenTK.Graphics.OpenGL;
 using Uno.Diagnostics;
 using Uno.Platform;
 using Uno.Platform.Internal;
+using System.Runtime.Versioning;
 
 namespace Uno.AppLoader.MonoMac
 {
+    [SupportedOSPlatform("macOS10.14")]
     public class UnoGLView : NSView
     {
         readonly MonoMacPlatformWindow _unoWindow;

--- a/src/runtime/mac/app-mac.csproj
+++ b/src/runtime/mac/app-mac.csproj
@@ -1,26 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\GlobalAssemblyInfo.props" />
-  <Import Project="..\..\..\node_modules\@fuse-open\xamarin-mac\FuseOpen.Xamarin.Mac.props" Condition="Exists('..\..\..\node_modules\@fuse-open\xamarin-mac\FuseOpen.Xamarin.Mac.props')" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-macOS</TargetFramework>
     <RootNamespace>Uno.AppLoader</RootNamespace>
     <AssemblyName>uno-app</AssemblyName>
     <OutputPath>$(SolutionDir)bin\mac</OutputPath>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationId>com.fuseopen.unomac</ApplicationId>
+    <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <UseSGen>false</UseSGen>
+    <LinkMode>None</LinkMode>
+    <NoWarn>CA1416</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <UseSGen>false</UseSGen>
+    <LinkMode>None</LinkMode>
+    <NoWarn>CA1416</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="OpenTK.macOS" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
-      <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\OpenTK.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Mac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, processorArchitecture=MSIL">
-      <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\Xamarin.Mac.dll</HintPath>
-    </Reference>
     <Reference Include="UnoCore">
       <HintPath>..\..\..\lib\UnoCore\build\debug\dotnet\UnoCore.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Getting closer to running .NET 6.0 apps on macOS.

* Use generic app loader for now so we can run tests.