### PR TITLE
compiler: support lamdas in generic classes

### DIFF
--- a/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
@@ -25,7 +25,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
                     if (it.MasterDefinition == dt.MasterDefinition)
                         return Parameterize(it);
 
-                throw new FatalException(dt.Source, ErrorCode.I3044, "Unable to find parameterized version of " + dt.Quote());
+                var pr = CreateParameterizableInnerType(dt, pp);
+                pr.SetMasterDefinition(dt.MasterDefinition);
+                pp.NestedTypes.Add(pr);
+                return pr;
             }
 
             var pt = Parameterize(dt.Source, dt, dt.GenericParameters);

--- a/tests/src/UnoTest/General/Lambdas.uno
+++ b/tests/src/UnoTest/General/Lambdas.uno
@@ -445,6 +445,28 @@ namespace UnoTest.General
 
             Assert.AreEqual("Yo!", f().Message);
         }
+
+        [Test]
+        public void GenericContext()
+        {
+            var test = new GenericContextHelper<int>(10);
+            Assert.AreEqual(10, test.Run());
+        }
+
+        class GenericContextHelper<T>
+        {
+            Func<T> f;
+
+            public GenericContextHelper(T arg)
+            {
+                f = () => arg;
+            }
+
+            public T Run()
+            {
+                return f();
+            }
+        }
     }
 
     public class LambdasClashClass


### PR DESCRIPTION
This updates ClosureConvertFunction to generate valid code when lambdas are used inside generic classes.

Generic classes need a definition object and one or more parameterized objects pointing back to their definition. Essentially, we're now creating copies of relevant objects where necessary, so that other parts of the comiler can work correctly.