### PR TITLE
bin: remove framework from output path (beta-3.0)

### DIFF
--- a/.unoconfig
+++ b/.unoconfig
@@ -1,16 +1,16 @@
 // Core config
-appLoader.console: bin/console/net6.0
-appLoader.windows: bin/win/net6.0-windows
+appLoader.console: bin/console
+appLoader.windows: bin/win
 
 if WIN32 {
-    appLoader.assembly: bin/win/net6.0-windows/uno-app.dll
-    uno.command: bin/net6.0/uno.exe
+    appLoader.assembly: bin/win/uno-app.dll
+    uno.command: bin/uno.exe
 } else if MAC {
-    // appLoader.assembly is not used to create macOS apps
-    uno.command: bin/net6.0/uno
+    // appLoader.assembly is not used on macOS
+    uno.command: bin/uno
 } else {
-    appLoader.assembly: bin/console/net6.0/uno-app.dll
-    uno.command: bin/net6.0/uno
+    appLoader.assembly: bin/console/uno-app.dll
+    uno.command: bin/uno
 }
 
 // Standard library

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 default:
 	@bash scripts/build.sh
 lib:
-	@bin/net6.0/uno doctor -e lib
+	@bin/uno doctor -e lib
 unocore:
-	@bin/net6.0/uno build lib/UnoCore
+	@bin/uno build lib/UnoCore
 uno:
 	@dotnet build uno.sln -v m
 disasm:

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ const path = require("path")
 const run = require("dotnet-run")
 
 module.exports = function(args) {
-    const filename = path.join(__dirname, "bin", "net6.0", "uno.dll")
+    const filename = path.join(__dirname, "bin", "uno.dll")
     return run(filename, args)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dotnet-run": "^2.0.0"
       },
       "bin": {
-        "uno": "bin/net6.0/uno.js"
+        "uno": "bin/uno.js"
       },
       "devDependencies": {
         "filecompare": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "prepack": "bash scripts/pack.sh",
     "test": "bash scripts/test.sh",
     "version": "bash scripts/version.sh",
-    "uno": "node bin/net6.0/uno.js"
+    "uno": "node bin/uno.js"
   },
   "bin": {
-    "uno": "bin/net6.0/uno.js"
+    "uno": "bin/uno.js"
   },
   "files": [
     ".unoconfig",

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,7 +2,7 @@
 set -e
 
 function uno {
-    dotnet bin/net6.0/uno.dll "$@"
+    dotnet bin/uno.dll "$@"
 }
 
 function h1 {

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -82,7 +82,7 @@ function rm-identical {
 h1 "Optimizing package"
 
 # OpenTK will be added back by restore.js
-rm-identical bin/win/net6.0-windows node_modules/@fuse-open/opentk *.dll
+rm-identical bin/win node_modules/@fuse-open/opentk *.dll
 
 # Remove needless build artifacts
 rm-all bin *.config *.pdb *.xml

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -43,12 +43,12 @@ function restoreFiles(src, dst) {
 
 function makeExecutable(path) {
     if (os.platform() !== "win32" && fs.existsSync(path))
-        fs.chmodSync(path, 0755)
+        fs.chmodSync(path, 0o755)
 }
 
 // Restore OpenTK and ANGLE (Windows only)
 const opentk = findNodeModule("@fuse-open/opentk")
-restoreFiles(opentk, path.join(__dirname, "..", "bin", "win", "net6.0-windows"))
+restoreFiles(opentk, path.join(__dirname, "..", "bin", "win"))
 
 // Make sure the shell script is executable
-makeExecutable(path.join(__dirname, "..", "bin", "net6.0", "uno"))
+makeExecutable(path.join(__dirname, "..", "bin", "uno"))

--- a/src/disasm/core/Uno.Disasm.csproj
+++ b/src/disasm/core/Uno.Disasm.csproj
@@ -95,19 +95,19 @@
 
   <ItemGroup>
     <Reference Include="uno">
-      <HintPath>..\..\..\bin\net6.0\uno.dll</HintPath>
+      <HintPath>..\..\..\bin\uno.dll</HintPath>
     </Reference>
     <Reference Include="Uno.Build">
-      <HintPath>..\..\..\bin\net6.0\Uno.Build.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.Build.dll</HintPath>
     </Reference>
     <Reference Include="Uno.Common">
-      <HintPath>..\..\..\bin\net6.0\Uno.Common.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.Common.dll</HintPath>
     </Reference>
     <Reference Include="Uno.Compiler.API">
-      <HintPath>..\..\..\bin\net6.0\Uno.Compiler.API.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.Compiler.API.dll</HintPath>
     </Reference>
     <Reference Include="Uno.ProjectFormat">
-      <HintPath>..\..\..\bin\net6.0\Uno.ProjectFormat.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.ProjectFormat.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/disasm/wpf/disasm-wpf.csproj
+++ b/src/disasm/wpf/disasm-wpf.csproj
@@ -31,10 +31,10 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Uno.Build">
-      <HintPath>..\..\..\bin\net6.0\Uno.Build.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.Build.dll</HintPath>
     </Reference>
     <Reference Include="Uno.Common">
-      <HintPath>..\..\..\bin\net6.0\Uno.Common.dll</HintPath>
+      <HintPath>..\..\..\bin\Uno.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/runtime/console/app-console.csproj
+++ b/src/runtime/console/app-console.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Uno.AppLoader</RootNamespace>
     <AssemblyName>uno-app</AssemblyName>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(SolutionDir)bin\console</OutputPath>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/runtime/win/app-win.csproj
+++ b/src/runtime/win/app-win.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <RootNamespace>Uno.AppLoader</RootNamespace>
     <AssemblyName>uno-app</AssemblyName>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(SolutionDir)bin\win</OutputPath>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tool/cli/uno.csproj
+++ b/src/tool/cli/uno.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Uno.CLI</RootNamespace>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(SolutionDir)bin</OutputPath>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
Place assemblies right in bin/ instead of bin/net6.0, and similar for console and win assemblies.

* Update octal literal in restore.js