### PR TITLE
C++-backend: use a comparer when sorting in IncludeResolver (beta-3.0)

### DIFF
--- a/src/compiler/backend/cpp/DeclarationComparer.cs
+++ b/src/compiler/backend/cpp/DeclarationComparer.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Uno.Compiler.Backends.CPlusPlus
+{
+    /** A comparer that makes strings starting with '#' come out first. */
+    public class DeclarationComparer : IComparer<string>
+    {
+        public static readonly DeclarationComparer Singleton = new DeclarationComparer();
+
+        public int Compare(string x, string y)
+        {
+            var xIsDirective = x.Length > 0 && x[0] == '#';
+            var yIsDirective = y.Length > 0 && y[0] == '#';
+
+            return xIsDirective && !yIsDirective
+                ? -1
+                : !xIsDirective && yIsDirective
+                ? 1
+                : x.CompareTo(y);
+        }
+    }
+}

--- a/src/compiler/backend/cpp/IncludeResolver.cs
+++ b/src/compiler/backend/cpp/IncludeResolver.cs
@@ -31,7 +31,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 includes.Add(_backend.GetIncludeFilename(t));
 
             var result = includes.ToArray();
-            Array.Sort(result);
+            Array.Sort(result, DeclarationComparer.Singleton);
             return result;
         }
 
@@ -141,9 +141,9 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 Inline = inlineDeclarations,
             };
 
-            Array.Sort(result.Header);
-            Array.Sort(result.Source);
-            Array.Sort(result.Inline);
+            Array.Sort(result.Header, DeclarationComparer.Singleton);
+            Array.Sort(result.Source, DeclarationComparer.Singleton);
+            Array.Sort(result.Inline, DeclarationComparer.Singleton);
             return result;
         }
 


### PR DESCRIPTION
Use DeclarationComparer to sort declarations before being emitted into source files to make sure preprocessor directives (lines starting with '#') come out first.

This solves a problem where ManualTestingApp in Fuselibs fails to build for Android since our last beta release, because some declarations come out before includes. This might have regressed with changes in #456.