### PR TITLE
Android: Upgrade to API 33 and Minimum to 19

### DIFF
--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -22,10 +22,10 @@
     <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '16')" />
     <Set NDK.Version="@(Project.Android.NDK.Version || Config.Android.NDK.Version || '21.4.7075529')" />
     <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '30.0.3')" />
-    <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '31')" />
+    <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '33')" />
     <Set SDK.Directory="@(Config.Android.SDK:Path || Config.Android.SDK.Directory:Path || ANDROID_SDK:Env)" />
-    <Set SDK.MinVersion="@(Project.Android.SDK.MinVersion || Config.Android.SDK.MinVersion || '16')" />
-    <Set SDK.TargetVersion="@(Project.Android.SDK.TargetVersion || Config.Android.SDK.TargetVersion || '31')" />
+    <Set SDK.MinVersion="@(Project.Android.SDK.MinVersion || Config.Android.SDK.MinVersion || '19')" />
+    <Set SDK.TargetVersion="@(Project.Android.SDK.TargetVersion || Config.Android.SDK.TargetVersion || '33')" />
 
     <!-- Build properties -->
 


### PR DESCRIPTION
Targeting API 33 (Android 13) by default because this will be required by Google Play Store starting in August 2023. More info: https://developer.android.com/google/play/requirements/target-sdk

Also, we are upgrading minimum API 19 (Android KitKat), This is necessary for compatibility with Firebase Messaging for Push Notification