### PR TITLE
compiler: remove temp hack and TODOs (beta-3.0)

### DIFF
--- a/src/compiler/api/Domain/AST/Members/AstClassMember.cs
+++ b/src/compiler/api/Domain/AST/Members/AstClassMember.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Uno.Compiler.API.Domain.AST.Expressions;
 
 namespace Uno.Compiler.API.Domain.AST.Members
 {
@@ -16,22 +15,6 @@ namespace Uno.Compiler.API.Domain.AST.Members
             Attributes = attributes ?? AstAttribute.Empty;
             Modifiers = modifiers;
             OptionalCondition = cond;
-
-            // TODO: This is a temp hack that replaces [ExportCondition("CONDITION")] with extern(CONDITION)
-            if (OptionalCondition == null)
-            {
-                foreach (var attr in Attributes)
-                {
-                    var name = attr.Attribute as AstIdentifier;
-                    if (name != null && name.Symbol == "ExportCondition" &&
-                        attr.Arguments.Count == 1 && attr.Arguments[0].Value is AstString)
-                    {
-                        var val = (AstString) attr.Arguments[0].Value;
-                        OptionalCondition = val.Value;
-                        Modifiers |= Modifiers.Extern;
-                    }
-                }
-            }
         }
     }
 }

--- a/src/compiler/backend/cil/CilType.cs
+++ b/src/compiler/backend/cil/CilType.cs
@@ -246,9 +246,9 @@ namespace Uno.Compiler.Backends.CIL
                 if (p.OptionalDefault is Constant)
                     pb.SetConstant(p.OptionalDefault.ConstantValue);
             }
-            catch
+            catch (Exception e)
             {
-                // TODO
+                Log.VeryVerbose("PopulateParameter: " + e);
             }
 
             if (p.Modifier == ParameterModifier.Params)

--- a/src/compiler/core/IL/Bytecode/BytecodeCompiler.Expression.cs
+++ b/src/compiler/core/IL/Bytecode/BytecodeCompiler.Expression.cs
@@ -289,7 +289,7 @@ namespace Uno.Compiler.Core.IL.Bytecode
                     {
                         var s = e as StoreLocal;
 
-                        // TODO: This is a workaround for bug in sub ctor calls, remove this later
+                        // This is a workaround for bug in sub ctor calls
                         if (!Locals.Contains(s.Variable))
                             Locals.Add(s.Variable);
 

--- a/src/compiler/core/IL/Validation/ILVerifier.Member.cs
+++ b/src/compiler/core/IL/Validation/ILVerifier.Member.cs
@@ -120,7 +120,6 @@ namespace Uno.Compiler.Core.IL.Validation
                 Log.Error(dt.Source, ErrorCode.E0000, "Events are only allowed in classes, structs and interfaces");
         }
 
-        // TODO: Clean up later
         void OnFunction(Function f, DataType dt)
         {
             if (f.CanLink)


### PR DESCRIPTION
This removes an obsolete temp hack and addresses a few old TODOs.