### PR TITLE
UnoCore: rename PackageName members (beta-3.0)

### DIFF
--- a/lib/UnoCore/src/Uno/Compiler/CallerMemberNameAttribute.uno
+++ b/lib/UnoCore/src/Uno/Compiler/CallerMemberNameAttribute.uno
@@ -9,6 +9,12 @@ namespace Uno.Compiler
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]
+    public sealed class CallerBundleNameAttribute : Attribute
+    {
+    }
+
+    [Obsolete("Please use 'CallerBundleNameAttribute' instead.")]
+    [AttributeUsage(AttributeTargets.Parameter)]
     public sealed class CallerPackageNameAttribute : Attribute
     {
     }

--- a/lib/UnoCore/src/Uno/IO/Bundle.uno
+++ b/lib/UnoCore/src/Uno/IO/Bundle.uno
@@ -208,27 +208,27 @@ namespace Uno.IO
 
             lock (_bundles)
             {
-                foreach (var package in new BundleFile(
+                foreach (var name in new BundleFile(
                             new Bundle(),
                             null,
                             "bundles")
                         .ReadAllText()
                         .Split('\n'))
-                    _bundles[package] = new Bundle(package, true);
+                    _bundles[name] = new Bundle(name, true);
             }
         }
 
-        public static Bundle Get([CallerPackageName] string package = null)
+        public static Bundle Get([CallerPackageName] string name = null)
         {
             Load();
 
             lock (_bundles)
             {
                 Bundle bundle;
-                if (!_bundles.TryGetValue(package, out bundle))
+                if (!_bundles.TryGetValue(name, out bundle))
                 {
-                    bundle = new Bundle(package);
-                    _bundles.Add(package, bundle);
+                    bundle = new Bundle(name);
+                    _bundles.Add(name, bundle);
                 }
 
                 return bundle;
@@ -250,7 +250,13 @@ namespace Uno.IO
         extern(DOTNET) internal readonly Assembly Assembly;
         readonly List<BundleFile> _files = new List<BundleFile>();
 
+        [Obsolete("Please use 'Name' instead.")]
         public string PackageName
+        {
+            get { return Name; }
+        }
+
+        public string Name
         {
             get;
             private set;
@@ -261,12 +267,12 @@ namespace Uno.IO
             get { return _files; }
         }
 
-        Bundle(string packageName = null, bool load = false)
+        Bundle(string name = null, bool load = false)
         {
-            PackageName = packageName;
+            Name = name;
 
             if defined(DOTNET)
-                Assembly = GetAssembly(packageName);
+                Assembly = GetAssembly(name);
 
             if (!load)
                 return;
@@ -274,7 +280,7 @@ namespace Uno.IO
             foreach (var line in new BundleFile(
                         this,
                         null,
-                        packageName + ".bundle")
+                        name + ".bundle")
                     .ReadAllText()
                     .Split('\n'))
             {
@@ -291,12 +297,12 @@ namespace Uno.IO
                 if (f.SourcePath == filename || f.BundlePath == filename)
                     return f;
 
-            throw new FileNotFoundException("The file '" + filename + "' was not found in bundle '" + PackageName + "'", filename);
+            throw new FileNotFoundException("The file '" + filename + "' was not found in bundle '" + Name + "'", filename);
         }
 
         public override string ToString()
         {
-            return PackageName;
+            return Name;
         }
 
         extern(DOTNET)

--- a/src/compiler/core/IL/Utilities/Essentials.cs
+++ b/src/compiler/core/IL/Utilities/Essentials.cs
@@ -70,7 +70,7 @@ namespace Uno.Compiler.Core.IL.Utilities
         public DataType CallerFilePathAttribute { get; private set; }
         public DataType CallerLineNumberAttribute { get; private set; }
         public DataType CallerMemberNameAttribute { get; private set; }
-        public DataType CallerPackageNameAttribute { get; private set; }
+        public DataType CallerBundleNameAttribute { get; private set; }
         public DataType WeakReferenceAttribute { get; private set; }
         public DataType OptionalAttribute { get; private set; }
         public DataType ObsoleteAttribute { get; private set; }
@@ -159,7 +159,7 @@ namespace Uno.Compiler.Core.IL.Utilities
             CallerFilePathAttribute = ilf.GetType("Uno.Compiler.CallerFilePathAttribute");
             CallerLineNumberAttribute = ilf.GetType("Uno.Compiler.CallerLineNumberAttribute");
             CallerMemberNameAttribute = ilf.GetType("Uno.Compiler.CallerMemberNameAttribute");
-            CallerPackageNameAttribute = ilf.GetType("Uno.Compiler.CallerPackageNameAttribute");
+            CallerBundleNameAttribute = ilf.GetType("Uno.Compiler.CallerBundleNameAttribute");
             WeakReferenceAttribute = ilf.GetType("Uno.WeakReferenceAttribute");
             OptionalAttribute = ilf.GetType("Uno.Compiler.ExportTargetInterop.OptionalAttribute");
             ObsoleteAttribute = ilf.GetType("Uno.ObsoleteAttribute");

--- a/src/compiler/core/IL/Validation/ILVerifier.cs
+++ b/src/compiler/core/IL/Validation/ILVerifier.cs
@@ -308,7 +308,7 @@ namespace Uno.Compiler.Core.IL.Validation
                 {
                     DataType type = attr.ReturnType;
 
-                    if (type == Essentials.CallerPackageNameAttribute && p.Type != Essentials.String)
+                    if (type == Essentials.CallerBundleNameAttribute && p.Type != Essentials.String)
                         Log.Error(attr.Source, ErrorCode.E0000, type.Quote() + " can only be used on string parameters");
                     if (type == Essentials.CallerFilePathAttribute && p.Type != Essentials.String)
                         Log.Error(attr.Source, ErrorCode.E0000, type.Quote() + " can only be used on string parameters");

--- a/src/compiler/core/Syntax/Compilers/FunctionCompiler.OverloadResolver.cs
+++ b/src/compiler/core/Syntax/Compilers/FunctionCompiler.OverloadResolver.cs
@@ -164,7 +164,7 @@ namespace Uno.Compiler.Core.Syntax.Compilers
                             return new Constant(src, Essentials.String, src.FullPath);
                         if (parameter.HasAttribute(Essentials.CallerMemberNameAttribute))
                             return new Constant(src, Essentials.String, Function.Name);
-                        if (parameter.HasAttribute(Essentials.CallerPackageNameAttribute))
+                        if (parameter.HasAttribute(Essentials.CallerBundleNameAttribute))
                             return new Constant(src, Essentials.String, src.Bundle.Name);
                         break;
                 }


### PR DESCRIPTION
* In the Bundle class, deprecate the PackageName property and add Name instead.
* Deprecate the CallerPackageName attribute and add CallerBundleName instead.
* Update the compiler to use the new attribute.
* Update related variable names.

Related to #440