### PR TITLE
C++ (android): add back deprecated header (beta-3.0)

### DIFF
--- a/lib/UnoCore/UnoCore.unoproj
+++ b/lib/UnoCore/UnoCore.unoproj
@@ -95,6 +95,7 @@
     "cpp/Uno/_config.h:File",
     "cpp/Uno/_internal.h:File",
     "cpp/Uno/_invoke.cpp:File",
+    "cpp/Uno/Graphics/GLHelper.h:File",
     "cpp/Uno/Memory.cpp:File",
     "cpp/Uno/Memory.h:File",
     "cpp/Uno/NativeStackTrace.cpp:File",

--- a/lib/UnoCore/cpp/Uno/Graphics/GLHelper.h
+++ b/lib/UnoCore/cpp/Uno/Graphics/GLHelper.h
@@ -1,0 +1,5 @@
+// @(MSG_ORIGIN)
+// @(MSG_EDIT_WARNING)
+
+#warning "Deprecated: Please include <uDroid/GLHelper.h> instead."
+#include <uDroid/GLHelper.h>

--- a/lib/UnoCore/cpp/uno.cpp.uxl
+++ b/lib/UnoCore/cpp/uno.cpp.uxl
@@ -15,14 +15,17 @@
     <ProcessFile SourceFile="Uno/Support.cpp" />
     <ProcessFile HeaderFile="Uno/Support.h" />
     <ProcessFile SourceFile="Uno/SupportApple.mm" Condition="APPLE" />
-    <ProcessFile HeaderFile="Uno/Uno.h" Condition="APPLE" />
     <ProcessFile SourceFile="Uno/Reflection.cpp" Condition="REFLECTION" />
     <ProcessFile HeaderFile="Uno/Reflection.h" Condition="REFLECTION" />
 
     <ProcessFile SourceFile="uPlatform/_main.cpp" Condition="!MOBILE"/>
     <ProcessFile SourceFile="uPlatform/_mainMobile.cpp" Condition="MOBILE" />
-    <ProcessFile HeaderFile="uPlatform/GraphicsContext.h" />
+    <ProcessFile HeaderFile="uPlatform/GraphicsContext.h" Condition="!MOBILE" />
     <ProcessFile HeaderFile="uPlatform/GLHelper.h" Condition="OPENGL" />
     <ProcessFile HeaderFile="uPlatform/WinAPIHelper.h" Condition="WIN32" />
+
+    <!-- Deprecated headers -->
+    <ProcessFile HeaderFile="Uno/Graphics/GLHelper.h" Condition="ANDROID" />
+    <ProcessFile HeaderFile="Uno/Uno.h" Condition="APPLE" />
 
 </Extensions>


### PR DESCRIPTION
Moving GLHelper.h to uDroid/ in #456 caused build errors in Fuselibs, so this adds back a deprecated version on the old path for now.

Also adds a Condition for GraphicsContext.h in uno.cpp.uxl.