### PR TITLE
engine: rename manifest file in libraries (beta-3.0)

### DIFF
--- a/src/tool/engine/Libraries/LibraryProject.cs
+++ b/src/tool/engine/Libraries/LibraryProject.cs
@@ -23,7 +23,7 @@ namespace Uno.Build.Libraries
             RootDirectory = Path.Combine(sourceDir, "build", project.Name);
             CacheDirectory = Path.Combine(RootDirectory, ".uno");
             ConfigFile = Path.Combine(CacheDirectory, "config");
-            ManifestFile = Path.Combine(CacheDirectory, "package");
+            ManifestFile = Path.Combine(CacheDirectory, "manifest");
         }
 
         LibraryProject(LibraryProject lib)
@@ -32,7 +32,7 @@ namespace Uno.Build.Libraries
             RootDirectory = lib.RootDirectory;
             CacheDirectory = Path.Combine(RootDirectory, ".uno");
             ConfigFile = Path.Combine(CacheDirectory, "config");
-            ManifestFile = Path.Combine(CacheDirectory, "package");
+            ManifestFile = Path.Combine(CacheDirectory, "manifest");
         }
 
         public bool TryGetExistingBuild(out LibraryProject existing)

--- a/src/tool/engine/Libraries/ManifestFile.cs
+++ b/src/tool/engine/Libraries/ManifestFile.cs
@@ -10,7 +10,14 @@ namespace Uno.Build.Libraries
     {
         internal static string GetName(string dir)
         {
-            return Path.Combine(dir, ".uno", "package");
+            var manifest = Path.Combine(dir, ".uno", "manifest");
+            var package = Path.Combine(dir, ".uno", "package");
+
+            // Legacy: This file used to be called "package" before v3.0.
+            if (!File.Exists(manifest) && File.Exists(package))
+                return package;
+
+            return manifest;
         }
 
         public static bool Exists(string dir)


### PR DESCRIPTION
This file used to be called "package". We will fallback to the old name if "manifest" isn't found, to keep supporting libraries built by an older version of Uno.