### PR TITLE
accept ForeignInclude attributes on methods (beta-3.0)

### DIFF
--- a/lib/Uno.Net.Sockets/Dns.uno
+++ b/lib/Uno.Net.Sockets/Dns.uno
@@ -12,7 +12,6 @@ namespace Uno.Net
     [extern(UNIX) Require("Source.Include", "netinet/in.h")]
     [extern(MSVC) Require("Source.Include", "ws2tcpip.h")]
     [Require("Source.Include", "vector")]
-    [ForeignInclude(Language.Java, "java.util.*", "java.net.*")]
     public class Dns
     {
         extern(APPLE || LINUX) static IPAddress[] GetLocalAddresses()
@@ -47,6 +46,7 @@ namespace Uno.Net
         @}
 
         [Foreign(Language.Java)]
+        [ForeignInclude(Language.Java, "java.util.*", "java.net.*")]
         extern(ANDROID) static bool JavaGetLocalAddresses(List<string> addresses)
         @{
             try

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignAnnotationAttribute.uno
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignAnnotationAttribute.uno
@@ -6,69 +6,9 @@ namespace Uno.Compiler.ExportTargetInterop
         public readonly Language Language;
         public readonly string[] Annotations;
 
-        public ForeignAnnotationAttribute(Language language, string[] annotations)
+        public ForeignAnnotationAttribute(Language language, params string[] annotations)
         {
             Language = language;
         }
-
-        public ForeignAnnotationAttribute(Language language, string annotation0)
-        : this(language, new string[] { annotation0 }) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1)
-        : this(language, new string[] { annotation0, annotation1 }) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2)
-        : this(language, new string[] { annotation0, annotation1 , annotation2 }) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14, string annotation15)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14, annotation15}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14, string annotation15, string annotation16)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14, annotation15, annotation16}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14, string annotation15, string annotation16, string annotation17)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14, annotation15, annotation16, annotation17}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14, string annotation15, string annotation16, string annotation17, string annotation18)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14, annotation15, annotation16, annotation17, annotation18}) {}
-
-        public ForeignAnnotationAttribute(Language language, string annotation0, string annotation1, string annotation2, string annotation3, string annotation4, string annotation5, string annotation6, string annotation7, string annotation8, string annotation9, string annotation10, string annotation11, string annotation12, string annotation13, string annotation14, string annotation15, string annotation16, string annotation17, string annotation18, string annotation19)
-        : this(language, new string[] { annotation0, annotation1, annotation2, annotation3, annotation4, annotation5, annotation6, annotation7, annotation8, annotation9, annotation10, annotation11, annotation12, annotation13, annotation14, annotation15, annotation16, annotation17, annotation18, annotation19}) {}
     }
 }

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignDataView.uno
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignDataView.uno
@@ -6,7 +6,6 @@ using Android.Base.Primitives;
 namespace Uno.Compiler.ExportTargetInterop
 {
     [ForeignTypeName("::NSData*")]
-    [ForeignInclude(Language.ObjC, "Foundation/Foundation.h")]
     public extern(FOREIGN_OBJC_SUPPORTED) class ForeignDataView : ObjC.Object
     {
         ForeignDataView() { }
@@ -36,6 +35,7 @@ namespace Uno.Compiler.ExportTargetInterop
         }
 
         [Foreign(Language.ObjC)]
+        [ForeignInclude(Language.ObjC, "Foundation/Foundation.h")]
         static ObjC.Object CreateNSDataFromByteArray(IntPtr rawUnoArray)
         @{
             auto unoArray = (\@{byte[]})rawUnoArray;

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignIncludeAttribute.uno
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignIncludeAttribute.uno
@@ -1,77 +1,15 @@
 namespace Uno.Compiler.ExportTargetInterop
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Constructor)]
     public sealed class ForeignIncludeAttribute : Attribute
     {
         public readonly Language Language;
         public readonly string[] Includes;
 
-        // look..I know. I'm sorry, but at the time attributes didnt like param args
-        public ForeignIncludeAttribute(Language language, string[] includes)
+        public ForeignIncludeAttribute(Language language, params string[] includes)
         {
             Language = language;
             Includes = includes;
         }
-
-        public ForeignIncludeAttribute(Language language, string include0)
-        : this(language, new string[] { include0 }) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1)
-        : this(language, new string[] { include0, include1 }) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2)
-        : this(language, new string[] { include0, include1 , include2 }) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3)
-        : this(language, new string[] { include0, include1, include2, include3}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4)
-        : this(language, new string[] { include0, include1, include2, include3, include4}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14, string include15)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14, include15}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14, string include15, string include16)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14, include15, include16}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14, string include15, string include16, string include17)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14, include15, include16, include17}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14, string include15, string include16, string include17, string include18)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14, include15, include16, include17, include18}) {}
-
-        public ForeignIncludeAttribute(Language language, string include0, string include1, string include2, string include3, string include4, string include5, string include6, string include7, string include8, string include9, string include10, string include11, string include12, string include13, string include14, string include15, string include16, string include17, string include18, string include19)
-        : this(language, new string[] { include0, include1, include2, include3, include4, include5, include6, include7, include8, include9, include10, include11, include12, include13, include14, include15, include16, include17, include18, include19}) {}
-
     }
 }

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignIncludeAttribute.uno
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/ForeignIncludeAttribute.uno
@@ -1,6 +1,6 @@
 namespace Uno.Compiler.ExportTargetInterop
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public sealed class ForeignIncludeAttribute : Attribute
     {
         public readonly Language Language;

--- a/src/compiler/api/Domain/IL/Expressions/Expression.cs
+++ b/src/compiler/api/Domain/IL/Expressions/Expression.cs
@@ -16,7 +16,12 @@ namespace Uno.Compiler.API.Domain.IL
         public Expression Address => !ReturnType.IsReferenceType ? this as AddressOf ?? new AddressOf(this) : ActualValue;
         public virtual Expression ActualValue => this;
         public virtual object ConstantValue => null;
-        public string ConstantString => ConstantValue as string ?? ConstantValue?.ToString();
+        public string ConstantString => ConstantValue as string ?? (
+                                            ConstantValue is object[]
+                                                ? ToString() // Use disassembler for arrays
+                                                : ConstantValue?.ToString()
+                                        );
+
         public override StatementType StatementType => StatementType.Expression;
 
         protected Expression(Source src)

--- a/src/compiler/api/Domain/IL/Expressions/NewArray.cs
+++ b/src/compiler/api/Domain/IL/Expressions/NewArray.cs
@@ -13,7 +13,19 @@ namespace Uno.Compiler.API.Domain.IL.Expressions
 
         public override DataType ReturnType => ArrayType;
 
-        private NewArray(Source src, RefArrayType arrayType, Expression size, Expression[] initializers)
+        public override object ConstantValue => GetInitalizerConstants();
+
+        object[] GetInitalizerConstants()
+        {
+            var result = new object[Initializers.Length];
+
+            for (int i = 0; i < result.Length; i++)
+                result[i] = Initializers[i].ConstantValue;
+
+            return result;
+        }
+
+        NewArray(Source src, RefArrayType arrayType, Expression size, Expression[] initializers)
             : base(src)
         {
             ArrayType = arrayType;

--- a/src/compiler/api/Domain/IL/Expressions/NewObject.cs
+++ b/src/compiler/api/Domain/IL/Expressions/NewObject.cs
@@ -17,18 +17,6 @@ namespace Uno.Compiler.API.Domain.IL.Expressions
             Arguments = args;
         }
 
-        public object[] GetArgumentValues()
-        {
-            var result = new object[Arguments.Length];
-
-            for (int i = 0; i < result.Length; i++)
-                result[i] = Arguments[i] is Constant
-                    ? (Arguments[i] as Constant).Value
-                    : null;
-
-            return result;
-        }
-
         public override ExpressionType ExpressionType => ExpressionType.NewObject;
 
         public override void Disassemble(StringBuilder sb, ExpressionUsage u)

--- a/src/compiler/backend/unodoc/Builders/Syntax/SyntaxGenerator.cs
+++ b/src/compiler/backend/unodoc/Builders/Syntax/SyntaxGenerator.cs
@@ -45,27 +45,20 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.Syntax
 
                 if (attribute.Arguments.Length > 0)
                 {
-                    sb.Append("(");
+                    sb.Append('(');
 
                     for (var i = 0; i < attribute.Arguments.Length; i++)
                     {
-                        var arg = (Constant)attribute.Arguments[i];
+                        var arg = attribute.Arguments[i].ConstantValue;
                         var param = attribute.Constructor.Parameters[i];
 
                         if (i > 0) sb.Append(", ");
                         sb.Append(param.Name);
                         sb.Append(" = ");
-                        if (arg.Value is string)
-                        {
-                            sb.Append("\"" + arg.Value + "\"");
-                        }
-                        else
-                        {
-                            sb.Append(arg.Value);
-                        }
+                        BuildParameterValue(arg, sb);
                     }
 
-                    sb.Append(")");
+                    sb.Append(')');
                 }
 
                 sb.AppendLine("]");
@@ -75,6 +68,32 @@ namespace Uno.Compiler.Backends.UnoDoc.Builders.Syntax
             return result.Any()
                            ? string.Join("\n", result)
                            : null;
+        }
+
+        static void BuildParameterValue(object arg, StringBuilder sb)
+        {
+            if (arg is object[] array)
+            {
+                sb.Append("new[] {");
+
+                for (int i = 0; i < array.Length; i++)
+                {
+                    if (i > 0)
+                        sb.Append(", ");
+
+                    BuildParameterValue(array[i], sb);
+                }
+
+                sb.Append('}');
+            }
+            else if (arg is string)
+            {
+                sb.Append("\"" + arg + "\"");
+            }
+            else
+            {
+                sb.Append(arg);
+            }
         }
 
         protected string BuildModifiers(List<string> modifiers)

--- a/src/compiler/core/IL/Validation/ILVerifier.cs
+++ b/src/compiler/core/IL/Validation/ILVerifier.cs
@@ -446,12 +446,18 @@ namespace Uno.Compiler.Core.IL.Validation
                 if (!attr.ReturnType.IsSubclassOf(Essentials.Attribute))
                     Log.Error(attr.Source, ErrorCode.E0000, attr.ReturnType.AttributeString + " cannot be used as an attribute because it does not inherit " + Essentials.Attribute.Quote());
 
-                foreach (var arg in attr.Arguments)
-                    if (arg.ExpressionType != ExpressionType.Constant)
-                        Log.Error(arg.Source, ErrorCode.E0000, "Attribute argument must be constant");
-
+                VeryfyArgumentsAreConstant(attr.Arguments);
                 VerifyAttributeUsage(attr.Source, owner, attr.ReturnType);
             }
+        }
+
+        void VeryfyArgumentsAreConstant(Expression[] args)
+        {
+            foreach (var arg in args)
+                if (arg.ExpressionType == ExpressionType.NewArray)
+                    VeryfyArgumentsAreConstant(((NewArray)arg).Initializers);
+                else if (arg.ExpressionType != ExpressionType.Constant)
+                    Log.Error(arg.Source, ErrorCode.E0000, "Attribute argument must be constant or an array of constants");
         }
 
         void VerifyAttributeUsage(Source src, SourceObject owner, DataType attribute)

--- a/src/compiler/foreign/ForeignHelpers.cs
+++ b/src/compiler/foreign/ForeignHelpers.cs
@@ -62,9 +62,9 @@ namespace Uno.Compiler.Foreign
                     if (attr.ReferencedType == Essentials.ForeignIncludeAttribute &&
                         Essentials.Language.Literals[(int)attr.Arguments[0].ConstantValue].Name == language)
                     {
-                        foreach (var arg in attr.Arguments.Skip(1))
+                        foreach (var arg in (object[])attr.Arguments[1].ConstantValue)
                         {
-                            result.Add(Environment.Expand(dt.Source, (string)arg.ConstantValue));
+                            result.Add(Environment.Expand(dt.Source, (string)arg));
                         }
                     }
                 }
@@ -79,9 +79,9 @@ namespace Uno.Compiler.Foreign
                         if (attr.ReferencedType == Essentials.ForeignIncludeAttribute &&
                             Essentials.Language.Literals[(int)attr.Arguments[0].ConstantValue].Name == language)
                         {
-                            foreach (var arg in attr.Arguments.Skip(1))
+                            foreach (var arg in (object[])attr.Arguments[1].ConstantValue)
                             {
-                                result.Add(Environment.Expand(f.Source, (string)arg.ConstantValue));
+                                result.Add(Environment.Expand(f.Source, (string)arg));
                             }
                         }
                     }
@@ -102,9 +102,9 @@ namespace Uno.Compiler.Foreign
                     if (attr.ReferencedType == Essentials.ForeignAnnotationAttribute &&
                         Essentials.Language.Literals[(int)attr.Arguments[0].ConstantValue].Name == language)
                     {
-                        foreach (var arg in attr.Arguments.Skip(1))
+                        foreach (var arg in (object[])attr.Arguments[1].ConstantValue)
                         {
-                            result.Add((string)arg.ConstantValue);
+                            result.Add((string)arg);
                         }
                     }
                 }

--- a/src/compiler/foreign/ForeignHelpers.cs
+++ b/src/compiler/foreign/ForeignHelpers.cs
@@ -51,7 +51,7 @@ namespace Uno.Compiler.Foreign
             return null;
         }
 
-        public List<string> GetForeignIncludes(DataType dt, string language, IEnvironment env)
+        public List<string> GetForeignIncludes(DataType dt, string language)
         {
             var result = new HashSet<string>();
 
@@ -64,7 +64,7 @@ namespace Uno.Compiler.Foreign
                     {
                         foreach (var arg in attr.Arguments.Skip(1))
                         {
-                            result.Add(env.Expand(dt.Source, (string)arg.ConstantValue));
+                            result.Add(Environment.Expand(dt.Source, (string)arg.ConstantValue));
                         }
                     }
                 }
@@ -81,7 +81,7 @@ namespace Uno.Compiler.Foreign
                         {
                             foreach (var arg in attr.Arguments.Skip(1))
                             {
-                                result.Add(env.Expand(f.Source, (string)arg.ConstantValue));
+                                result.Add(Environment.Expand(f.Source, (string)arg.ConstantValue));
                             }
                         }
                     }

--- a/src/compiler/foreign/ForeignObjCPass.cs
+++ b/src/compiler/foreign/ForeignObjCPass.cs
@@ -505,7 +505,7 @@ namespace Uno.Compiler.Foreign.ObjC
             if (!visitedTypes.Contains(dt))
             {
                 visitedTypes.Add(dt);
-                var includes = Helpers.GetForeignIncludes(dt, "ObjC", Environment);
+                var includes = Helpers.GetForeignIncludes(dt, "ObjC");
                 if (includes.Count > 0)
                     Helpers.SourceInclude(includes, dt);
             }

--- a/src/compiler/foreign/Java/JavaClass.cs
+++ b/src/compiler/foreign/Java/JavaClass.cs
@@ -35,7 +35,7 @@ namespace Uno.Compiler.Foreign.Java
                 var split = FullName.LastIndexOf(".", StringComparison.Ordinal);
                 _name = FullName.Substring(split + 1);
                 _package = FullName.Substring(0, split);
-                _usings.AddRange(helpers.GetForeignIncludes(dt, "Java", env));
+                _usings.AddRange(helpers.GetForeignIncludes(dt, "Java"));
                 _nested = dt.IsNestedType;
             }
 

--- a/tests/src/ForeignJavaTest/Args.uno
+++ b/tests/src/ForeignJavaTest/Args.uno
@@ -8,7 +8,6 @@ public extern(android) class TestClass0
 {
 }
 
-[ForeignInclude(Language.Java, "java.lang.Runnable", "android.app.Activity")]
 public extern(android) class Args
 {
     [Test]
@@ -63,6 +62,7 @@ public extern(android) class Args
     //------------------------------------------------------------
 
     [Foreign(Language.Java)]
+    [ForeignInclude(Language.Java, "java.lang.Runnable")]
     public bool CallUnoWithRunable0()
     @{
         java.lang.Runnable rrr = new Runnable() {

--- a/tests/src/ForeignJavaTest/Arrays.uno
+++ b/tests/src/ForeignJavaTest/Arrays.uno
@@ -4,7 +4,6 @@ using Uno.Graphics;
 using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 
-[ForeignInclude(Language.Java, "java.lang.Runnable", "android.app.Activity")]
 public extern(android) class Arrays
 {
     //------------------------------------------------------------

--- a/tests/src/ForeignJavaTest/Fields.uno
+++ b/tests/src/ForeignJavaTest/Fields.uno
@@ -4,7 +4,6 @@ using Uno.Graphics;
 using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 
-[ForeignInclude(Language.Java, "java.util.ArrayList")]
 public extern(android) class Fields
 {
     [Test]
@@ -76,6 +75,7 @@ public extern(android) class Fields
     @}
 
     [Foreign(Language.Java)]
+    [ForeignInclude(Language.Java, "java.util.ArrayList")]
     public extern(android) bool Test7()
     @{
         @{_staticJavaObj:Set(new ArrayList<String>())};

--- a/tests/src/ForeignJavaTest/Macros.uno
+++ b/tests/src/ForeignJavaTest/Macros.uno
@@ -4,7 +4,6 @@ using Uno.Graphics;
 using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 
-[ForeignInclude(Language.Java, "java.lang.Runnable", "android.app.Activity")]
 public extern(android) class Macros
 {
     [Test]

--- a/tests/src/ForeignJavaTest/Names.uno
+++ b/tests/src/ForeignJavaTest/Names.uno
@@ -4,7 +4,6 @@ using Uno.Graphics;
 using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 
-[ForeignInclude(Language.Java, "java.lang.Runnable", "android.app.Activity")]
 public extern(android) class Names
 {
     [Test]

--- a/tests/src/ForeignObjCTest/FileInclude.uno
+++ b/tests/src/ForeignObjCTest/FileInclude.uno
@@ -4,10 +4,10 @@ using Uno.Testing;
 
 namespace ForeignObjCTest
 {
-    [ForeignInclude(Language.ObjC, "FileInclude.h")]
     public extern(FOREIGN_OBJC_SUPPORTED) class FileInclude
     {
         [Foreign(Language.ObjC)]
+        [ForeignInclude(Language.ObjC, "FileInclude.h")]
         string StringFromFileInclude() @{ return string_from_file_include(); @}
 
         [Test]

--- a/tests/src/SwiftFileIncludeTest/SwiftFileIncludeTest.uno
+++ b/tests/src/SwiftFileIncludeTest/SwiftFileIncludeTest.uno
@@ -4,10 +4,10 @@ using Uno.Testing;
 
 namespace SwiftFileIncludeTest
 {
-    [ForeignInclude(Language.ObjC, "@(Project.Name)-Swift.h")]
     public extern(iOS) class SimpleFileInclude
     {
         [Foreign(Language.ObjC)]
+        [ForeignInclude(Language.ObjC, "@(Project.Name)-Swift.h")]
         string GetTheString()
         @{
             HelloSwiftWorld* x = [[HelloSwiftWorld alloc] init];


### PR DESCRIPTION
### UnoCore: use params in Foreign attributes

This removes a bunch of redundant constructors from
ForeignIncludeAttribute and ForeignAnnotatonAttribute.

### compiler: support array arguments in attributes

This makes it possible to accept an array of constants (or use params)
in attribute constructors, enabling us to make some code a bit nicer
(ForeignIncludeAttribute and ForeignAnnotatonAttribute).

* Implement NewArray.ConstantValue
* Modify Expression.ConstantString to serialize arrays (via ToString())
* Remove unused method in NewObject
* Remove redundant 'env' parameter in ForeignHelpers
* Update UnoDoc backend

### compiler: accept ForeignInclude attributes on methods

This accepts ForeignInclude attributes on methods and types, instead of
just types. Specifying the ForeignInclude attribute on the method it is
used (rather than the whole type) makes things more coherent.

* Update existing ForeignInclude attributes in the code-base