### PR TITLE
unoconfig: {Packages -> References}.Default (beta-3.0)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,20 +14,37 @@ C:\> git clone https://github.com/fuse-open/fuselibs.git
 ```
 
 ```javascript
-if (DEV) {
-    Packages.SourcePaths += `C:\fuselibs\Source`
-}
+SearchPaths.Sources += `C:\fuselibs\Source`
 ```
 
 (Replace `C:\fuselibs\Source` with your own location.)
+
+Run `uno doctor` to build your standard library.
+
+### Additional libraries
+
+Use the following `.unoconfig` properties to add additional Uno libraries (or projects) to your search paths.
+
+```javascript
+SearchPaths += find/my/packages/here
+SearchPaths.Sources += build/these/projects
+```
+
+### Conditional inclusion
+
+```javascript
+if (DEV) {
+    SearchPaths.Sources += `C:\fuselibs\Source`
+}
+```
 
 The `if (DEV)` test makes sure we only use those packages when running `uno` built from source.
 If omitted, the packages are also made available to any installed versions of Fuse Studio and Uno,
 which might have unintended side-effects.
 
-Run `uno doctor` to build your standard library.
+## Dependencies
 
-## Android
+### Android
 
 To support building Android apps, we need to know where your [Android SDKs](https://developer.android.com/studio/index.html)
 are installed. Running `npm install -g android-build-tools@1.x` will set this up automatically, or you can
@@ -48,7 +65,7 @@ Android.NDK: ~/Library/Android/sdk/ndk-bundle
 Android.SDK: ~/Library/Android/sdk
 ```
 
-## iOS
+### iOS
 
 To support building iOS apps, we need macOS and Xcode.
 
@@ -60,20 +77,9 @@ This is usually automatically detected, but configuring a signing identity can b
 iOS.DeveloperTeam: ABCD012345
 ```
 
-## Native
+### Native
 
 To support building native apps, we need [CMake](https://cmake.org/) and C++ compilers.
 
 - **macOS:** Xcode with command line tools
 - **Windows:** Visual Studio 2019
-
-## Node.js
-
-We need [Node.js](https://nodejs.org/en/download/) to support transpiling FuseJS files to ES5.
-
-## Package manager
-
-```javascript
-Packages.SearchPaths += find/my/packages/here
-Packages.SourcePaths += build/these/projects
-```

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -5,7 +5,7 @@ source scripts/common.sh
 
 # Clean stdlib
 IFS=$'\n'
-for dir in `uno config Packages.SourcePaths`; do
+for dir in `uno config SearchPaths.Sources`; do
     if [ -d "$dir" ]; then
         rm -rf "$dir/build"
         uno clean --recursive "$dir"
@@ -22,4 +22,6 @@ dotnet clean --configuration Debug uno.sln 1> /dev/null
 dotnet clean --configuration Release uno.sln 1> /dev/null
 
 # Clean other artifacts
-rm -rf bin packages
+rm -rf bin \
+    FuseOpen.UnoCore.*.nupkg \
+    fuse-open-uno-*.tgz

--- a/src/test/compiler-test/CompilerTestRunner.cs
+++ b/src/test/compiler-test/CompilerTestRunner.cs
@@ -41,7 +41,7 @@ namespace Uno.CompilerTestRunner
         private void RunTestSuite(ITestResultLogger logger, string directoryName)
         {
             var project = new Project(Path.Combine(directoryName, Path.GetFileName(directoryName) + ".unoproj"));
-            project.MutablePackageReferences.Add(new LibraryReference(project.Source, "Uno.Testing"));
+            project.MutableLibraryReferences.Add(new LibraryReference(project.Source, "Uno.Testing"));
             project.MutableProjectReferences.Add(new ProjectReference(project.Source, "../_Outracks.UnoTest.InternalHelpers/_Outracks.UnoTest.InternalHelpers.unoproj"));
 
             logger.ProjectStarting(project.Name, BuildTargets.Default.Identifier);

--- a/src/tool/cli/Building/Create.cs
+++ b/src/tool/cli/Building/Create.cs
@@ -79,8 +79,8 @@ namespace Uno.CLI.Building
             {
                 project.MutableIncludeItems.Add("*");
 
-                foreach (var e in project.Config.GetStringArray("Packages.Default") ?? new string[0])
-                    project.MutablePackageReferences.Add(e);
+                foreach (var e in project.Config.GetStringArray("References.Default", "Packages.Default") ?? new string[0])
+                    project.MutableLibraryReferences.Add(e);
             }
 
             if (className != null)

--- a/src/tool/cli/Building/Update.cs
+++ b/src/tool/cli/Building/Update.cs
@@ -83,7 +83,7 @@ namespace Uno.CLI.Building
                     if (project.InternalsVisibleTo.Count > 0)
                         project.MutableInternalsVisibleTo.Sort();
                     if (project.PackageReferences.Count > 0)
-                        project.MutablePackageReferences.Sort();
+                        project.MutableLibraryReferences.Sort();
                     if (project.ProjectReferences.Count > 0)
                         project.MutableProjectReferences.Sort();
 

--- a/src/tool/config/UnoConfig.cs
+++ b/src/tool/config/UnoConfig.cs
@@ -168,6 +168,13 @@ namespace Uno.Configuration
             return GetStrings(key).Select(x => x.Value).ToArray();
         }
 
+        public string[] GetStringArray(string key1, string key2)
+        {
+            return GetStrings(key1).Select(x => x.Value)
+                .Concat(GetStrings(key2).Select(x => x.Value))
+                .ToArray();
+        }
+
         public string GetString(string key)
         {
             var strings = GetStrings(key);

--- a/src/tool/engine/Libraries/LibraryBuilder.cs
+++ b/src/tool/engine/Libraries/LibraryBuilder.cs
@@ -41,11 +41,11 @@ namespace Uno.Build.Libraries
                 return sourceDirectories;
             }
 
-            var configSourcePaths = (config ?? UnoConfig.Current).GetFullPathArray("Packages.SourcePaths", "PackageSourcePaths");
+            var configSourcePaths = (config ?? UnoConfig.Current).GetFullPathArray("SearchPaths.Sources", "Packages.SourcePaths");
 
             if (configSourcePaths.Length == 0)
             {
-                Log.VeryVerbose("'Packages.SourcePaths' was not found in .unoconfig");
+                Log.VeryVerbose("'SearchPaths.Sources' was not found in .unoconfig");
                 return sourceDirectories;
             }
 

--- a/src/tool/engine/Libraries/LibraryDoctor.cs
+++ b/src/tool/engine/Libraries/LibraryDoctor.cs
@@ -60,16 +60,16 @@ namespace Uno.Build.Libraries
             return false;
         }
 
-        public IEnumerable<DirectoryInfo> EnumerateDirectories(List<string> optionalPackages = null)
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(List<string> optionalLibraries = null)
         {
             var cache = new BundleCache();
 
-            if (optionalPackages == null || optionalPackages.Count == 0)
+            if (optionalLibraries == null || optionalLibraries.Count == 0)
                 foreach (var dir in cache.EnumerateVersions("*"))
                     yield return dir;
             else
             {
-                foreach (var p in optionalPackages)
+                foreach (var p in optionalLibraries)
                 {
                     var result = cache.EnumerateVersions(p).ToArray();
                     if (result.Length == 0)

--- a/src/tool/project/Project.cs
+++ b/src/tool/project/Project.cs
@@ -64,7 +64,7 @@ namespace Uno.ProjectFormat
         public IEnumerable<FileItem> FuseJSFiles => GetFlattenedItems().Where(x => x.Type == IncludeItemType.FuseJS).Select(x => new FileItem(x.Value, x.Condition));
 
         public Dictionary<string, SourceValue> MutableProperties => _doc.Properties;
-        public List<LibraryReference> MutablePackageReferences => _doc.OptionalLibraryReferences ?? (_doc.OptionalLibraryReferences = new List<LibraryReference>());
+        public List<LibraryReference> MutableLibraryReferences => _doc.OptionalLibraryReferences ?? (_doc.OptionalLibraryReferences = new List<LibraryReference>());
         public List<SourceValue> MutableInternalsVisibleTo => _doc.OptionalInternalsVisibleTo ?? (_doc.OptionalInternalsVisibleTo = new List<SourceValue>());
 
         public List<ProjectReference> MutableProjectReferences


### PR DESCRIPTION
### unoconfig: {Packages -> References}.Default

Like #453, this renames another unoconfig property:

* Packages.Defaults -> References.Default

(The old name is deprecated but still works)

Also includes updates to LibraryBuilder and LibraryDoctor, missed in
e13bddaa9f4c69c7dda12991c77dbb254496ae89.

### scripts: update clean.sh

* Update unoconfig property names
* Clean nupkg and tgz files

### docs: update configuration.md

* Update unoconfig property names
* Restructure the document a little
