### PR TITLE
Uno.Graphics.Utils: drop reference to Experimental.TextureLoader (beta-3.0)

### DIFF
--- a/lib/Uno.Graphics.Utils/Uno.Graphics.Utils.unoproj
+++ b/lib/Uno.Graphics.Utils/Uno.Graphics.Utils.unoproj
@@ -2,9 +2,6 @@
   "Copyright": "Copyright (c) Fuse Open",
   "Description": "Font and texture loading",
   "Publisher": "Fuse Open",
-  "InternalsVisibleTo": [
-    "Experimental.TextureLoader"
-  ],
   "Includes": [
     "Bitmap.uno:Source",
     "cpp/CppFontFace.uno:Source",


### PR DESCRIPTION
This library is being removed in https://github.com/fuse-open/fuselibs/pull/1458.