### PR TITLE
C++: remove legacy uFreeCStr() (beta-3.0)

### DIFF
--- a/lib/UnoCore/cpp/Uno/ObjectModel.cpp
+++ b/lib/UnoCore/cpp/Uno/ObjectModel.cpp
@@ -1181,11 +1181,6 @@ char* uAllocCStr(const uString* string, size_t* length)
     return dst;
 }
 
-void uFreeCStr(const char* cstr)
-{
-    free((void*)cstr);
-}
-
 uEnumType* uEnumType::New(const char* name, uType* base, size_t literalCount)
 {
     U_ASSERT(base);

--- a/lib/UnoCore/cpp/Uno/ObjectModel.h
+++ b/lib/UnoCore/cpp/Uno/ObjectModel.h
@@ -570,8 +570,6 @@ struct uString : uObject
 
 // Leak warning: The returned string must be deleted using free()
 char* uAllocCStr(const uString* string, size_t* length = nullptr);
-// Deprecated: Use free() instead - the parameter type shouldn't be const
-void DEPRECATED("Use free() instead") uFreeCStr(const char* cstr);
 
 struct uCString
 {


### PR DESCRIPTION
Deprecated since before version 1.0.