### PR TITLE
compiler: return "if-test and throw" when compiling 'assert' (beta-3.0)

### DIFF
--- a/tests/src/UnoTest/General/TryCatch.uno
+++ b/tests/src/UnoTest/General/TryCatch.uno
@@ -98,16 +98,23 @@ namespace UnoTest.General
             while (false);
         }
 
-        // Please uncomment method when #289 is fixed.
-        //void method5()
-        //{
-        //    try
-        //    {
-        //    }
-        //    catch (Exception)
-        //    {
-        //    }
-        //}
+        void method5()
+        {
+            try
+            {
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        void method6()
+        {
+            // Check that assert-statements compile to valid code
+            assert true;
+            assert !false;
+            assert 1 == 1;
+        }
 
         [Test]
         public void Run()


### PR DESCRIPTION
'assert' statements were turned into method calls to a method that was removed in 992b515, resulting in compile errors.

'assert' is still used in a few places, and this commit turns them into "if-test and throw" in debug builds (noop in release builds) to fix the compile errors.

    assert VALUE;

becomes when compiled:

    if (IS_DEBUG_BUILD && !VALUE)
        throw new Uno.InvalidOperationException(
            "Assertion failed: VALUE"
        );