### PR TITLE
uno-test: don't print stats with --build-only (beta-3.0)

### DIFF
--- a/src/test/runner/UnoTest.cs
+++ b/src/test/runner/UnoTest.cs
@@ -29,7 +29,7 @@ namespace Uno.TestRunner
 
             var failedCount = tests.Count(t => t.Failed);
 
-            if (discoveredProjects.Length > 1)
+            if (discoveredProjects.Length > 1 && tests.Count > 0)
             {
                 logger.Log("Since you ran multiple projects, here is a summary:");
                 logger.Log("From {0} projects, ran {1} tests, {2} failed.", discoveredProjects.Length, tests.Count, failedCount);


### PR DESCRIPTION
This restructures TestProjectRunner.cs a little to make it slightly cleaner and to early out before reaching _logger.ProjectEnded(tests) if the --build-only flag was passed.