### PR TITLE
unoconfig: rename Packages.* properties (beta-3.0)

### DIFF
--- a/.unoconfig
+++ b/.unoconfig
@@ -14,7 +14,7 @@ if WIN32 {
 }
 
 // Package config
-Packages.SourcePaths += lib
+SearchPaths.Sources += lib
 
 // Tooling
 Android.Emulator.Architecture: x86_64

--- a/src/tool/engine/Libraries/BundleCache.cs
+++ b/src/tool/engine/Libraries/BundleCache.cs
@@ -47,14 +47,14 @@ namespace Uno.Build.Libraries
             _config = config;
             _enableTranspiler = enableTranspiler;
 
-            foreach (var src in config.GetFullPathArray("Packages.SourcePaths"))
+            foreach (var src in config.GetFullPathArray("SearchPaths.Sources", "Packages.SourcePaths"))
                 _sourcePaths.AddOnce(Path.Combine(
                     File.Exists(src)
                         ? Path.GetDirectoryName(src)
                         : src,
                     "build"));
 
-            foreach (var src in config.GetFullPathArray("Packages.SearchPaths"))
+            foreach (var src in config.GetFullPathArray("SearchPaths", "Packages.SearchPaths"))
                 _searchPaths.AddOnce(src);
         }
 

--- a/tests/src/.unoconfig
+++ b/tests/src/.unoconfig
@@ -1,1 +1,1 @@
-Packages.SourcePaths += ../lib
+SearchPaths.Sources += ../lib


### PR DESCRIPTION
We want to stop saying "packages" when referring to Uno libraries (#440), so this renames the following unoconfig properties:

* Packages.SearchPaths -> SearchPaths
* Packages.SourcePaths -> SearchPaths.Sources

(The old names are deprecated but still work)