### PR TITLE
iOS: use iPhone-14 as default Simulator device

### DIFF
--- a/.unoconfig
+++ b/.unoconfig
@@ -19,4 +19,4 @@ Packages.SourcePaths += lib
 
 // Tooling
 Android.Emulator.Architecture: x86_64
-iOS.Simulator.Device: iPhone-13
+iOS.Simulator.Device: iPhone-14


### PR DESCRIPTION
iPhone 14 Simulator is included with Xcode 14.