### PR TITLE
compiler: refactor build queue (beta-3.0)

### DIFF
--- a/src/compiler/core/Compiler.cs
+++ b/src/compiler/core/Compiler.cs
@@ -49,6 +49,7 @@ namespace Uno.Compiler.Core
         public readonly NameResolver NameResolver;
 
         // Building
+        public readonly BuildQueue Queue;
         public readonly BlockBuilder BlockBuilder;
         public readonly BundleBuilder BundleBuilder;
         public readonly TypeBuilder TypeBuilder;
@@ -91,8 +92,9 @@ namespace Uno.Compiler.Core
             var data = Data = new BuildData(il, extensions, ilf);
             var environment = Environment = new BuildEnvironment(backend, bundle, options, extensions, ilf, this);
             var input = Input = new SourceReader(log, bundle, environment);
-            var blockBuilder = BlockBuilder = new BlockBuilder(backend, il, ilf, resolver, this);
-            var typeBuilder = TypeBuilder = new TypeBuilder(environment, ilf, resolver, this);
+            var queue = Queue = new BuildQueue(log, environment, backend, this);
+            var blockBuilder = BlockBuilder = new BlockBuilder(backend, il, ilf, resolver, this, queue);
+            var typeBuilder = TypeBuilder = new TypeBuilder(environment, ilf, resolver, this, queue);
             BundleBuilder = new BundleBuilder(backend, environment, ilf, this);
             AstProcessor = new AstProcessor(il, blockBuilder, typeBuilder, resolver, environment);
             UxlProcessor = new UxlProcessor(disk, backend.Name, il, extensions, environment, ilf);
@@ -132,20 +134,23 @@ namespace Uno.Compiler.Core
                 if (Backend.CanLink(bundle))
                     bundle.Flags |= SourceBundleFlags.CanLink;
 
-            using (Log.StartProfiler(TypeBuilder))
-                TypeBuilder.Build();
-            if (Log.HasErrors)
-                return;
+            using (Log.StartProfiler(Queue))
+                Queue.BuildTypesAndFunctions();
 
-            Backend.ShaderBackend.Initialize(this, BundleBuilder);
-
-            using (Log.StartProfiler(BlockBuilder))
-                BlockBuilder.Build();
             if (Log.HasErrors)
                 return;
 
             using (Log.StartProfiler(UxlProcessor))
                 UxlProcessor.CompileDocuments();
+
+            if (Log.HasErrors)
+                return;
+
+            Backend.ShaderBackend.Initialize(this, BundleBuilder);
+
+            using (Log.StartProfiler(Queue))
+                Queue.BuildEverything();
+
             if (Log.HasErrors)
                 return;
 
@@ -205,7 +210,6 @@ namespace Uno.Compiler.Core
             UxlProcessor.CompileRequirements();
             ILStripper.Begin();
             Run(_transforms);
-            TypeBuilder.BuildTypes();
 
             using (Log.StartProfiler(ILStripper))
                 ILStripper.End();

--- a/src/compiler/core/IL/EntitySwapper.cs
+++ b/src/compiler/core/IL/EntitySwapper.cs
@@ -65,7 +65,6 @@ namespace Uno.Compiler.Core.IL
                                 args[i] = GetType(dt.FlattenedArguments[i]);
 
                             result = TypeBuilder.Parameterize(result.Source, def, args);
-                            TypeBuilder.BuildTypes();
                             SwapTypes.Add(dt, result);
                             return result;
                         }
@@ -99,7 +98,6 @@ namespace Uno.Compiler.Core.IL
 
                 var def = result.IsGenericDefinition ? result : GetType(dt.GenericDefinition);
                 result = TypeBuilder.Parameterize(dt.Source, def, args);
-                TypeBuilder.BuildTypes();
             }
 
             SwapTypes.Add(dt, result);

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CompileDraw.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CompileDraw.cs
@@ -32,10 +32,8 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             var result = new DrawBlock(draw.Source, parent, method, FlattenVariableScopes(vscopeStack));
             method.DrawBlocks.Add(result);
-
-            EnqueueBlock(result, x => PopulateBlock(draw.Block, x));
-            _enqueuedDrawClasses.Add(method.DeclaringType);
-
+            _queue.EnqueueBlock(result, x => PopulateBlock(draw.Block, x));
+            _queue.EnqueueDrawClass(method.DeclaringType);
             return result.DrawScope;
         }
 

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CreateBlock.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CreateBlock.cs
@@ -30,8 +30,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(src, ErrorCode.E3214, "Block declaration is not allowed in this scope");
 
             _processedBlocks.Add(ast, result);
-            EnqueueBlock(result, x => PopulateBlock(ast, x));
-
+            _queue.EnqueueBlock(result, x => PopulateBlock(ast, x));
             return result;
         }
 
@@ -76,7 +75,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                     return MetaBlock.Invalid;
             }
 
-            EnqueueBlock(result, x => PopulateBlock(ast, x));
+            _queue.EnqueueBlock(result, x => PopulateBlock(ast, x));
             return result;
         }
     }

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CreateMetaProperty.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CreateMetaProperty.cs
@@ -58,12 +58,11 @@ namespace Uno.Compiler.Core.Syntax.Builders
             }
 
             var result = new MetaProperty(ast.Name.Source, parent, dt, ast.Name.Symbol, visibility);
-            _enqueuedProperties.Add(new KeyValuePair<AstMetaProperty, MetaProperty>(ast, result));
-
+            _queue.EnqueueMetaProperty(ast, result);
             return result;
         }
 
-        void CompileMetaPropertyDefinitions(AstMetaProperty ast, MetaProperty mp)
+        internal void CompileMetaPropertyDefinitions(AstMetaProperty ast, MetaProperty mp)
         {
             var defs = new MetaDefinition[ast.Definitions.Count];
 

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.FlattenType.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.FlattenType.cs
@@ -8,7 +8,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
     {
         internal readonly Dictionary<DataType, HashSet<DataType>> FlattenedTypes = new Dictionary<DataType, HashSet<DataType>>();
 
-        void FlattenTypes()
+        internal void FlattenTypes()
         {
             FlattenTypes(_il);
 

--- a/src/compiler/core/Syntax/Builders/BuildQueue.cs
+++ b/src/compiler/core/Syntax/Builders/BuildQueue.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using Uno.Compiler.API.Backends;
+using Uno.Compiler.API.Domain.AST.Members;
+using Uno.Compiler.API.Domain.AST.Statements;
+using Uno.Compiler.API.Domain.Graphics;
+using Uno.Compiler.API.Domain.IL;
+using Uno.Compiler.API.Domain.IL.Members;
+using Uno.Compiler.Core.Syntax.Compilers;
+using Uno.Compiler.Core.Syntax.Generators;
+using Uno.Logging;
+
+namespace Uno.Compiler.Core.Syntax.Builders
+{
+    public class BuildQueue : LogObject
+    {
+        readonly BuildEnvironment _env;
+        readonly Backend _backend;
+        readonly Compiler _compiler;
+        readonly List<BlockBase> _enqueuedBlocks = new List<BlockBase>();
+        readonly List<KeyValuePair<AstMetaProperty, MetaProperty>> _enqueuedMetaProperties = new List<KeyValuePair<AstMetaProperty, MetaProperty>>();
+        readonly HashSet<DataType> _enqueuedDrawClasses = new HashSet<DataType>();
+        readonly List<FunctionCompiler> _enqueuedFunctions = new List<FunctionCompiler>();
+        readonly List<Entity> _enqueuedAttributes = new List<Entity>();
+        readonly List<DataType> _enqueuedTypes = new List<DataType>();
+        readonly List<Action> _enqueuedActions = new List<Action>();
+        int _assignBaseTypeIndex;
+        int _populateMembersIndex;
+
+        public BuildQueue(Log log, BuildEnvironment env, Backend backend, Compiler compiler)
+            : base(log)
+        {
+            _env = env;
+            _backend = backend;
+            _compiler = compiler;
+        }
+
+        internal FunctionCompiler EnqueueFunction(Function func, DataType parameterizedParent, AstScope body)
+        {
+            var fc = new FunctionCompiler(_compiler, func, parameterizedParent, body);
+            func.Tag = fc;
+
+            if (_env.IsGeneratingCode)
+                func.Stats |= EntityStats.CanLink;
+            else if (body != null)
+                _enqueuedFunctions.Add(fc);
+            else if (_compiler.Backend.CanLink(func))
+                func.Stats |= EntityStats.CanLink;
+
+            return fc;
+        }
+
+        internal void EnqueueDrawClass(DataType declaringType)
+        {
+            _enqueuedDrawClasses.Add(declaringType);
+        }
+
+        internal void EnqueueType(DataType dt, Action<DataType> assignBaseType, Action<DataType> populate)
+        {
+            if (_env.IsGeneratingCode)
+            {
+                assignBaseType(dt);
+                populate(dt);
+                return;
+            }
+
+            dt.AssigningBaseType = assignBaseType;
+            dt.PopulatingMembers = x =>
+            {
+                populate(x);
+                x.Stats &= ~EntityStats.PopulatingMembers;
+            };
+            dt.Stats |= EntityStats.PopulatingMembers;
+            _enqueuedTypes.Add(dt);
+        }
+
+        internal void EnqueueAttributes(Entity e, Action<Entity> assign)
+        {
+            e.AssigningAttributes = assign;
+            _enqueuedAttributes.Add(e);
+        }
+
+        internal void EnqueueAttributes(Member e, DataType parameterizedParent, IReadOnlyList<AstAttribute> attributes)
+        {
+            if (attributes.Count > 0)
+                EnqueueAttributes(e, x => e.SetAttributes(_compiler.CompileAttributes(parameterizedParent, attributes)));
+        }
+
+        public void BuildTypes()
+        {
+            for (int count = 0, j = 0; count != _enqueuedTypes.Count && j < 10; j++)
+            {
+                count = _enqueuedTypes.Count;
+
+                while (_assignBaseTypeIndex < count)
+                    _enqueuedTypes[_assignBaseTypeIndex++].AssignBaseType();
+
+                for (int i = 0; i < _enqueuedAttributes.Count; i++)
+                    _enqueuedAttributes[i].AssignAttributes();
+
+                _enqueuedAttributes.Clear();
+
+                while (_populateMembersIndex < count)
+                    if (_backend.CanLink(_enqueuedTypes[_populateMembersIndex]))
+                        _enqueuedTypes[_populateMembersIndex++].Stats |= EntityStats.CanLink;
+                    else
+                        _enqueuedTypes[_populateMembersIndex++].PopulateMembers();
+
+                for (int i = 0; i < _enqueuedActions.Count; i++)
+                    _enqueuedActions[i]();
+
+                _enqueuedActions.Clear();
+            }
+
+            for (; _populateMembersIndex < _enqueuedTypes.Count; _populateMembersIndex++)
+                Log.Warning(_enqueuedTypes[_populateMembersIndex].Source, ErrorCode.I0000, "Unable to parameterize " + _enqueuedTypes[_populateMembersIndex].Quote());
+
+            _assignBaseTypeIndex = _populateMembersIndex;
+        }
+
+        public void BuildTypesAndFunctions()
+        {
+            BuildTypes();
+
+            for (var i = 0; i < _enqueuedFunctions.Count; i++)
+            {
+                _enqueuedFunctions[i].Compile();
+                BuildTypes();
+            }
+
+            _enqueuedFunctions.Clear();
+            _enqueuedTypes.Clear();
+
+            _assignBaseTypeIndex = 0;
+            _populateMembersIndex = 0;
+        }
+
+        public void BuildEverything()
+        {
+            _compiler.BlockBuilder.FlattenTypes();
+
+            do
+            {
+                BuildTypesAndFunctions();
+                BuildBlocks();
+                BuildMetaProperties();
+
+                foreach (var dt in _enqueuedDrawClasses)
+                    DrawCallGenerator.GenerateDrawCalls(_compiler, dt);
+
+                _enqueuedDrawClasses.Clear();
+
+            } while (_enqueuedFunctions.Count > 0);
+        }
+
+        public void BuildBlocks()
+        {
+            for (var i = 0; i < _enqueuedBlocks.Count; i++)
+                if (!_enqueuedBlocks[i].Source.Bundle.CanLink)
+                    _enqueuedBlocks[i].Populate();
+
+            _enqueuedBlocks.Clear();
+        }
+
+        internal void EnqueueBlock(BlockBase b, Action<BlockBase> populate)
+        {
+            b.Populating = populate;
+            _enqueuedBlocks.Add(b);
+        }
+
+        public void BuildMetaProperties()
+        {
+            for (var i = 0; i < _enqueuedMetaProperties.Count; i++)
+                _compiler.BlockBuilder.CompileMetaPropertyDefinitions(_enqueuedMetaProperties[i].Key, _enqueuedMetaProperties[i].Value);
+
+            _enqueuedMetaProperties.Clear();
+        }
+
+        public void EnqueueMetaProperty(AstMetaProperty ast, MetaProperty result)
+        {
+            _enqueuedMetaProperties.Add(new KeyValuePair<AstMetaProperty, MetaProperty>(ast, result));
+        }
+
+        internal void Enqueue(Action action)
+        {
+            _enqueuedActions.Add(action);
+        }
+    }
+}

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateClass.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateClass.cs
@@ -68,9 +68,9 @@ namespace Uno.Compiler.Core.Syntax.Builders
                     _compiler.AstProcessor.CreateBlock(b as AstBlockBase, result, astClass.Members);
 
             if (astClass.Attributes.Count > 0)
-                EnqueueAttributes(result, x =>
+                _queue.EnqueueAttributes(result, x =>
                 {
-                    result.SetAttributes(_compiler.CompileAttributes(result.Parent, astClass.Attributes));
+                    result.SetAttributes(_compiler.CompileAttributes(parent, astClass.Attributes));
 
                     // Remove default constructor if TargetSpecificType
                     if (result.HasAttribute(_ilf.Essentials.TargetSpecificTypeAttribute) &&
@@ -78,7 +78,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                         result.Constructors.Clear();
                 });
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 x => CompileBaseTypes(x, astClass.Bases),
                 x => PopulateClass(astClass, x));
         }

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateDelegate.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateDelegate.cs
@@ -29,23 +29,23 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(src, ErrorCode.I3019, "'delegate' cannot contain members");
 
             if (ast.Attributes.Count > 0)
-                EnqueueAttributes(result,
-                    x => result.SetAttributes(_compiler.CompileAttributes(result.Parent, ast.Attributes)));
+                _queue.EnqueueAttributes(result,
+                    _ => result.SetAttributes(_compiler.CompileAttributes(parent, ast.Attributes)));
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 assignBaseType: x =>
                 {
                     var deferredActions = new List<Action>();
-                    var parameterizedType = Parameterize(result);
+                    var parameterizedType = Parameterize(x);
 
                     result.SetBase(_ilf.Essentials.Delegate);
-                    result.SetReturnType(_resolver.GetType(result, ast.ReturnType));
-                    result.SetParameters(_compiler.CompileParameterList(result, ast.Parameters, deferredActions));
+                    result.SetReturnType(_resolver.GetType(x, ast.ReturnType));
+                    result.SetParameters(_compiler.CompileParameterList(x, ast.Parameters, deferredActions));
 
                     if (parameterizedType != result)
                     {
                         var parameterizedDelegate = (DelegateType)parameterizedType;
-                        parameterizedDelegate.SetBase(result.Base);
+                        parameterizedDelegate.SetBase(x.Base);
                         parameterizedDelegate.SetReturnType(result.ReturnType);
                         parameterizedDelegate.SetParameters(result.Parameters);
                     }

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateEnum.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateEnum.cs
@@ -39,10 +39,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(result.Source, ErrorCode.I3037, "'enum' is not allowed in this context");
 
             if (ast.Attributes.Count > 0)
-                EnqueueAttributes(result,
-                    x => result.SetAttributes(_compiler.CompileAttributes(result.Parent, ast.Attributes)));
+                _queue.EnqueueAttributes(result,
+                    _ => result.SetAttributes(_compiler.CompileAttributes(parent, ast.Attributes)));
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 assignBaseType: x =>
                 {
                     x.SetBase(ast.OptionalBaseType != null
@@ -102,7 +102,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                             s.DocComment, Modifiers.Public, parameterizedType, TypedEnumValue(parameterizedType.Base, value));
 
                         if (s.Attributes.Count > 0)
-                            EnqueueAttributes(literal,
+                            _queue.EnqueueAttributes(literal,
                                 _ => literal.SetAttributes(_compiler.CompileAttributes(result, s.Attributes)));
 
                         result.Literals.Add(literal);

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
@@ -186,9 +186,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             result.SetMasterDefinition(definition.MasterDefinition);
             ParameterizeInnerTypes(definition, definition, map, result);
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 x => ParameterizeBaseType(definition, map, x),
                 x => ParameterizeMembers(definition, definition, map, x));
+
             return result;
         }
 
@@ -292,7 +293,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             if (result != null)
             {
-                map.Add(arg, result);
+                map[arg] = result;
                 return result;
             }
 
@@ -361,17 +362,23 @@ namespace Uno.Compiler.Core.Syntax.Builders
             {
                 var e = current.NestedTypes[i];
                 var t = CreateParameterizableInnerType(e, result);
+                result.NestedTypes.Add(t);
 
                 if (e.IsGenericDefinition)
                     t.MakeGenericDefinition(e.GenericParameters);
 
                 t.SetMasterDefinition(e.MasterDefinition);
 
-                EnqueueType(t,
+                _queue.EnqueueType(t,
                     x => ParameterizeBaseType(e, map, x),
                     x => ParameterizeMembers(definition, e, map, x));
+            }
+
+            for (int i = 0; i < current.NestedTypes.Count; i++)
+            {
+                var e = current.NestedTypes[i];
+                var t = result.NestedTypes[i];
                 ParameterizeInnerTypes(definition, e, map, t);
-                result.NestedTypes.Add(t);
             }
         }
 

--- a/src/ux/markup/CompilerReflection/ILCache.cs
+++ b/src/ux/markup/CompilerReflection/ILCache.cs
@@ -35,7 +35,7 @@ namespace Uno.UX.Markup.CompilerReflection
 
             try
             {
-                compiler.TypeBuilder.BuildTypes();
+                compiler.Queue.BuildTypes();
             }
             catch (Exception)
             {


### PR DESCRIPTION
Extract BuildQueue from BlockBuilder and TypeBuilder to get better control over when different classes, functions, etc, are compiled, improving abilities when it comes to lazy compilation.