### PR TITLE
iOS: replace Uno/Uno.h includes

### DIFF
--- a/lib/Uno.Net.Http/ios/HttpRequest.mm
+++ b/lib/Uno.Net.Http/ios/HttpRequest.mm
@@ -1,4 +1,4 @@
-#include <Uno/Uno.h>
+#include <uno.h>
 
 #include <@{Uno.Byte:Include}>
 #include <@{Uno.String:Include}>

--- a/lib/UnoCore/cpp/Uno/Uno.h
+++ b/lib/UnoCore/cpp/Uno/Uno.h
@@ -1,5 +1,5 @@
 // @(MSG_ORIGIN)
 // @(MSG_EDIT_WARNING)
 
-//#pragma message ( "Deprecated: Please include <uno.h> instead." )
+#warning "Deprecated: Please include <uno.h> instead."
 #include "../uno.h"

--- a/lib/UnoCore/ios/@(Project.Name)/@(Project.Name)-Prefix.pch
+++ b/lib/UnoCore/ios/@(Project.Name)/@(Project.Name)-Prefix.pch
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef __cplusplus
-#include <Uno/Uno.h>
+#include <uno.h>
 #endif
 
 @(Xcode.PrefixHeader.Declaration:Join())

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.h
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.String.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Uno/Uno.h>
+#include <uno.h>
 
 #if __OBJC__
 @class NSString;

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.h
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Uno/Uno.h>
+#include <uno.h>
 #include <Foundation/Foundation.h>
 
 @protocol UnoArray <NSObject>

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.mm
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoArray.mm
@@ -1,4 +1,4 @@
-#include <Uno/Uno.h>
+#include <uno.h>
 #include <uObjC.Foreign.h>
 #include <uObjC.UnoArray.h>
 

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoObject.mm
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ObjC/uObjC.UnoObject.mm
@@ -1,4 +1,4 @@
-#include <Uno/Uno.h>
+#include <uno.h>
 #include <uObjC.Foreign.h>
 #include <uObjC.UnoObject.h>
 

--- a/lib/UnoCore/src/Uno/Platform/iOS/Display.mm
+++ b/lib/UnoCore/src/Uno/Platform/iOS/Display.mm
@@ -1,6 +1,6 @@
 #include <UIKit/UIKit.h>
 
-#include <Uno/Uno.h>
+#include <uno.h>
 #include <Uno-iOS/AppDelegate.h>
 #include <Uno-iOS/Uno-iOS.h>
 

--- a/lib/UnoCore/src/Uno/Platform/iOS/Window.mm
+++ b/lib/UnoCore/src/Uno/Platform/iOS/Window.mm
@@ -1,4 +1,4 @@
-#include <Uno/Uno.h>
+#include <uno.h>
 #include <Uno-iOS/Uno-iOS.h>
 #include <Window.h>
 @{Uno.Platform.iOSDisplay:IncludeDirective}


### PR DESCRIPTION
Include uno.h instead and fix the deprecation warning in Uno/Uno.h.