### PR TITLE
uno test: define TEST (beta-3.0)

### DIFF
--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -87,6 +87,7 @@ namespace Uno.Build
 
             if (_options.Test)
             {
+                _options.Defines.Add("TEST");
                 _compilerOptions.TestOptions = new TestOptions {
                     Filter = _options.TestFilter
                 };


### PR DESCRIPTION
In 1e13ffc we assumed that TEST was already defined when building via `uno test`, but it was not, so this commit defines it now.

It's possible to pass custom defines if necesary, e.g. for old code: `uno test -DUNO_TEST`.