### PR TITLE
install xcode-devteams (beta-3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "@fuse-open/opentk": "^3.2.0",
         "@fuse-open/transpiler": "^1.18.0",
-        "dotnet-run": "^2.0.0"
+        "dotnet-run": "^2.0.0",
+        "xcode-devteams": "^1.0.1"
       },
       "bin": {
         "uno": "bin/uno.js"
@@ -106,6 +107,14 @@
         "bash": "cli.js",
         "xbash": "cli.js"
       }
+    },
+    "node_modules/xcode-devteams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xcode-devteams/-/xcode-devteams-1.0.1.tgz",
+      "integrity": "sha512-7TbAgRpOqisPkQUwQzUKw5gJachoIu9PZGVswqxEbFLaT7l3fWTKGM+NgCIrZEG/gySWm3bILC3bHfwhqMGuuw==",
+      "bin": {
+        "xcode-devteams": "cli.js"
+      }
     }
   },
   "dependencies": {
@@ -169,6 +178,11 @@
       "requires": {
         "which": "^2.0.2"
       }
+    },
+    "xcode-devteams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xcode-devteams/-/xcode-devteams-1.0.1.tgz",
+      "integrity": "sha512-7TbAgRpOqisPkQUwQzUKw5gJachoIu9PZGVswqxEbFLaT7l3fWTKGM+NgCIrZEG/gySWm3bILC3bHfwhqMGuuw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@fuse-open/opentk": "^3.2.0",
     "@fuse-open/transpiler": "^1.18.0",
-    "dotnet-run": "^2.0.0"
+    "dotnet-run": "^2.0.0",
+    "xcode-devteams": "^1.0.1"
   },
   "devDependencies": {
     "filecompare": "^1.0.4",

--- a/src/tool/engine/Targets/iOSBuild.cs
+++ b/src/tool/engine/Targets/iOSBuild.cs
@@ -25,7 +25,7 @@ namespace Uno.Build.Targets
 
         public override void Configure(ICompiler compiler)
         {
-            XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles);
+            XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles, compiler.Shell);
         }
     }
 }

--- a/src/tool/engine/Targets/iOSSimulatorBuild.cs
+++ b/src/tool/engine/Targets/iOSSimulatorBuild.cs
@@ -27,7 +27,7 @@ namespace Uno.Build.Targets
 
         public override void Configure(ICompiler compiler)
         {
-            XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles);
+            XcodeGenerator.Configure(compiler.Environment, compiler.Data.Extensions.BundleFiles, compiler.Shell);
         }
     }
 }


### PR DESCRIPTION
This uses the native xcode-devteams utility to get information about Xcode developer teams and restores the functionality that was removed in ead12f8.