### PR TITLE
lazy compilation for .NET targets (beta-3.0)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ environment:
   nodejs_version: 16
   matrix:
   - TARGET: dotnet
+    UNO_TEST_ARGS: -DLAZY
   - TARGET: native
     UNO_TEST_ARGS: -DDEBUG_UNSAFE
     SKIP_UNO_TESTS: 1

--- a/src/compiler/api/Domain/IL/Types/DataType.cs
+++ b/src/compiler/api/Domain/IL/Types/DataType.cs
@@ -525,6 +525,7 @@ namespace Uno.Compiler.API.Domain.IL
         public bool IsParameterizedDefinition => Stats.HasFlag(EntityStats.ParameterizedDefinition);
         public bool CanLink => MasterDefinition.Stats.HasFlag(EntityStats.CanLink);
         public bool HasRefCount => Stats.HasFlag(EntityStats.RefCount);
+        public bool IsLazy => Stats.HasFlag(EntityStats.PopulatingMembers) && Bundle.IsCached;
 
         Source IEntity.Source => Source;
         IEntity IEntity.MasterDefinition => MasterDefinition;

--- a/src/compiler/core/BuildEnvironment.cs
+++ b/src/compiler/core/BuildEnvironment.cs
@@ -23,6 +23,7 @@ namespace Uno.Compiler.Core
         internal BuildStep Step;
 
         public bool Debug => Options.Debug;
+        public bool Lazy => Options.Lazy;
         public bool Parallel => Options.Parallel;
         public bool Strip => Options.Strip;
         public bool IsConsole => IsDefined("CONSOLE");
@@ -31,6 +32,7 @@ namespace Uno.Compiler.Core
         public bool IsGeneratingCode => Step == BuildStep.Generating;
         public bool CanCacheIL => Options.CanCacheIL;
         public bool HasCustomEntrypoint => Options.MainClass != null;
+        public bool HasUpToDateOptions;
 
         public string CacheDirectory { get; }
         public string BundleDirectory { get; }
@@ -70,7 +72,7 @@ namespace Uno.Compiler.Core
 
         public bool IsUpToDate(SourceBundle bundle, string filename)
         {
-            if (!bundle.IsCached)
+            if (!bundle.IsCached || !HasUpToDateOptions)
                 return false;
 
             var file = Path.Combine(OutputDirectory, filename);

--- a/src/compiler/core/CompilerOptions.cs
+++ b/src/compiler/core/CompilerOptions.cs
@@ -5,6 +5,7 @@ namespace Uno.Compiler.Core
         public bool Debug;
         public bool CanCacheIL;
         public bool CodeCompletionMode;
+        public bool Lazy;
         public bool Parallel;
         public bool Strip;
         public string OutputDirectory;

--- a/src/compiler/core/IL/Testing/TestSetupTransform.cs
+++ b/src/compiler/core/IL/Testing/TestSetupTransform.cs
@@ -44,6 +44,7 @@ namespace Uno.Compiler.Core.IL.Testing
             _testSetupType = ILFactory.GetType("Uno.Testing.TestSetup");
 
             _appClass = Essentials.Application;
+            _appClass.PopulateMembers();
 
             // Lazy populate app class
             _appClass.PopulateMembers();

--- a/src/compiler/core/IL/Utilities/ILFactory.cs
+++ b/src/compiler/core/IL/Utilities/ILFactory.cs
@@ -792,6 +792,8 @@ namespace Uno.Compiler.Core.IL.Utilities
 
                     if (root is DataType)
                     {
+                        (root as DataType).PopulateMembers();
+
                         foreach (var m in (root as DataType).Constructors)
                             if (TryMatchParameterList(m, s.Arguments, parameters))
                                 return m;

--- a/src/compiler/core/IL/Validation/ILVerifier.Type.cs
+++ b/src/compiler/core/IL/Validation/ILVerifier.Type.cs
@@ -12,7 +12,7 @@ namespace Uno.Compiler.Core.IL.Validation
     {
         public override bool Begin(DataType dt)
         {
-            if (dt.CanLink || dt.Bundle.IsVerified)
+            if (dt.CanLink || dt.IsLazy || dt.Bundle.IsVerified)
                 return false;
 
             var validModifiers = (
@@ -314,7 +314,7 @@ namespace Uno.Compiler.Core.IL.Validation
 
             foreach (var pt in dt.GenericParameterizations)
             {
-                if (!Environment.IsGeneratingCode)
+                if (!Environment.IsGeneratingCode && !pt.IsLazy)
                     if (pt.Fields.Count != dt.Fields.Count ||
                         pt.Methods.Count != dt.Methods.Count ||
                         pt.Properties.Count != dt.Properties.Count ||

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.PopulateBlock.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.PopulateBlock.cs
@@ -72,7 +72,9 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
                         if (pe == null)
                         {
-                            if (!dt.CanLink)
+                            if (!pt.CanLink && !pt.Bundle.CanLink && (
+                                    !_compiler.Environment.Lazy ||
+                                    !pt.Bundle.IsCached))
                                 Log.Warning(f.Name.Source, ErrorCode.IW3205, f.Name.Symbol.Quote() + " was not found in class scope");
                             continue;
                         }

--- a/src/compiler/core/Syntax/Builders/BuildQueue.cs
+++ b/src/compiler/core/Syntax/Builders/BuildQueue.cs
@@ -103,6 +103,8 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 while (_populateMembersIndex < count)
                     if (_backend.CanLink(_enqueuedTypes[_populateMembersIndex]))
                         _enqueuedTypes[_populateMembersIndex++].Stats |= EntityStats.CanLink;
+                    else if (_env.Lazy && _env.Strip && _enqueuedTypes[_populateMembersIndex].Bundle.IsCached)
+                        _populateMembersIndex++;
                     else
                         _enqueuedTypes[_populateMembersIndex++].PopulateMembers();
 
@@ -156,7 +158,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
         public void BuildBlocks()
         {
             for (var i = 0; i < _enqueuedBlocks.Count; i++)
-                if (!_enqueuedBlocks[i].Source.Bundle.CanLink)
+                if (!_enqueuedBlocks[i].Source.Bundle.CanLink && (
+                        !_env.Lazy ||
+                        !_env.Strip ||
+                        !_enqueuedBlocks[i].Source.Bundle.IsCached))
                     _enqueuedBlocks[i].Populate();
 
             _enqueuedBlocks.Clear();

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -86,6 +86,14 @@ namespace Uno.Build
                 CanCacheIL = _options.BundleCache != null
             };
 
+            if (_options.Defines.Contains("LAZY"))
+            {
+                if (!target.SupportsLazy)
+                    Log.Warning("The build target " + target.Quote() + " does not support lazy compilation.");
+                else
+                    _compilerOptions.Lazy = true;
+            }
+
             if (_options.Test)
             {
                 _options.Defines.Add("TEST");

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -38,9 +38,8 @@ namespace Uno.Build
         readonly LazyTranspiler _transpiler;
         IDisposable _anim;
 
-        public bool IsUpToDate => !_options.Force && _file.Exists &&
-                                  !_input.HasAnythingChangedSince(_file.Timestamp) &&
-                                  _file.Load() == GetHashCode();
+        public bool IsUpToDate => !_options.Force && _env.HasUpToDateOptions &&
+                                  !_input.HasAnythingChangedSince(_file.Timestamp);
         public bool CanBuildNative => _options.NativeBuild && _target.CanBuild(_file) && (
                                       _options.Force ||
                                       !_file.IsProductUpToDate);
@@ -116,6 +115,7 @@ namespace Uno.Build
                 _compiler.Disk.DeleteDirectory(_env.OutputDirectory);
 
             _file = new BuildFile(_env.OutputDirectory);
+            _env.HasUpToDateOptions = _file.Exists && _file.Load() == GetHashCode();
         }
 
         SourceBundle GetBundle()

--- a/src/tool/engine/BuildTarget.cs
+++ b/src/tool/engine/BuildTarget.cs
@@ -21,6 +21,7 @@ namespace Uno.Build
         public virtual bool IsExperimental => false;
         public virtual bool IsObsolete => false;
         public virtual bool DefaultStrip => true;
+        public virtual bool SupportsLazy => false;
 
         public virtual Backend CreateBackend()
         {

--- a/src/tool/engine/Targets/DotNetBuild.cs
+++ b/src/tool/engine/Targets/DotNetBuild.cs
@@ -11,6 +11,7 @@ namespace Uno.Build.Targets
         public override string FormerName => "dotnetexe";
         public override string Description => ".NET/GL bytecode and executable. (default)";
         public override bool DefaultStrip => false;
+        public override bool SupportsLazy => true;
 
         public override Backend CreateBackend()
         {


### PR DESCRIPTION
### appveyor: use -DLAZY when testing the dotnet target
    
We want to make sure this feature keeps on working. This is the first
iteration and more updates are expected.

### engine: lazy compilation for .NET targets

Pass -DLAZY to "uno build" to enable lazy compilation (experimental).

We've seen around 10x[1] speed-up on subsequent builds of a normal app
when lazy compilation is enabled, since there is minimal work to do
when most of the code is already built.

The feature is experimental for now, but we might want to take
advantage of this (e.g. in the Fuse X editor) when the feature
matures a bit more, to speed up loading times in a significant way
by prebuilding standard libraries (including Fuselibs), and better
caching.

1: More or less, depending on project size

### compiler: support lazy compilation

This modifies the compiler to only compile something when it is needed
and not compiled before, rather than always compiling everything,
significantly speeding up compilation time when enabled.
