### PR TITLE
beta recovery & tweaks (beta-3.0)

### DIFF
--- a/lib/Uno.Net.Http/android/ExperimentalHttp/HttpRequest.cpp.uxl
+++ b/lib/Uno.Net.Http/android/ExperimentalHttp/HttpRequest.cpp.uxl
@@ -503,8 +503,6 @@ COMMIT_REG_MTD(@{_javaProxyClass});
 </Body>
         </Method>
         <Require Source.Declaration>
-//~Callbacks forHttpRequest
-
 #if !@{Android.com.fuse.ExperimentalHttp.HttpRequest.OnDataReceived(Android.Base.Wrappers.IJWrapper,int):IsStripped}
 JNFUN(void,Android_com_fuse_ExperimentalHttp_HttpRequest__OnDataReceived44285,jlong ujPtr, jobject arg0, jint arg1, jlong arg2, jlong arg3) {
     INITCALLBACK(uPtr,@{Android.com.fuse.ExperimentalHttp.HttpRequest});

--- a/lib/UnoCore/android/uDroid/Wrappers.cpp.uxl
+++ b/lib/UnoCore/android/uDroid/Wrappers.cpp.uxl
@@ -38,7 +38,6 @@
         <Require Entity="JNI.LoadClass(JNIEnvPtr,ConstCharPtr)" />
         <Require Header.Include="@{Android.Base.AndroidBindingMacros:Include}" />
         <Require Header.Declaration>
-        //~
         #define MAYBEPROXIFYARG(NUM,ID,NEW) bool subclassed ## NUM = (!ID) ? false : (@{Android.Base.Wrappers.IJWrapper:Of(ID)._IsSubclassed():Call()}); jobject _iProx ## NUM = (!ID) ? nullptr : (subclassed ## NUM ? NEW : @{Android.Base.Wrappers.IJWrapper:Of(ID)._GetJavaObject():Call()});
 
         #define FREEPROXIED(NUM)if (subclassed ## NUM) { U_JNIVAR->DeleteLocalRef(_iProx ## NUM); }
@@ -97,7 +96,6 @@ return result;
         </Method>
 
         <Require Source.Declaration>
-//~
         bool __JWrapper_WeakCallback(uWeakStateIntercept::Event e, uObject* obj)
         {
             @{Android.Base.JNI.CheckException():Call()};
@@ -134,7 +132,6 @@ return result;
         }
         </Require>
         <Require Source.Declaration>
-//~
         bool __JWrapper_Callbacks_Registered = false;
         void __JWrapper_Finalizer(JNIEnv *env , jclass clazz, jlong ptr)
         {

--- a/lib/UnoCore/cpp/main-app.cpp
+++ b/lib/UnoCore/cpp/main-app.cpp
@@ -30,7 +30,7 @@
 #include <stdio.h> // needed for sprintf
 #endif
 
-// See @{Uno.Environment.GetCommandLineArgs():Call()}
+// Used by Uno.Environment.GetCommandLineArgs()
 int uArgc = 0;
 char** uArgv = nullptr;
 

--- a/lib/UnoCore/cpp/main-console.cpp
+++ b/lib/UnoCore/cpp/main-console.cpp
@@ -6,7 +6,7 @@
 @(TypeObjects.Declaration:JoinSorted())
 void uInitTypes(uType*(*factories[])());
 
-// See @{Uno.Environment.GetCommandLineArgs():Call()}
+// Used by Uno.Environment.GetCommandLineArgs()
 int uArgc = 0;
 char** uArgv = nullptr;
 

--- a/lib/UnoCore/cpp/main-mobile.cpp
+++ b/lib/UnoCore/cpp/main-mobile.cpp
@@ -3,7 +3,7 @@
 
 #include <uno/ObjectModel.h>
 
-// See @{Uno.Environment.GetCommandLineArgs():Call()}
+// Used by Uno.Environment.GetCommandLineArgs()
 int uArgc = 0;
 char** uArgv = nullptr;
 

--- a/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/Android/JavaUnoObject.uxl
+++ b/lib/UnoCore/src/Uno/Compiler/ExportTargetInterop/Foreign/Android/JavaUnoObject.uxl
@@ -1,7 +1,6 @@
 <Extensions Backend="CPlusPlus" Condition="Android">
     <Type Name="Uno.Compiler.ExportTargetInterop.Foreign.Android.JavaUnoObject">
         <Require Source.Declaration>
-//~
 void __JavaUnoObject_Finalizer(JNIEnv *env , jclass clazz, jlong ptr)
 {
     uAutoReleasePool pool;

--- a/src/common/Diagnostics/Shell.cs
+++ b/src/common/Diagnostics/Shell.cs
@@ -303,7 +303,9 @@ namespace Uno.Diagnostics
                     {
                         if (!proc.HasExited)
                         {
-                            Log.Default.Verbose("Killing process " + proc.MainModule.FileName.Quote() + " (" + proc.Id + ")");
+                            Log.Default.Verbose("Killing process " +
+                                (proc.MainModule?.FileName ?? "(null)").Quote() +
+                                " (" + proc.Id + ")");
                             proc.KillTree();
                         }
                     }

--- a/src/common/Extensions.cs
+++ b/src/common/Extensions.cs
@@ -642,6 +642,8 @@ namespace Uno
                 case "iPhone":
                 case "iOS":
                 case "qIdentifier":
+                case "dotNet":
+                case "unoDoc":
                     return str.ToLowerInvariant();
             }
 

--- a/src/compiler/backend/cpp/CppBackend.cs
+++ b/src/compiler/backend/cpp/CppBackend.cs
@@ -71,8 +71,8 @@ namespace Uno.Compiler.Backends.CPlusPlus
             HeaderDirectory = Environment.GetOutputPath("HeaderDirectory");
             SourceDirectory = Environment.GetOutputPath("SourceDirectory");
 
-            // On Android, truncate lengths of filenames to avoid problem with Gradle on Windows.
-            if (Environment.IsDefined("ANDROID"))
+            // Android: Truncate filenames to workaround build problems with Gradle on Windows
+            if (Environment.IsDefined("ANDROID") && OperatingSystem.IsWindows())
                 MaxExportNameLength = 30;
         }
 

--- a/src/compiler/backend/unodoc/UnoDocBackend.cs
+++ b/src/compiler/backend/unodoc/UnoDocBackend.cs
@@ -9,7 +9,7 @@ namespace Uno.Compiler.Backends.UnoDoc
     public class UnoDocBackend : Backend
     {
         public override string Name => "UnoDoc";
-        public override string What => "api-docs";
+        public override string What => "api docs";
 
         public UnoDocBackend()
         {

--- a/src/compiler/core/IL/Building/Entrypoint/MainClassFinder.cs
+++ b/src/compiler/core/IL/Building/Entrypoint/MainClassFinder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Uno.Compiler.API.Backends;
 using Uno.Compiler.API.Domain;
 using Uno.Compiler.API.Domain.IL;
 using Uno.Compiler.API.Domain.IL.Members;
@@ -26,7 +27,7 @@ namespace Uno.Compiler.Core.IL.Building.Entrypoint
                     break;
                 case 0:
                     // Auto-generate main-class when building a library.
-                    if (Environment.IsLibrary)
+                    if (Environment.IsLibrary || Backend.BuildType == BuildType.Library)
                     {
                         var type = new ClassType(Bundle.Source, Data.IL, null, Modifiers.Generated | Modifiers.Public, Bundle.Name.ToIdentifier() + "_app");
                         type.SetBase(Essentials.Application);

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -258,7 +258,7 @@ namespace Uno.Build
 
         public void BuildNative()
         {
-            using (Log.StartAnimation("Building " + _target.ToString().ToLower() + (
+            using (Log.StartAnimation("Building " + _target.ToString().ToLower() + " " + (
                         _env.IsTest
                             ? "test" :
                         _env.IsConsole

--- a/src/tool/engine/FuseJS/TranspilerServer.cs
+++ b/src/tool/engine/FuseJS/TranspilerServer.cs
@@ -28,9 +28,11 @@ namespace Uno.Build.FuseJS
         bool _disposed;
         bool _isFaulted;
 
-        public TranspilerServer(Log log, UnoConfig config)
+        public TranspilerServer(Log log, UnoConfig config = null)
             : base(log)
         {
+            config ??= UnoConfig.Current;
+
             var script = Path.Combine(
                 config.GetNodeModuleDirectory("@fuse-open/transpiler"),
                 "server.min.js");

--- a/src/tool/engine/Targets/LibraryBuild.cs
+++ b/src/tool/engine/Targets/LibraryBuild.cs
@@ -17,6 +17,11 @@ namespace Uno.Build.Targets
             return new DefaultBackend { BuildType = BuildType.Library };
         }
 
+        public override void Initialize(IEnvironment env)
+        {
+            env.Define("LIBRARY");
+        }
+
         public override void Configure(ICompiler compiler)
         {
             new BundleGenerator(


### PR DESCRIPTION
### android: truncate filenames on Windows only

This isn't a problem on other platforms and non-truncated filenames
seem better when possible.

### engine: add missing space in BuildDriver

Regressed in daa1e75 (#489)

### C++: update comments

This fixes compile errors such as:

    main-mobile.cpp(1): E3356: 'Uno.Environment.GetCommandLineArgs()'
    could not be resolved

Regressed in c049bc1 (#489)

### unodoc: remove dash in "api docs"

### common: add cases in ToLowerCamelCase()

We've seen DotNet and UnoDoc in the past and it's better if they come
out as dotnet and unodoc (in all lowercase).

### engine: define LIBRARY in LibraryBuild

Don't get false errors about missing main class in libraries.

Regressed in 6d6577e (#483)

### common: fix NRE in Shell.KillAll()

Observed on macOS Ventura. Likely been happening since the initial
.NET 6.0 port.

### engine: fix NRE in TranspilerServer

Regressed in 000294e (#482)

### android: remove //~ comments

These strange comments are no longer necessary.