### PR TITLE
common: swallow InvalidOperationException in KillTree() (beta-3.0)

### DIFF
--- a/src/common/Diagnostics/ProcessExtensions.cs
+++ b/src/common/Diagnostics/ProcessExtensions.cs
@@ -87,7 +87,14 @@ namespace Uno.Diagnostics
 
         public static void KillTree(this Process process)
         {
-            ProcessTreeKiller.KillTree(process.Id);
+            try
+            {
+                ProcessTreeKiller.KillTree(process.Id);
+            }
+            catch (InvalidOperationException)
+            {
+                // Ignore
+            }
         }
     }
 }


### PR DESCRIPTION
Avoid getting a callstack in the output when force quitting using CTRL + C keys on macOS Ventura.