### PR TITLE
compiler: fix build queue regressions (beta-3.0)

### DIFF
--- a/lib/UnoCore/cil/run.bat
+++ b/lib/UnoCore/cil/run.bat
@@ -2,7 +2,7 @@
 :: @(MSG_EDIT_WARNING)
 @echo off
 
-#if @(LIBRARY:Defined)
+#if @(LIBRARY:defined) || @(PREVIEW:defined)
 echo ERROR: @(Product) is a library and cannot be run directly.
 exit /b 1
 #else

--- a/lib/UnoCore/cil/run.sh
+++ b/lib/UnoCore/cil/run.sh
@@ -1,17 +1,14 @@
 #!/bin/sh
 # @(MSG_ORIGIN)
 # @(MSG_EDIT_WARNING)
+set -e
+cd "`dirname "$0"`"
 
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
-done
-
-#if @(LIBRARY:Defined)
+#if @(LIBRARY:defined) || @(PREVIEW:defined)
 echo "ERROR: @(Product) is a library and cannot be run directly." >&2
 exit 1
+#elif @(CONSOLE:defined) || @(TEST:defined) && !@(APPTEST:defined) || !@(HOST_MAC:defined)
+exec dotnet @(Product:QuoteSpace) "$@"
 #else
-exec dotnet "@(Product)" "$@"
+exec @(Product:QuoteSpace) "$@"
 #endif

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,11 +17,12 @@ uno config -v
 h1 "Starting test suite"
 ########################
 
-# Run uno tests
+# Run library tests
 if [[ "$SKIP_LIB_TESTS" != 1 ]]; then
     uno test $TARGET lib $UNO_TEST_ARGS
 fi
 
+# Run uno/ux tests
 if [[ "$SKIP_UNO_TESTS" != 1 ]]; then
     uno test $TARGET tests/src/{Uno,UX}Test $UNO_TEST_ARGS
 fi
@@ -41,3 +42,20 @@ if [[ "$TARGET" == dotnet ]]; then
         src/test/tests/bin/$CONFIGURATION/net6.0/Uno.TestRunner.Tests.dll \
         src/ux/tests/bin/$CONFIGURATION/net6.0/Uno.UX.Markup.Tests.dll
 fi
+
+if [[ "$SKIP_SUBSEQUENT" == 1 ]]; then
+    exit 0
+fi
+
+h1 "Testing subsequent builds"
+##############################
+
+if [[ "$SKIP_LIB_TESTS" != 1 ]]; then
+    uno test $TARGET lib $UNO_TEST_ARGS --build-only
+fi
+
+if [[ "$SKIP_UNO_TESTS" != 1 ]]; then
+    uno test $TARGET tests/src/{Uno,UX}Test $UNO_TEST_ARGS --build-only
+fi
+
+uno build $TARGET --no-strip tests/libtest

--- a/src/compiler/api/Domain/Graphics/Drawable.cs
+++ b/src/compiler/api/Domain/Graphics/Drawable.cs
@@ -56,6 +56,7 @@ namespace Uno.Compiler.API.Domain.Graphics
                 Block = block;
                 Top = top;
                 Bottom = bottom;
+                Block.Populate();
             }
 
             public Node(Expression obj, BlockBase block)

--- a/src/compiler/core/Compiler.cs
+++ b/src/compiler/core/Compiler.cs
@@ -134,6 +134,23 @@ namespace Uno.Compiler.Core
                 if (Backend.CanLink(bundle))
                     bundle.Flags |= SourceBundleFlags.CanLink;
 
+            // Make sure all references of linkable bundles are also linkable
+            foreach (var bundle in Input.Bundles)
+            {
+                if (bundle.CanLink)
+                {
+                    foreach (var reference in bundle.References)
+                    {
+                        if (!reference.CanLink)
+                        {
+                            Log.Verbose(bundle.Name + ": Removing CanLink flag because " + reference.Name + " can't link");
+                            bundle.Flags &= ~SourceBundleFlags.CanLink;
+                            break;
+                        }
+                    }
+                }
+            }
+
             using (Log.StartProfiler(Queue))
                 Queue.BuildTypesAndFunctions();
 

--- a/src/compiler/core/Compiler.cs
+++ b/src/compiler/core/Compiler.cs
@@ -49,6 +49,7 @@ namespace Uno.Compiler.Core
         public readonly NameResolver NameResolver;
 
         // Building
+        public readonly BuildQueue Queue;
         public readonly BlockBuilder BlockBuilder;
         public readonly BundleBuilder BundleBuilder;
         public readonly TypeBuilder TypeBuilder;
@@ -91,8 +92,9 @@ namespace Uno.Compiler.Core
             var data = Data = new BuildData(il, extensions, ilf);
             var environment = Environment = new BuildEnvironment(backend, bundle, options, extensions, ilf, this);
             var input = Input = new SourceReader(log, bundle, environment);
-            var blockBuilder = BlockBuilder = new BlockBuilder(backend, il, ilf, resolver, this);
-            var typeBuilder = TypeBuilder = new TypeBuilder(environment, ilf, resolver, this);
+            var queue = Queue = new BuildQueue(log, environment, backend, this);
+            var blockBuilder = BlockBuilder = new BlockBuilder(backend, il, ilf, resolver, this, queue);
+            var typeBuilder = TypeBuilder = new TypeBuilder(environment, ilf, resolver, this, queue);
             BundleBuilder = new BundleBuilder(backend, environment, ilf, this);
             AstProcessor = new AstProcessor(il, blockBuilder, typeBuilder, resolver, environment);
             UxlProcessor = new UxlProcessor(disk, backend.Name, il, extensions, environment, ilf);
@@ -132,20 +134,23 @@ namespace Uno.Compiler.Core
                 if (Backend.CanLink(bundle))
                     bundle.Flags |= SourceBundleFlags.CanLink;
 
-            using (Log.StartProfiler(TypeBuilder))
-                TypeBuilder.Build();
-            if (Log.HasErrors)
-                return;
+            using (Log.StartProfiler(Queue))
+                Queue.BuildTypesAndFunctions();
 
-            Backend.ShaderBackend.Initialize(this, BundleBuilder);
-
-            using (Log.StartProfiler(BlockBuilder))
-                BlockBuilder.Build();
             if (Log.HasErrors)
                 return;
 
             using (Log.StartProfiler(UxlProcessor))
                 UxlProcessor.CompileDocuments();
+
+            if (Log.HasErrors)
+                return;
+
+            Backend.ShaderBackend.Initialize(this, BundleBuilder);
+
+            using (Log.StartProfiler(Queue))
+                Queue.BuildEverything();
+
             if (Log.HasErrors)
                 return;
 
@@ -205,7 +210,6 @@ namespace Uno.Compiler.Core
             UxlProcessor.CompileRequirements();
             ILStripper.Begin();
             Run(_transforms);
-            TypeBuilder.BuildTypes();
 
             using (Log.StartProfiler(ILStripper))
                 ILStripper.End();

--- a/src/compiler/core/IL/EntitySwapper.cs
+++ b/src/compiler/core/IL/EntitySwapper.cs
@@ -65,7 +65,6 @@ namespace Uno.Compiler.Core.IL
                                 args[i] = GetType(dt.FlattenedArguments[i]);
 
                             result = TypeBuilder.Parameterize(result.Source, def, args);
-                            TypeBuilder.BuildTypes();
                             SwapTypes.Add(dt, result);
                             return result;
                         }
@@ -99,7 +98,6 @@ namespace Uno.Compiler.Core.IL
 
                 var def = result.IsGenericDefinition ? result : GetType(dt.GenericDefinition);
                 result = TypeBuilder.Parameterize(dt.Source, def, args);
-                TypeBuilder.BuildTypes();
             }
 
             SwapTypes.Add(dt, result);

--- a/src/compiler/core/IL/Testing/TestSetupTransform.cs
+++ b/src/compiler/core/IL/Testing/TestSetupTransform.cs
@@ -45,6 +45,9 @@ namespace Uno.Compiler.Core.IL.Testing
 
             _appClass = Essentials.Application;
 
+            // Lazy populate app class
+            _appClass.PopulateMembers();
+
             _source = Bundle.Source;
             _testRegistryType = ILFactory.GetType("Uno.Testing.Registry");
             _mainClass = new ClassType(_source, Data.IL, null, Modifiers.Generated | Modifiers.Public, "MainClass");

--- a/src/compiler/core/IL/Validation/ILVerifier.Type.cs
+++ b/src/compiler/core/IL/Validation/ILVerifier.Type.cs
@@ -348,6 +348,10 @@ namespace Uno.Compiler.Core.IL.Validation
                             break;
                     }
 
+                    // Skip lazy populated type
+                    if (at.CanLink && at.Constructors.Count == 0)
+                        continue;
+
                     var defCtor = at.TryGetDefaultConstructor();
 
                     if (gt.Constructors.Count > 0 && (

--- a/src/compiler/core/Syntax/Binding/NameResolver.cs
+++ b/src/compiler/core/Syntax/Binding/NameResolver.cs
@@ -205,6 +205,9 @@ namespace Uno.Compiler.Core.Syntax.Binding
                         var fieldSizeSum = 0;
                         var fieldAlignMax = 1;
 
+                        // Lazy populate fields
+                        dt.PopulateMembers();
+
                         foreach (var f in dt.EnumerateFields())
                         {
                             int fieldSize;

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CompileDraw.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CompileDraw.cs
@@ -32,10 +32,8 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             var result = new DrawBlock(draw.Source, parent, method, FlattenVariableScopes(vscopeStack));
             method.DrawBlocks.Add(result);
-
-            EnqueueBlock(result, x => PopulateBlock(draw.Block, x));
-            _enqueuedDrawClasses.Add(method.DeclaringType);
-
+            _queue.EnqueueBlock(result, x => PopulateBlock(draw.Block, x));
+            _queue.EnqueueDrawClass(method.DeclaringType);
             return result.DrawScope;
         }
 

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CreateBlock.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CreateBlock.cs
@@ -30,8 +30,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(src, ErrorCode.E3214, "Block declaration is not allowed in this scope");
 
             _processedBlocks.Add(ast, result);
-            EnqueueBlock(result, x => PopulateBlock(ast, x));
-
+            _queue.EnqueueBlock(result, x => PopulateBlock(ast, x));
             return result;
         }
 
@@ -76,7 +75,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                     return MetaBlock.Invalid;
             }
 
-            EnqueueBlock(result, x => PopulateBlock(ast, x));
+            _queue.EnqueueBlock(result, x => PopulateBlock(ast, x));
             return result;
         }
     }

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.CreateMetaProperty.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.CreateMetaProperty.cs
@@ -58,12 +58,11 @@ namespace Uno.Compiler.Core.Syntax.Builders
             }
 
             var result = new MetaProperty(ast.Name.Source, parent, dt, ast.Name.Symbol, visibility);
-            _enqueuedProperties.Add(new KeyValuePair<AstMetaProperty, MetaProperty>(ast, result));
-
+            _queue.EnqueueMetaProperty(ast, result);
             return result;
         }
 
-        void CompileMetaPropertyDefinitions(AstMetaProperty ast, MetaProperty mp)
+        internal void CompileMetaPropertyDefinitions(AstMetaProperty ast, MetaProperty mp)
         {
             var defs = new MetaDefinition[ast.Definitions.Count];
 

--- a/src/compiler/core/Syntax/Builders/BlockBuilder.FlattenType.cs
+++ b/src/compiler/core/Syntax/Builders/BlockBuilder.FlattenType.cs
@@ -8,7 +8,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
     {
         internal readonly Dictionary<DataType, HashSet<DataType>> FlattenedTypes = new Dictionary<DataType, HashSet<DataType>>();
 
-        void FlattenTypes()
+        internal void FlattenTypes()
         {
             FlattenTypes(_il);
 

--- a/src/compiler/core/Syntax/Builders/BuildQueue.cs
+++ b/src/compiler/core/Syntax/Builders/BuildQueue.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using Uno.Compiler.API.Backends;
+using Uno.Compiler.API.Domain.AST.Members;
+using Uno.Compiler.API.Domain.AST.Statements;
+using Uno.Compiler.API.Domain.Graphics;
+using Uno.Compiler.API.Domain.IL;
+using Uno.Compiler.API.Domain.IL.Members;
+using Uno.Compiler.Core.Syntax.Compilers;
+using Uno.Compiler.Core.Syntax.Generators;
+using Uno.Logging;
+
+namespace Uno.Compiler.Core.Syntax.Builders
+{
+    public class BuildQueue : LogObject
+    {
+        readonly BuildEnvironment _env;
+        readonly Backend _backend;
+        readonly Compiler _compiler;
+        readonly List<BlockBase> _enqueuedBlocks = new List<BlockBase>();
+        readonly List<KeyValuePair<AstMetaProperty, MetaProperty>> _enqueuedMetaProperties = new List<KeyValuePair<AstMetaProperty, MetaProperty>>();
+        readonly HashSet<DataType> _enqueuedDrawClasses = new HashSet<DataType>();
+        readonly List<FunctionCompiler> _enqueuedFunctions = new List<FunctionCompiler>();
+        readonly List<Entity> _enqueuedAttributes = new List<Entity>();
+        readonly List<DataType> _enqueuedTypes = new List<DataType>();
+        readonly List<Action> _enqueuedActions = new List<Action>();
+        int _assignBaseTypeIndex;
+        int _populateMembersIndex;
+
+        public BuildQueue(Log log, BuildEnvironment env, Backend backend, Compiler compiler)
+            : base(log)
+        {
+            _env = env;
+            _backend = backend;
+            _compiler = compiler;
+        }
+
+        internal FunctionCompiler EnqueueFunction(Function func, DataType parameterizedParent, AstScope body)
+        {
+            var fc = new FunctionCompiler(_compiler, func, parameterizedParent, body);
+            func.Tag = fc;
+
+            if (_env.IsGeneratingCode)
+                func.Stats |= EntityStats.CanLink;
+            else if (body != null)
+                _enqueuedFunctions.Add(fc);
+            else if (_compiler.Backend.CanLink(func))
+                func.Stats |= EntityStats.CanLink;
+
+            return fc;
+        }
+
+        internal void EnqueueDrawClass(DataType declaringType)
+        {
+            _enqueuedDrawClasses.Add(declaringType);
+        }
+
+        internal void EnqueueType(DataType dt, Action<DataType> assignBaseType, Action<DataType> populate)
+        {
+            if (_env.IsGeneratingCode)
+            {
+                assignBaseType(dt);
+                populate(dt);
+                return;
+            }
+
+            dt.AssigningBaseType = assignBaseType;
+            dt.PopulatingMembers = x =>
+            {
+                populate(x);
+                x.Stats &= ~EntityStats.PopulatingMembers;
+            };
+            dt.Stats |= EntityStats.PopulatingMembers;
+            _enqueuedTypes.Add(dt);
+        }
+
+        internal void EnqueueAttributes(Entity e, Action<Entity> assign)
+        {
+            e.AssigningAttributes = assign;
+            _enqueuedAttributes.Add(e);
+        }
+
+        internal void EnqueueAttributes(Member e, DataType parameterizedParent, IReadOnlyList<AstAttribute> attributes)
+        {
+            if (attributes.Count > 0)
+                EnqueueAttributes(e, x => e.SetAttributes(_compiler.CompileAttributes(parameterizedParent, attributes)));
+        }
+
+        public void BuildTypes()
+        {
+            for (int count = 0, j = 0; count != _enqueuedTypes.Count && j < 10; j++)
+            {
+                count = _enqueuedTypes.Count;
+
+                while (_assignBaseTypeIndex < count)
+                    _enqueuedTypes[_assignBaseTypeIndex++].AssignBaseType();
+
+                for (int i = 0; i < _enqueuedAttributes.Count; i++)
+                    _enqueuedAttributes[i].AssignAttributes();
+
+                _enqueuedAttributes.Clear();
+
+                while (_populateMembersIndex < count)
+                    if (_backend.CanLink(_enqueuedTypes[_populateMembersIndex]))
+                        _enqueuedTypes[_populateMembersIndex++].Stats |= EntityStats.CanLink;
+                    else
+                        _enqueuedTypes[_populateMembersIndex++].PopulateMembers();
+
+                for (int i = 0; i < _enqueuedActions.Count; i++)
+                    _enqueuedActions[i]();
+
+                _enqueuedActions.Clear();
+            }
+
+            for (; _populateMembersIndex < _enqueuedTypes.Count; _populateMembersIndex++)
+                Log.Warning(_enqueuedTypes[_populateMembersIndex].Source, ErrorCode.I0000, "Unable to parameterize " + _enqueuedTypes[_populateMembersIndex].Quote());
+
+            _assignBaseTypeIndex = _populateMembersIndex;
+        }
+
+        public void BuildTypesAndFunctions()
+        {
+            BuildTypes();
+
+            for (var i = 0; i < _enqueuedFunctions.Count; i++)
+            {
+                _enqueuedFunctions[i].Compile();
+                BuildTypes();
+            }
+
+            _enqueuedFunctions.Clear();
+            _enqueuedTypes.Clear();
+
+            _assignBaseTypeIndex = 0;
+            _populateMembersIndex = 0;
+        }
+
+        public void BuildEverything()
+        {
+            _compiler.BlockBuilder.FlattenTypes();
+
+            do
+            {
+                BuildTypesAndFunctions();
+                BuildBlocks();
+                BuildMetaProperties();
+
+                foreach (var dt in _enqueuedDrawClasses)
+                    DrawCallGenerator.GenerateDrawCalls(_compiler, dt);
+
+                _enqueuedDrawClasses.Clear();
+
+            } while (_enqueuedFunctions.Count > 0);
+        }
+
+        public void BuildBlocks()
+        {
+            for (var i = 0; i < _enqueuedBlocks.Count; i++)
+                if (!_enqueuedBlocks[i].Source.Bundle.CanLink)
+                    _enqueuedBlocks[i].Populate();
+
+            _enqueuedBlocks.Clear();
+        }
+
+        internal void EnqueueBlock(BlockBase b, Action<BlockBase> populate)
+        {
+            b.Populating = populate;
+            _enqueuedBlocks.Add(b);
+        }
+
+        public void BuildMetaProperties()
+        {
+            for (var i = 0; i < _enqueuedMetaProperties.Count; i++)
+                _compiler.BlockBuilder.CompileMetaPropertyDefinitions(_enqueuedMetaProperties[i].Key, _enqueuedMetaProperties[i].Value);
+
+            _enqueuedMetaProperties.Clear();
+        }
+
+        public void EnqueueMetaProperty(AstMetaProperty ast, MetaProperty result)
+        {
+            _enqueuedMetaProperties.Add(new KeyValuePair<AstMetaProperty, MetaProperty>(ast, result));
+        }
+
+        internal void Enqueue(Action action)
+        {
+            _enqueuedActions.Add(action);
+        }
+    }
+}

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateClass.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateClass.cs
@@ -68,9 +68,9 @@ namespace Uno.Compiler.Core.Syntax.Builders
                     _compiler.AstProcessor.CreateBlock(b as AstBlockBase, result, astClass.Members);
 
             if (astClass.Attributes.Count > 0)
-                EnqueueAttributes(result, x =>
+                _queue.EnqueueAttributes(result, x =>
                 {
-                    result.SetAttributes(_compiler.CompileAttributes(result.Parent, astClass.Attributes));
+                    result.SetAttributes(_compiler.CompileAttributes(parent, astClass.Attributes));
 
                     // Remove default constructor if TargetSpecificType
                     if (result.HasAttribute(_ilf.Essentials.TargetSpecificTypeAttribute) &&
@@ -78,7 +78,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                         result.Constructors.Clear();
                 });
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 x => CompileBaseTypes(x, astClass.Bases),
                 x => PopulateClass(astClass, x));
         }

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateDelegate.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateDelegate.cs
@@ -29,23 +29,23 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(src, ErrorCode.I3019, "'delegate' cannot contain members");
 
             if (ast.Attributes.Count > 0)
-                EnqueueAttributes(result,
-                    x => result.SetAttributes(_compiler.CompileAttributes(result.Parent, ast.Attributes)));
+                _queue.EnqueueAttributes(result,
+                    _ => result.SetAttributes(_compiler.CompileAttributes(parent, ast.Attributes)));
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 assignBaseType: x =>
                 {
                     var deferredActions = new List<Action>();
-                    var parameterizedType = Parameterize(result);
+                    var parameterizedType = Parameterize(x);
 
                     result.SetBase(_ilf.Essentials.Delegate);
-                    result.SetReturnType(_resolver.GetType(result, ast.ReturnType));
-                    result.SetParameters(_compiler.CompileParameterList(result, ast.Parameters, deferredActions));
+                    result.SetReturnType(_resolver.GetType(x, ast.ReturnType));
+                    result.SetParameters(_compiler.CompileParameterList(x, ast.Parameters, deferredActions));
 
                     if (parameterizedType != result)
                     {
                         var parameterizedDelegate = (DelegateType)parameterizedType;
-                        parameterizedDelegate.SetBase(result.Base);
+                        parameterizedDelegate.SetBase(x.Base);
                         parameterizedDelegate.SetReturnType(result.ReturnType);
                         parameterizedDelegate.SetParameters(result.Parameters);
                     }

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.CreateEnum.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.CreateEnum.cs
@@ -39,10 +39,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 Log.Error(result.Source, ErrorCode.I3037, "'enum' is not allowed in this context");
 
             if (ast.Attributes.Count > 0)
-                EnqueueAttributes(result,
-                    x => result.SetAttributes(_compiler.CompileAttributes(result.Parent, ast.Attributes)));
+                _queue.EnqueueAttributes(result,
+                    _ => result.SetAttributes(_compiler.CompileAttributes(parent, ast.Attributes)));
 
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 assignBaseType: x =>
                 {
                     x.SetBase(ast.OptionalBaseType != null
@@ -102,7 +102,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
                             s.DocComment, Modifiers.Public, parameterizedType, TypedEnumValue(parameterizedType.Base, value));
 
                         if (s.Attributes.Count > 0)
-                            EnqueueAttributes(literal,
+                            _queue.EnqueueAttributes(literal,
                                 _ => literal.SetAttributes(_compiler.CompileAttributes(result, s.Attributes)));
 
                         result.Literals.Add(literal);

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
@@ -186,9 +186,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             result.SetMasterDefinition(definition.MasterDefinition);
             ParameterizeInnerTypes(definition, definition, map, result);
-            EnqueueType(result,
+            _queue.EnqueueType(result,
                 x => ParameterizeBaseType(definition, map, x),
                 x => ParameterizeMembers(definition, definition, map, x));
+
             return result;
         }
 
@@ -292,7 +293,7 @@ namespace Uno.Compiler.Core.Syntax.Builders
 
             if (result != null)
             {
-                map.Add(arg, result);
+                map[arg] = result;
                 return result;
             }
 
@@ -361,17 +362,23 @@ namespace Uno.Compiler.Core.Syntax.Builders
             {
                 var e = current.NestedTypes[i];
                 var t = CreateParameterizableInnerType(e, result);
+                result.NestedTypes.Add(t);
 
                 if (e.IsGenericDefinition)
                     t.MakeGenericDefinition(e.GenericParameters);
 
                 t.SetMasterDefinition(e.MasterDefinition);
 
-                EnqueueType(t,
+                _queue.EnqueueType(t,
                     x => ParameterizeBaseType(e, map, x),
                     x => ParameterizeMembers(definition, e, map, x));
+            }
+
+            for (int i = 0; i < current.NestedTypes.Count; i++)
+            {
+                var e = current.NestedTypes[i];
+                var t = result.NestedTypes[i];
                 ParameterizeInnerTypes(definition, e, map, t);
-                result.NestedTypes.Add(t);
             }
         }
 

--- a/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
+++ b/src/compiler/core/Syntax/Builders/TypeBuilder.Parameterize.cs
@@ -241,6 +241,10 @@ namespace Uno.Compiler.Core.Syntax.Builders
                 {
                     bool innerTypeFound = false;
 
+                    // Lazy populate nested types
+                    if (p.NestedTypes.Count == 0)
+                        ParameterizeInnerTypes(p.MasterDefinition, p.MasterDefinition, map, p);
+
                     foreach (var it in p.NestedTypes)
                     {
                         if (arg.MasterDefinition == it.MasterDefinition)

--- a/src/compiler/core/Syntax/Compilers/FunctionCompiler.NameResolver.TypeExtension.cs
+++ b/src/compiler/core/Syntax/Compilers/FunctionCompiler.NameResolver.TypeExtension.cs
@@ -46,12 +46,17 @@ namespace Uno.Compiler.Core.Syntax.Compilers
             var extensionMethods = new List<Method>();
 
             foreach (var dt in staticClasses)
+            {
+                // Lazy populate methods
+                dt.PopulateMembers();
+
                 foreach (var m in dt.Methods)
                     if (m.IsStatic &&
                         m.Parameters.Length > 0 && m.Parameters[0].Modifier == ParameterModifier.This &&
                         (typeParamCount == null || m.IsGenericDefinition && m.GenericParameters.Length == typeParamCount) &&
                         m.Name == name)
                         extensionMethods.Add(m);
+            }
 
             if (extensionMethods.Count == 0)
                 return null;

--- a/src/compiler/core/Syntax/Generators/DrawCallGenerator.cs
+++ b/src/compiler/core/Syntax/Generators/DrawCallGenerator.cs
@@ -94,6 +94,8 @@ namespace Uno.Compiler.Core.Syntax.Generators
 
         static void GenerateDrawCalls(Compiler compiler, Method initMethod, Method freeMethod, DrawBlock drawBlock, HashSet<Scope> drawScopes)
         {
+            compiler.Queue.BuildMetaProperties();
+
             foreach (var drawable in drawBlock.Drawables)
             {
                 new ShaderGenerator(compiler, drawable, initMethod.Body, freeMethod.Body, drawBlock.DrawScope).Generate();

--- a/src/compiler/core/Syntax/UxlProcessor.cs
+++ b/src/compiler/core/Syntax/UxlProcessor.cs
@@ -254,6 +254,7 @@ namespace Uno.Compiler.Core.Syntax
                 return;
             }
 
+            dt.AssignAttributes();
             if (!dt.IsIntrinsic &&
                 !dt.HasAttribute(_ilf.Essentials.TargetSpecificImplementationAttribute) &&
                 !dt.HasAttribute(_ilf.Essentials.TargetSpecificTypeAttribute))
@@ -326,6 +327,7 @@ namespace Uno.Compiler.Core.Syntax
             else if (!method.ReturnType.IsVoid)
                 Log.Error(uxl.Signature.Source, ErrorCode.E0000, "Requiring return type for " + method.Quote() + " (" + method.ReturnType + ")");
 
+            method.AssignAttributes();
             if (!method.HasAttribute(_ilf.Essentials.TargetSpecificImplementationAttribute) &&
                 !method.IsIntrinsic)
                 Log.Error(uxl.Signature.Source, ErrorCode.E0000, method.Quote() + " cannot be extended because it does not specify " + _ilf.Essentials.TargetSpecificImplementationAttribute.AttributeString);

--- a/src/compiler/frontend/SourceReader.cs
+++ b/src/compiler/frontend/SourceReader.cs
@@ -7,7 +7,6 @@ using Uno.Compiler.API;
 using Uno.Compiler.API.Domain.AST;
 using Uno.Compiler.API.Domain.AST.Expressions;
 using Uno.Compiler.API.Domain.UXL;
-using Uno.Compiler.Frontend.Analysis;
 using Uno.IO;
 using Uno.Logging;
 

--- a/src/ux/markup/CompilerReflection/ILCache.cs
+++ b/src/ux/markup/CompilerReflection/ILCache.cs
@@ -35,7 +35,7 @@ namespace Uno.UX.Markup.CompilerReflection
 
             try
             {
-                compiler.TypeBuilder.BuildTypes();
+                compiler.Queue.BuildTypes();
             }
             catch (Exception)
             {


### PR DESCRIPTION
### cil: update run scripts

Apps that are not console apps or tests should be run without using the
dotnet command on macOS.

### compiler: make sure all references are linkable

This fixes errors with subsequent builds experienced when using the
dotnet backend on macOS (while running Fuselibs tests).

### test.sh: test subsequent builds

Make sure it still works when building the same projects a second time.

### compiler: fix build queue regressions

This fixes five problems experienced on subsequent builds using the
dotnet backend (regressed in 40403e7):

* Resolving an extension method
* Resolving the application constructor in TestTestupTransform
* Resolving sizeof expressions
* Resolving a type nested inside a generic type
* Validating a generic type argument

All problems were already fixed on the lazy branch so the fixes were
cherry-picked together with a few similar fixes.

### Revert "Revert "compiler: refactor build queue""

This reverts commit 02f2177804edc94545318773244428af24ac46ff.