### PR TITLE
uno test: add --clean parameter (beta-3.0)

### DIFF
--- a/src/test/runner/TestOptions.cs
+++ b/src/test/runner/TestOptions.cs
@@ -16,6 +16,7 @@ namespace Uno.TestRunner
         public bool DontUninstall;
         public bool UpdateLibrary;
         public string OutputDirectory;
+        public bool Clean;
         public readonly List<string> Defines = new List<string>();
         public readonly List<string> Undefines = new List<string>();
     }

--- a/src/test/runner/TestProjectRunner.cs
+++ b/src/test/runner/TestProjectRunner.cs
@@ -44,7 +44,8 @@ namespace Uno.TestRunner
                     TestFilter = _options.Filter,
                     OutputDirectory = outputDirectory,
                     WarningLevel = 1,
-                    UpdateLibrary = _options.UpdateLibrary
+                    UpdateLibrary = _options.UpdateLibrary,
+                    Clean = _options.Clean
                 };
 
                 options.Defines.AddRange(_options.Defines);

--- a/src/tool/cli/Building/Test.cs
+++ b/src/tool/cli/Building/Test.cs
@@ -45,6 +45,7 @@ namespace Uno.CLI.Building
             WriteRow("-D, --define=STRING",         "Add define, to enable a feature");
             WriteRow("-U, --undefine=STRING",       "Remove define, to disable a feature");
             WriteRow("-o, --out-dir=PATH",          "Override output directory");
+            WriteRow("-z, --clean",                 "Clean the output directory before building");
 
             WriteHead("Available build targets", 19);
 
@@ -115,6 +116,7 @@ namespace Uno.CLI.Building
                 { "U=|undefine=",           options.Undefines.Add },
                 { "o=|out-dir=|output-dir=",    v => options.OutputDirectory = v },
                 { "libs",                   v => options.UpdateLibrary = true },
+                { "z|clean",                v => options.Clean = true },
             };
 
             try


### PR DESCRIPTION
Pass --clean or -z to clean the output directory when building tests, like the "uno build" command already supports.