### PR TITLE
iOS: silence warnings

### DIFF
--- a/lib/UnoCore/cpp/Uno/Uno.h
+++ b/lib/UnoCore/cpp/Uno/Uno.h
@@ -1,5 +1,5 @@
 // @(MSG_ORIGIN)
 // @(MSG_EDIT_WARNING)
 
-#warning "Deprecated: Please include <uno.h> instead."
+//#warning "Deprecated: Please include <uno.h> instead."
 #include "../uno.h"

--- a/lib/UnoCore/ios/@(Project.Name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/ios/@(Project.Name).xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 #endif
 		9AD4CD511E23E76F005179FC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
* Silence warning about 'Run Script' will be run during every build

* Comment out #warning added in b2fad01, because warnings are seen even if no source files are including the deprecated header file