### PR TITLE
C++-backend: fix Android compile errors on macOS (beta-3.0)

### DIFF
--- a/src/compiler/backend/cpp/CppGenerator.cs
+++ b/src/compiler/backend/cpp/CppGenerator.cs
@@ -165,7 +165,7 @@ namespace Uno.Compiler.Backends.CPlusPlus
                 }
 
                 var declarations = declSet.ToArray();
-                Array.Sort(declarations);
+                Array.Sort(declarations, DeclarationComparer.Singleton);
 
                 var cppFilename = key + "." + ext.Key;
                 _env.Require("SourceFile", cppFilename);

--- a/src/compiler/backend/cpp/DeclarationComparer.cs
+++ b/src/compiler/backend/cpp/DeclarationComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Uno.Compiler.Backends.CPlusPlus
@@ -5,18 +6,27 @@ namespace Uno.Compiler.Backends.CPlusPlus
     /** A comparer that makes strings starting with '#' come out first. */
     public class DeclarationComparer : IComparer<string>
     {
-        public static readonly DeclarationComparer Singleton = new DeclarationComparer();
+        public static readonly DeclarationComparer Singleton = new();
 
         public int Compare(string x, string y)
         {
-            var xIsDirective = x.Length > 0 && x[0] == '#';
-            var yIsDirective = y.Length > 0 && y[0] == '#';
+            var xIsDirective = FirstNonWhiteSpaceChar(x) == '#';
+            var yIsDirective = FirstNonWhiteSpaceChar(y) == '#';
 
             return xIsDirective && !yIsDirective
                 ? -1
                 : !xIsDirective && yIsDirective
                 ? 1
-                : x.CompareTo(y);
+                : StringComparer.InvariantCulture.Compare(x, y);
+        }
+
+        static char FirstNonWhiteSpaceChar(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+                if (!char.IsWhiteSpace(value[i]))
+                    return value[i];
+
+            return '\0';
         }
     }
 }


### PR DESCRIPTION
This makes DeclarationComparer more robust and makes sure to use it when combining declarations in CppGenerator, missed in fa03654.

This fixes compile errors when compiling Android apps on macOS.