### PR TITLE
ios: make iOS 11 default deploymentTarget (beta-3.0)

### DIFF
--- a/src/tool/project/PropertyDefinitions.cs
+++ b/src/tool/project/PropertyDefinitions.cs
@@ -58,7 +58,7 @@ namespace Uno.ProjectFormat
             {"ios.statusBarHidden", PropertyType.Bool, "!$(mobile.showStatusbar)"},
             {"ios.statusBarStyle", PropertyType.String, "Default"},
             {"ios.defines", PropertyType.String},
-            {"ios.deploymentTarget", PropertyType.String, "9.0"},
+            {"ios.deploymentTarget", PropertyType.String, "11.0"},
             {"ios.developmentTeam", PropertyType.String},
             {"ios.icons.iphone_20_2x", PropertyType.Path, "$(icon)"},
             {"ios.icons.iphone_20_3x", PropertyType.Path, "$(icon)"},


### PR DESCRIPTION
This is the minumum version of iOS supported by Xcode 14, and it seems like a good idea to follow that since we're making a new major release of Fuse Open.