### PR TITLE
frontend: require XML attribute values to be quoted (beta-3.0)

### DIFF
--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -89,10 +89,10 @@
 
     <!-- Run-time properties -->
 
-    <Set Runtime.CatchCppExceptions=2 />
+    <Set Runtime.CatchCppExceptions="2" />
     <Set Runtime.CppMainLoop="Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN" />
-    <Set Runtime.DebugPauseMilliseconds=0 />
-    <Set Runtime.KillActivityOnDestroy=true />
+    <Set Runtime.DebugPauseMilliseconds="0" />
+    <Set Runtime.KillActivityOnDestroy="true" />
     <Set Runtime.SeperateUnoThread="AppRuntimeSettings.CppMainLoop" />
 
     <!-- Output files -->
@@ -189,14 +189,14 @@
     <CopyFile Name="gradle/wrapper/gradle-wrapper.jar" />
     <ProcessFile Name="gradle/wrapper/gradle-wrapper.properties" />
     <ProcessFile Name="gradlew.bat" Condition="HOST_WIN32" />
-    <ProcessFile Name="gradlew" Condition="HOST_UNIX" IsExecutable=true />
+    <ProcessFile Name="gradlew" Condition="HOST_UNIX" IsExecutable="true" />
     <ProcessFile Name="settings.gradle" />
 
     <ProcessFile Name="build.bat" Condition="HOST_WIN32" />
-    <ProcessFile Name="build.sh" Condition="HOST_UNIX" IsExecutable=true />
+    <ProcessFile Name="build.sh" Condition="HOST_UNIX" IsExecutable="true" />
 
     <ProcessFile Name="run.bat" Condition="HOST_WIN32" />
-    <ProcessFile Name="run.sh" Condition="HOST_UNIX" IsExecutable=true />
+    <ProcessFile Name="run.sh" Condition="HOST_UNIX" IsExecutable="true" />
     <ProcessFile Name="gradle.properties" />
     <ProcessFile Name="local.properties" />
     <ProcessFile Name="gradlew.bat" />
@@ -205,14 +205,14 @@
 
     <!-- Android Studio project -->
 
-    <ProcessFile Name=".idea/copyright/profiles_settings.xml" Overwrite=false />
-    <ProcessFile Name=".idea/.name" Overwrite=false />
-    <ProcessFile Name=".idea/compiler.xml" Overwrite=false />
-    <ProcessFile Name=".idea/gradle.xml" Overwrite=false />
-    <ProcessFile Name=".idea/misc.xml" Overwrite=false />
-    <ProcessFile Name=".idea/modules.xml" Overwrite=false />
-    <ProcessFile Name=".idea/runConfigurations.xml" Overwrite=false />
-    <ProcessFile Name=".idea/vcs.xml" Overwrite=false />
+    <ProcessFile Name=".idea/copyright/profiles_settings.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/.name" Overwrite="false" />
+    <ProcessFile Name=".idea/compiler.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/gradle.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/misc.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/modules.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/runConfigurations.xml" Overwrite="false" />
+    <ProcessFile Name=".idea/vcs.xml" Overwrite="false" />
 
     <!-- Git ignore -->
 

--- a/lib/UnoCore/cpp/config.cpp.uxl
+++ b/lib/UnoCore/cpp/config.cpp.uxl
@@ -4,10 +4,10 @@
     <Define DEBUG_NATIVE="O0" />
 
     <!-- Output configuration -->
-    <Set BundleDirectory="data" IsDefault=true />
-    <Set HeaderDirectory="include" IsDefault=true />
-    <Set SourceDirectory="src" IsDefault=true />
-    <Set BinaryDirectory="." IsDefault=true />
+    <Set BundleDirectory="data" IsDefault="true" />
+    <Set HeaderDirectory="include" IsDefault="true" />
+    <Set SourceDirectory="src" IsDefault="true" />
+    <Set BinaryDirectory="." IsDefault="true" />
 
     <!-- Codegen extensions -->
     <Declare TypeElement="Header.Declaration" />

--- a/lib/UnoCore/ios/ios.uxl
+++ b/lib/UnoCore/ios/ios.uxl
@@ -49,8 +49,8 @@
     <ProcessFile Name="@(Project.Name)/@(Project.Name)-Prefix.pch" />
     <ProcessFile Name="@(Project.Name)/@(Project.Name).entitlements" />
     <ProcessFile Name="@(Project.Name)/LaunchScreen.storyboard" />
-    <ProcessFile Name="build.sh" IsExecutable=true />
-    <ProcessFile Name="run.sh" IsExecutable=true />
+    <ProcessFile Name="build.sh" IsExecutable="true" />
+    <ProcessFile Name="run.sh" IsExecutable="true" />
     <ProcessFile Name="Podfile" Condition="COCOAPODS" />
 
     <!-- Icons -->
@@ -108,7 +108,7 @@
     <!-- Create schemes for Release build in Xcode -->
 
     <Set Schemes="@(Project.Name).xcodeproj/xcuserdata/@(LOGNAME:Env).xcuserdatad/xcschemes" />
-    <ProcessFile Name="@(Schemes)/@(Project.Name).xcscheme" Overwrite=false />
-    <ProcessFile Name="@(Schemes)/xcschememanagement.plist" Overwrite=false />
+    <ProcessFile Name="@(Schemes)/@(Project.Name).xcscheme" Overwrite="false" />
+    <ProcessFile Name="@(Schemes)/xcschememanagement.plist" Overwrite="false" />
 
 </Extensions>

--- a/lib/UnoCore/native/native.uxl
+++ b/lib/UnoCore/native/native.uxl
@@ -35,8 +35,8 @@
     <Set Commands.Build="@(WIN32:Defined:Test('build.bat', 'bash build.sh'))" />
     <Set Commands.Run="@(WIN32:Defined:Test('run.bat', 'bash run.sh'))" />
 
-    <ProcessFile Name="build.sh" Condition="UNIX" IsExecutable=true />
-    <ProcessFile Name="run.sh" Condition="UNIX" IsExecutable=true />
+    <ProcessFile Name="build.sh" Condition="UNIX" IsExecutable="true" />
+    <ProcessFile Name="run.sh" Condition="UNIX" IsExecutable="true" />
     <ProcessFile Name="build.bat" Condition="WIN32" />
     <ProcessFile Name="run.bat" Condition="WIN32" />
     <ProcessFile Name="CMakeLists.txt" />

--- a/lib/UnoCore/pinvoke/pinvoke.uxl
+++ b/lib/UnoCore/pinvoke/pinvoke.uxl
@@ -27,7 +27,7 @@
     <Declare Element="Xcode.Framework" />
     <Declare Element="Xcode.FrameworkDirectory" />
 
-    <ProcessFile Name="build.sh" Condition="HOST_UNIX" IsExecutable=true />
+    <ProcessFile Name="build.sh" Condition="HOST_UNIX" IsExecutable="true" />
     <ProcessFile Name="build.bat" Condition="HOST_WIN32" />
     <ProcessFile Name="CMakeLists.txt" />
 

--- a/src/compiler/frontend/Xml/XmlPreprocessor.cs
+++ b/src/compiler/frontend/Xml/XmlPreprocessor.cs
@@ -36,7 +36,6 @@ namespace Uno.Compiler.Frontend.Xml
             get { return true; }
         }
 
-
         public string Process()
         {
             while (Scan('<'))
@@ -75,8 +74,8 @@ namespace Uno.Compiler.Frontend.Xml
 
                     if (c != '=')
                     {
-                        // Insert ATTRIBUTE="ATTRIBUTE" when a value was missing, if this looks like sane XML
-                        if (LooksLikeValidAttribute(attr, c))
+                        // Insert ATTRIBUTE="ATTRIBUTE" when a value was missing
+                        if (IsAttribute(attr, c))
                             _sb.Append("=\"" + attr + "\"");
 
                         ConsumeTo(start);
@@ -124,15 +123,6 @@ namespace Uno.Compiler.Frontend.Xml
 
                         if (next == _source.Length)
                             continue;
-
-                        // Insert missing quotes, if XML looks sane
-                        if (LooksLikeValidAttribute(attr, _source[next]))
-                        {
-                            _sb.Append('"');
-                            _sb.Append(_source, _index, end - _index);
-                            _sb.Append('"');
-                            _index = start = end;
-                        }
                     }
                 }
 
@@ -178,7 +168,7 @@ namespace Uno.Compiler.Frontend.Xml
             return _sb.ToString();
         }
 
-        bool LooksLikeValidAttribute(string name, char next)
+        bool IsAttribute(string name, char next)
         {
             return !string.IsNullOrEmpty(name) &&
                    (name[0] == '_' || char.IsLetter(name[0])) &&


### PR DESCRIPTION
Attribute values without quotes is not valid XML, confuses editors and syntax-highlighters, and should not have been supported.

This adds quotes to existing UXL files where quotes were previously missing, and modifies XmlPreprocessor to require quotes in version 3.0.