### PR TITLE
unoproj: rename "Packages" -> "References" (beta-3.0)

### DIFF
--- a/lib/Uno.Collections/tests/Uno.Collections.Test.unoproj
+++ b/lib/Uno.Collections/tests/Uno.Collections.Test.unoproj
@@ -1,6 +1,5 @@
 {
-  "Copyright": "Copyright (C) 2014",
-  "Packages": [
+  "References": [
     "Uno.Collections",
     "Uno.Testing"
   ],

--- a/lib/Uno.Data.Json/tests/Uno.Data.Json.Test.unoproj
+++ b/lib/Uno.Data.Json/tests/Uno.Data.Json.Test.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Data.Json",
     "Uno.Testing"
   ],

--- a/lib/Uno.Data.Xml/tests/Xml.Test.unoproj
+++ b/lib/Uno.Data.Xml/tests/Xml.Test.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Data.Xml",
     "Uno.Testing"
   ],

--- a/lib/Uno.Net.Http/tests/Http.Test/Http.Test.unoproj
+++ b/lib/Uno.Net.Http/tests/Http.Test/Http.Test.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Net.Http",
     "Uno.Testing"
   ],

--- a/lib/Uno.Net.Http/tests/HttpStatusCodeTester/HttpStatusCodeTester/HttpStatusCodeTester.unoproj
+++ b/lib/Uno.Net.Http/tests/HttpStatusCodeTester/HttpStatusCodeTester/HttpStatusCodeTester.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Fuse.Animations",
     "Fuse.BasicTheme",
     "Fuse.Controls",

--- a/lib/Uno.Net.Sockets/tests/Uno.Net.Sockets.Test.unoproj
+++ b/lib/Uno.Net.Sockets/tests/Uno.Net.Sockets.Test.unoproj
@@ -1,6 +1,5 @@
 {
-  "Copyright": "Copyright (C) 2015",
-  "Packages": [
+  "References": [
     "Uno.Net.Sockets",
     "Uno.Testing"
   ],

--- a/lib/Uno.Testing/tests/Uno.Testing.Test.unoproj
+++ b/lib/Uno.Testing/tests/Uno.Testing.Test.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing"
   ],
   "Includes": [

--- a/lib/Uno.Threading/tests/Threading.Test.unoproj
+++ b/lib/Uno.Threading/tests/Threading.Test.unoproj
@@ -1,10 +1,8 @@
 {
-  "InternalsVisibleTo": [],
-  "Packages": [
+  "References": [
     "Uno.Testing",
     "Uno.Threading"
   ],
-  "Projects": [],
   "Includes": [
     "AutoResetEventTest.uno",
     "ConcurrentDictionary.Test.uno:Source",

--- a/lib/UnoCore/tests/UnoCore.Test.unoproj
+++ b/lib/UnoCore/tests/UnoCore.Test.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
     "Uno.Threading"
   ],

--- a/src/test/data/FirstTest/FirstTest.unoproj
+++ b/src/test/data/FirstTest/FirstTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing"
   ],
   "Includes": [

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -135,7 +135,7 @@ namespace Uno.Build
             if (Log.HasErrors)
                 return null;
 
-            PrintRow("Packages", _input.Bundles);
+            PrintRow("References", _input.Bundles);
             PrintRow("Output dir", _env.OutputDirectory);
 
             _file.Delete();

--- a/src/tool/project/Project.cs
+++ b/src/tool/project/Project.cs
@@ -47,7 +47,7 @@ namespace Uno.ProjectFormat
         public Source Source => new Source(_fullPath);
         public UnoConfig Config => UnoConfig.GetUpToDate(_config) ?? (_config = UnoConfig.Get(_fullPath));
 
-        public IReadOnlyList<LibraryReference> PackageReferences => (IReadOnlyList<LibraryReference>)_doc.OptionalPackages ?? new LibraryReference[0];
+        public IReadOnlyList<LibraryReference> PackageReferences => (IReadOnlyList<LibraryReference>)_doc.OptionalLibraryReferences ?? new LibraryReference[0];
         public IReadOnlyList<ProjectReference> ProjectReferences => GetFlattenedProjects();
         public IReadOnlyList<SourceValue> InternalsVisibleTo => (IReadOnlyList<SourceValue>)_doc.OptionalInternalsVisibleTo ?? new SourceValue[0];
         public IReadOnlyList<IncludeItem> IncludeItems => (IReadOnlyList<IncludeItem>)_doc.Includes ?? new IncludeItem[0];
@@ -64,12 +64,12 @@ namespace Uno.ProjectFormat
         public IEnumerable<FileItem> FuseJSFiles => GetFlattenedItems().Where(x => x.Type == IncludeItemType.FuseJS).Select(x => new FileItem(x.Value, x.Condition));
 
         public Dictionary<string, SourceValue> MutableProperties => _doc.Properties;
-        public List<LibraryReference> MutablePackageReferences => _doc.OptionalPackages ?? (_doc.OptionalPackages = new List<LibraryReference>());
+        public List<LibraryReference> MutablePackageReferences => _doc.OptionalLibraryReferences ?? (_doc.OptionalLibraryReferences = new List<LibraryReference>());
         public List<SourceValue> MutableInternalsVisibleTo => _doc.OptionalInternalsVisibleTo ?? (_doc.OptionalInternalsVisibleTo = new List<SourceValue>());
 
         public List<ProjectReference> MutableProjectReferences
         {
-            get { _flattenedProjectsDirty = true; return _doc.OptionalProjects ?? (_doc.OptionalProjects = new List<ProjectReference>()); }
+            get { _flattenedProjectsDirty = true; return _doc.OptionalProjectReferences ?? (_doc.OptionalProjectReferences = new List<ProjectReference>()); }
         }
 
         public List<IncludeItem> MutableIncludeItems
@@ -193,8 +193,8 @@ namespace Uno.ProjectFormat
             if (_flattenedProjectsDirty || force)
             {
                 _flattenedProjects.Clear();
-                if (_doc.OptionalProjects != null)
-                    ProjectGlobber.FindItems(this, _doc.OptionalProjects, ExcludeItems, _flattenedProjects, log, !force);
+                if (_doc.OptionalProjectReferences != null)
+                    ProjectGlobber.FindItems(this, _doc.OptionalProjectReferences, ExcludeItems, _flattenedProjects, log, !force);
                 _flattenedProjectsDirty = false;
             }
 
@@ -215,11 +215,11 @@ namespace Uno.ProjectFormat
 
         public void AddDefaults()
         {
-            if (_doc.OptionalPackages == null)
-                _doc.OptionalPackages = new List<LibraryReference>();
+            if (_doc.OptionalLibraryReferences == null)
+                _doc.OptionalLibraryReferences = new List<LibraryReference>();
 
-            if (_doc.OptionalProjects == null)
-                _doc.OptionalProjects = new List<ProjectReference>();
+            if (_doc.OptionalProjectReferences == null)
+                _doc.OptionalProjectReferences = new List<ProjectReference>();
 
             if (_doc.OptionalInternalsVisibleTo == null)
                 _doc.OptionalInternalsVisibleTo = new List<SourceValue>();
@@ -234,13 +234,13 @@ namespace Uno.ProjectFormat
 
         public void RemoveDefaults()
         {
-            if (_doc.OptionalPackages != null &&
-                _doc.OptionalPackages.Count == 0)
-                _doc.OptionalPackages = null;
+            if (_doc.OptionalLibraryReferences != null &&
+                _doc.OptionalLibraryReferences.Count == 0)
+                _doc.OptionalLibraryReferences = null;
 
-            if (_doc.OptionalProjects != null &&
-                _doc.OptionalProjects.Count == 0)
-                _doc.OptionalProjects = null;
+            if (_doc.OptionalProjectReferences != null &&
+                _doc.OptionalProjectReferences.Count == 0)
+                _doc.OptionalProjectReferences = null;
 
             if (_doc.OptionalInternalsVisibleTo != null &&
                 _doc.OptionalInternalsVisibleTo.Count == 0)

--- a/src/tool/project/UnoprojDocument.cs
+++ b/src/tool/project/UnoprojDocument.cs
@@ -6,8 +6,8 @@ namespace Uno.ProjectFormat
     {
         public readonly Dictionary<string, SourceValue> Properties = new Dictionary<string,SourceValue>();
         public readonly List<IncludeItem> Includes = new List<IncludeItem>();
-        public List<ProjectReference> OptionalProjects;
-        public List<LibraryReference> OptionalPackages;
+        public List<ProjectReference> OptionalProjectReferences;
+        public List<LibraryReference> OptionalLibraryReferences;
         public List<SourceValue> OptionalInternalsVisibleTo;
         public List<SourceValue> OptionalExcludes;
     }

--- a/src/tool/project/UnoprojParser.cs
+++ b/src/tool/project/UnoprojParser.cs
@@ -101,32 +101,33 @@ namespace Uno.ProjectFormat
 
                             break;
                         }
-                        case "Packages":
+                        case "Packages":    // 1.x and 2.x
+                        case "References":  // 3.x
                         {
-                            _document.OptionalPackages = new List<LibraryReference>();
+                            _document.OptionalLibraryReferences = new List<LibraryReference>();
 
                             foreach (var e in ReadArray())
                             {
                                 try
                                 {
-                                    _document.OptionalPackages.Add(LibraryReference.FromString(GetSource(), e));
+                                    _document.OptionalLibraryReferences.Add(LibraryReference.FromString(GetSource(), e));
                                 }
                                 catch (Exception x)
                                 {
-                                    _log.Error(GetSource(), null, "Invalid 'Packages' element (" + e + "): " + x.Message);
+                                    _log.Error(GetSource(), null, "Invalid 'References' element (" + e + "): " + x.Message);
                                 }
                             }
                             break;
                         }
                         case "Projects":
                         {
-                            _document.OptionalProjects = new List<ProjectReference>();
+                            _document.OptionalProjectReferences = new List<ProjectReference>();
 
                             foreach (var e in ReadArray())
                             {
                                 try
                                 {
-                                    _document.OptionalProjects.Add(ProjectReference.FromString(GetSource(), e));
+                                    _document.OptionalProjectReferences.Add(ProjectReference.FromString(GetSource(), e));
                                 }
                                 catch (Exception x)
                                 {

--- a/src/tool/project/UnoprojSerializer.cs
+++ b/src/tool/project/UnoprojSerializer.cs
@@ -58,21 +58,21 @@ namespace Uno.ProjectFormat
                 json["InternalsVisibleTo"] = internals;
             }
 
-            if (project.OptionalPackages != null)
+            if (project.OptionalLibraryReferences != null)
             {
-                var packages = new List<string>();
+                var references = new List<string>();
 
-                foreach (var e in project.OptionalPackages)
-                    packages.Add(e.ToString());
+                foreach (var e in project.OptionalLibraryReferences)
+                    references.Add(e.ToString());
 
-                json["Packages"] = packages;
+                json["References"] = references;
             }
 
-            if (project.OptionalProjects != null)
+            if (project.OptionalProjectReferences != null)
             {
                 var projects = new List<string>();
 
-                foreach (var e in project.OptionalProjects)
+                foreach (var e in project.OptionalProjectReferences)
                     projects.Add(e.ToString());
 
                 json["Projects"] = projects;

--- a/tests/libtest/libtest.unoproj
+++ b/tests/libtest/libtest.unoproj
@@ -1,6 +1,6 @@
 {
     "RootNamespace": "ShippedLibrariesCompile",
-    "Packages": [
+    "References": [
         "Uno.Collections",
         "Uno.Data.Json",
         "Uno.Data.Xml",

--- a/tests/src/AutoReleasePoolStructTest/AutoReleasePoolStructTest.unoproj
+++ b/tests/src/AutoReleasePoolStructTest/AutoReleasePoolStructTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing"
   ],
   "Includes": [

--- a/tests/src/Benchmark/Benchmark.unoproj
+++ b/tests/src/Benchmark/Benchmark.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
     "UnoCore"
   ],

--- a/tests/src/BundleApp/BundleApp.unoproj
+++ b/tests/src/BundleApp/BundleApp.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "BundleLib"
   ],
   "Projects": [

--- a/tests/src/BundleRecursive/BundleRecursive.unoproj
+++ b/tests/src/BundleRecursive/BundleRecursive.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing"
   ],
   "Includes": [

--- a/tests/src/CFileIncludeTest/CFileIncludeTest.unoproj
+++ b/tests/src/CFileIncludeTest/CFileIncludeTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
   ],
   "Includes": [

--- a/tests/src/ForeignCPlusPlusTest/ForeignCPlusPlusTest.unoproj
+++ b/tests/src/ForeignCPlusPlusTest/ForeignCPlusPlusTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
   ],
   "Includes": [

--- a/tests/src/ForeignJavaTest/ForeignJavaTest.unoproj
+++ b/tests/src/ForeignJavaTest/ForeignJavaTest.unoproj
@@ -1,6 +1,6 @@
 {
   "RootNamespace":"",
-  "Packages": [
+  "References": [
     "Uno.Threading",
     "Uno.Testing",
     "UnoCore"

--- a/tests/src/ForeignObjCTest/ForeignObjCTest.unoproj
+++ b/tests/src/ForeignObjCTest/ForeignObjCTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
     "UnoCore"
   ],

--- a/tests/src/FullPathApp/FullPathApp.unoproj
+++ b/tests/src/FullPathApp/FullPathApp.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Fuse",
     "FuseJS"
   ],

--- a/tests/src/SwiftFileIncludeTest/SwiftFileIncludeTest.unoproj
+++ b/tests/src/SwiftFileIncludeTest/SwiftFileIncludeTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
   ],
   "iOS": {

--- a/tests/src/TransitiveApp/TransitiveApp.unoproj
+++ b/tests/src/TransitiveApp/TransitiveApp.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Transitive.A"
   ],
   "Includes": [

--- a/tests/src/UXTest/UXTest.unoproj
+++ b/tests/src/UXTest/UXTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Testing",
     "UnoCore"
   ],

--- a/tests/src/UnoTest/UnoTest.unoproj
+++ b/tests/src/UnoTest/UnoTest.unoproj
@@ -1,5 +1,5 @@
 {
-  "Packages": [
+  "References": [
     "Uno.Collections",
     "Uno.Testing",
     "Uno.Threading"


### PR DESCRIPTION
Same motivation as #451, #452 and #453. Old names are deprecated but still work.

* Update related member names in the compiler.
* Update project files.