### PR TITLE
export function to run Uno from JavaScript/TypeScript (beta-3.0)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare function uno(args?: string[]): Promise<number>
+export = uno

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+const path = require("path")
+const run = require("dotnet-run")
+
+module.exports = function(args) {
+    const filename = path.join(__dirname, "bin", "net6.0", "uno.dll")
+    return run(filename, args)
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "files": [
     ".unoconfig",
     "bin/*",
+    "index.d.ts",
+    "index.js",
     "lib/build/*",
     "scripts/restore.js"
   ],

--- a/tests/node/uno.js
+++ b/tests/node/uno.js
@@ -1,0 +1,4 @@
+const uno = require("../..")
+
+uno(process.argv.slice(2))
+    .then(process.exit)


### PR DESCRIPTION
When installing fuse-sdk locally in an empty Node.js package, npm fails with an ENOENT error because the following file can't be found, at least on some systems (tested on MacBook Air M1 with npm v8.9.0):

    [...]/node_modules/fuse-sdk/node_modules/@fuse-open/uno/bin/uno.js

(Installing fuse-sdk globally works fine, or installing @fuse-open/uno locally before installing fuse-sdk also works as a workaround.)

This patch is a step towards fixing the problem in fuse-sdk, and the idea is to "require" uno in fuse-sdk, rather than hardcoding its path.