### PR TITLE
project-format: add outputType.appTest (beta-3.0)

### DIFF
--- a/lib/UnoCore/cil/app.cil.uxl
+++ b/lib/UnoCore/cil/app.cil.uxl
@@ -1,4 +1,4 @@
-<Extensions Backend="CIL" Condition="!CONSOLE && !LIBRARY && !TEST">
+<Extensions Backend="CIL" Condition="!CONSOLE && !LIBRARY && !TEST || APPTEST">
 
     <Set AppDirectory="@(Project.Name).app" Condition="HOST_MAC" />
     <Set AssemblyDirectory="@(HOST_MAC:Defined:Test('@(AppDirectory)/Contents/MonoBundle', '.'))" />

--- a/lib/UnoCore/cil/mac-loader.stuff
+++ b/lib/UnoCore/cil/mac-loader.stuff
@@ -1,3 +1,3 @@
-if DOTNET && HOST_MAC && HOST_X64 && !CONSOLE && !LIBRARY && !TEST {
+if DOTNET && HOST_MAC && HOST_X64 && !CONSOLE && !LIBRARY {
     "mac-x64": "https://www.nuget.org/api/v2/package/uno-mac-loader-x64/3.0.0-beta.0"
 }

--- a/lib/UnoCore/cil/test.cil.uxl
+++ b/lib/UnoCore/cil/test.cil.uxl
@@ -1,4 +1,4 @@
-<Extensions Backend="CIL" Condition="TEST">
+<Extensions Backend="CIL" Condition="TEST && !APPTEST">
 
     <Set AppLoader.Assembly="@(Config.AppLoader.Console:Path)/uno-app.dll" />
     <Set AppLoader.Class="Uno.AppLoader.Program" />

--- a/src/compiler/core/BuildEnvironment.cs
+++ b/src/compiler/core/BuildEnvironment.cs
@@ -27,7 +27,7 @@ namespace Uno.Compiler.Core
         public bool Strip => Options.Strip;
         public bool IsConsole => IsDefined("CONSOLE");
         public bool IsLibrary => IsDefined("LIBRARY");
-        public bool IsTest => IsDefined("TEST");
+        public bool IsTest => IsDefined("TEST") || IsDefined("APPTEST");
         public bool IsGeneratingCode => Step == BuildStep.Generating;
         public bool CanCacheIL => Options.CanCacheIL;
         public bool HasCustomEntrypoint => Options.MainClass != null;

--- a/src/test/runner/ProjectDiscoverer.cs
+++ b/src/test/runner/ProjectDiscoverer.cs
@@ -71,6 +71,7 @@ namespace Uno.TestRunner
 
             switch (outputType)
             {
+                case OutputType.AppTest:
                 case OutputType.Test:
                     return true;
 

--- a/src/tool/engine/BuildDriver.cs
+++ b/src/tool/engine/BuildDriver.cs
@@ -94,7 +94,7 @@ namespace Uno.Build
                     Filter = _options.TestFilter
                 };
             }
-            else if (project.OutputType == OutputType.Test)
+            else if (project.OutputType == OutputType.Test || project.OutputType == OutputType.AppTest)
             {
                 Log.Warning(project.Source, ErrorCode.W0000, "Test projects should be built & run using \"uno test\"");
             }

--- a/src/tool/project/OutputType.cs
+++ b/src/tool/project/OutputType.cs
@@ -4,6 +4,8 @@
     {
         Undefined,
         App,
+        /** Test project that needs a graphics context (etc) to run */
+        AppTest,
         Console,
         Library,
         Test,


### PR DESCRIPTION
Some tests (several in Fuselibs) need a proper graphics context etc., so this adds a new "appTest" output type for tests to be run as apps.