### PR TITLE
remove xamarin-mac dependency (beta-3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@fuse-open/opentk": "^3.2.0",
         "@fuse-open/transpiler": "^1.18.0",
-        "@fuse-open/xamarin-mac": "^9.1.0",
         "dotnet-run": "^2.0.0"
       },
       "bin": {
@@ -39,11 +38,6 @@
       "bin": {
         "fusejs-transpiler": "bin/cli.js"
       }
-    },
-    "node_modules/@fuse-open/xamarin-mac": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@fuse-open/xamarin-mac/-/xamarin-mac-9.1.0.tgz",
-      "integrity": "sha512-GIim/+2XffHmA55d3jdBGH3jURaPJmof0dHr5q8ym3cRDgcyyTxfW+GvEKyLqAClUcODiubwsatAG6UvzXZ7/Q=="
     },
     "node_modules/dotnet-run": {
       "version": "2.0.0",
@@ -124,11 +118,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/@fuse-open/transpiler/-/transpiler-1.18.0.tgz",
       "integrity": "sha512-mqxz4Acz9EJ6yPFNJfnGA/4xY+ePWcsyn/eTh2NmvqREpbbtNB/08hTTaFBBjPnxqXqDONJ3N1JZdofgjyx6vQ=="
-    },
-    "@fuse-open/xamarin-mac": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@fuse-open/xamarin-mac/-/xamarin-mac-9.1.0.tgz",
-      "integrity": "sha512-GIim/+2XffHmA55d3jdBGH3jURaPJmof0dHr5q8ym3cRDgcyyTxfW+GvEKyLqAClUcODiubwsatAG6UvzXZ7/Q=="
     },
     "dotnet-run": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@fuse-open/opentk": "^3.2.0",
     "@fuse-open/transpiler": "^1.18.0",
-    "@fuse-open/xamarin-mac": "^9.1.0",
     "dotnet-run": "^2.0.0"
   },
   "devDependencies": {

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -81,8 +81,7 @@ function rm-identical {
 
 h1 "Optimizing package"
 
-# OpenTK and Xamarin.Mac will be added back by restore.js
-rm-identical bin/net6.0 node_modules/@fuse-open/xamarin-mac *.dll *.dylib
+# OpenTK will be added back by restore.js
 rm-identical bin/win/net6.0-windows node_modules/@fuse-open/opentk *.dll
 
 # Remove needless build artifacts

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -40,10 +40,6 @@ function restoreFiles(src, dst) {
     }
 }
 
-// Restore Xamarin.Mac binaries.
-const xamarin = findNodeModule("@fuse-open/xamarin-mac")
-restoreFiles(xamarin, path.join(__dirname, "..", "bin", "net6.0"))
-
 // Restore OpenTK and ANGLE (Windows only).
 const opentk = findNodeModule("@fuse-open/opentk")
 restoreFiles(opentk, path.join(__dirname, "..", "bin", "win", "net6.0-windows"))

--- a/src/tool/engine/Targets/Utilities/DevelopmentTeam.cs
+++ b/src/tool/engine/Targets/Utilities/DevelopmentTeam.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using AppKit;
-using Foundation;
-using ObjCRuntime;
 
 namespace Uno.Build.Targets.Utilities
 {
@@ -28,160 +24,15 @@ namespace Uno.Build.Targets.Utilities
 
     class DevelopmentTeamExtractorFailure : Exception
     {
-        public readonly int ErrorCode;
-        public DevelopmentTeamExtractorFailure(string message, int errorCode)
-            : base(message)
-        {
-            ErrorCode = errorCode;
-        }
     }
 
     class DevelopmentTeamExtractor
     {
-        private static readonly object _nsApplicationInitLock = new object();
-        private static bool _nsApplicationInitialized;
-
-        readonly byte[] _codeSigningUsageBytes = new byte[]{ 0x2b, 0x6, 0x1, 0x5, 0x5, 0x7, 0x3, 0x3 };
-        const string _securityLibraryPath = "/System/Library/Frameworks/Security.framework/Versions/Current/Security";
-        readonly IntPtr _securityLibrary;
-
-        public DevelopmentTeamExtractor()
-        {
-            lock (_nsApplicationInitLock)
-            {
-                if (!_nsApplicationInitialized)
-                {
-                    NSApplication.Init();
-                    _nsApplicationInitialized = true;
-                }
-            }
-
-            _securityLibrary = Dlfcn.dlopen(_securityLibraryPath, 0);
-        }
-
         public IEnumerable<DevTeam> FindAllDevelopmentTeams()
         {
-            var query = NSDictionary.FromObjectsAndKeys(new object[]
-                {
-                    SecClassCertificate,
-                    SecMatchLimitAll,
-                    new NSNumber(true),
-                    new NSNumber(true),
-                    new NSNumber(true)
-                },
-                new object[]
-                {
-                    SecClassKey,
-                    SecMatchLimit,
-                    SecReturnRef,
-                    SecMatchTrustedOnly,
-                    SecAttrCanSign
-                });
-
-
-            var certificationsRefPtr = IntPtr.Zero;
-            var error = SecItemCopyMatching(query.Handle, ref certificationsRefPtr);
-            if (error != 0)
-            {
-                throw new DevelopmentTeamExtractorFailure("Failed to search for developer identities", error);
-            }
-
-            var devTeams = new List<DevTeam>();
-            var certificationsRef = Runtime.GetNSObject<NSArray>(certificationsRefPtr);
-
-            for (uint i = 0; i < certificationsRef.Count; ++i)
-            {
-                var devTeam = PareDevelopmentTeam(certificationsRef.ValueAt (i));
-                if(devTeam != null)
-                    devTeams.Add(devTeam);
-            }
-
-            return devTeams;
+            // FIXME: Can't use Xamarin.Mac so we need to come up with something
+            // better... Time to develop native command-line tool in Swift?
+            yield break;
         }
-
-        DevTeam PareDevelopmentTeam(IntPtr certificationRef)
-        {
-            var certificateValuesRef = SecCertificateCopyValues(certificationRef, IntPtr.Zero, IntPtr.Zero);
-            if (certificateValuesRef == IntPtr.Zero)
-            {
-                throw new DevelopmentTeamExtractorFailure("Failed to copy values from certificate", -1);
-            }
-
-            var certificateValues = Runtime.GetNSObject<NSDictionary>(certificateValuesRef);
-
-            // Check if Extended Key Usage is Codesigning
-            var extendedKeyUsage = (NSDictionary)certificateValues.ValueForKey (SecOIDExtendedKeyUsage);
-            if (extendedKeyUsage == null)
-                return null;
-
-            var extendedKeyUsageValues = (NSArray)extendedKeyUsage.ValueForKey (SecPropertyKeyValue);
-            for (uint i = 0; i < extendedKeyUsageValues.Count; ++i)
-            {
-                var keyUsageData = Runtime.GetNSObject<NSData>(extendedKeyUsageValues.ValueAt(i));
-                if (!CompareData (keyUsageData, _codeSigningUsageBytes))
-                    return null;
-            }
-
-            var x509SubName = (NSDictionary)certificateValues.ValueForKey(SecOIDX509V1SubjectName);
-            var x509Values = (NSArray)x509SubName.ValueForKey(SecPropertyKeyValue);
-
-            NSString ouId = TryFind(x509Values, SecOIDOrganizationalUnitName);
-            NSString organizationName = TryFind(x509Values, SecOIDOrganizationName);
-            NSString commonName = TryFind(x509Values, SecOIDCommonName);
-
-            return new DevTeam(commonName, organizationName, ouId);
-        }
-
-        bool CompareData(NSData a, byte[] bytes)
-        {
-            if (a.Length != (nuint)bytes.Length)
-                return false;
-
-            for (var j = 0; j < (uint)a.Length; ++j)
-            {
-                if (a[j] != _codeSigningUsageBytes[j])
-                    return false;
-            }
-
-            return true;
-        }
-
-        NSString TryFind(NSArray x509Values, NSString key)
-        {
-            for (uint i = 0; i < x509Values.Count; ++i)
-            {
-                var curCertValue = Runtime.GetNSObject<NSDictionary>(x509Values.ValueAt(i));
-                var valueLabel = (NSString)curCertValue.ValueForKey(SecPropertyKeyLabel);
-                if (valueLabel.Compare(key) == NSComparisonResult.Same)
-                    return (NSString)curCertValue.ValueForKey(SecPropertyKeyValue);
-            }
-
-            return null;
-        }
-
-        NSString SecClassKey { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecClass")); } }
-        NSString SecReturnRef { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecReturnRef")); } }
-        NSString SecMatchLimit { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecMatchLimit")); } }
-        NSString SecReturnAttributes { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecReturnAttributes")); } }
-        NSString SecClassCertificate { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecClassCertificate")); } }
-        NSString SecMatchLimitAll { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecMatchLimitAll")); } }
-        NSString SecOIDX509V1SubjectName { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecOIDX509V1SubjectName")); } }
-        NSString SecPropertyKeyValue { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecPropertyKeyValue")); } }
-        NSString SecPropertyKeyLabel { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecPropertyKeyLabel")); } }
-        NSString SecOIDOrganizationalUnitName { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecOIDOrganizationalUnitName")); } }
-        NSString SecOIDOrganizationName { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecOIDOrganizationName")); } }
-        NSString SecOIDCommonName { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecOIDCommonName")); } }
-        NSString SecMatchTrustedOnly { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecMatchTrustedOnly")); } }
-        NSString SecAttrCanSign { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecAttrCanSign")); } }
-        NSString SecOIDExtendedKeyUsage { get { return Runtime.GetNSObject<NSString>(Dlfcn.GetIntPtr(_securityLibrary, "kSecOIDExtendedKeyUsage")); } }
-
-        [DllImport(_securityLibraryPath)]
-        public static extern int SecItemCopyMatching(IntPtr queryDict, ref IntPtr result);
-
-        [DllImport(_securityLibraryPath)]
-        public static extern int SecIdentityCopyCertificate(IntPtr identityRef, ref IntPtr certRef);
-
-        [DllImport(_securityLibraryPath)]
-        public static extern IntPtr SecCertificateCopyValues(IntPtr certRef, IntPtr keys, IntPtr errors);
     }
 }

--- a/src/tool/engine/Uno.Build.csproj
+++ b/src/tool/engine/Uno.Build.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\GlobalAssemblyInfo.props" />
-  <Import Project="..\..\..\node_modules\@fuse-open\xamarin-mac\FuseOpen.Xamarin.Mac.props" Condition="Exists('..\..\..\node_modules\@fuse-open\xamarin-mac\FuseOpen.Xamarin.Mac.props')" />
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -23,10 +22,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Xamarin.Mac">
-      <HintPath>..\..\..\node_modules\@fuse-open\xamarin-mac\Xamarin.Mac.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Xamarin.Mac isn't supported on .NET 6 (throws exception), blocking us from building iOS apps, so this commit removes the dependency.

Xamarin.Mac was used to access Xcode Developer Teams, so we need a way to replace this functionality. I have searched for a node module or a CLI that can replace it, without luck, so it looks like we'll need to implement a new tool to access Xcode Developer Teams at some point.