### PR TITLE
engine: fix library enumerator in BundleCache (beta-3.0)

### DIFF
--- a/src/tool/engine/Libraries/BundleCache.cs
+++ b/src/tool/engine/Libraries/BundleCache.cs
@@ -72,11 +72,17 @@ namespace Uno.Build.Libraries
                 result = new List<DirectoryInfo>();
                 _library.Add(library, result);
 
-                foreach (var feed in SearchPaths)
+                foreach (var searchPath in SearchPaths)
                 {
                     DirectoryInfo dir;
-                    if (!GetLibraryDirectories(feed).TryGetValue(library, out dir))
+                    if (!GetLibraryDirectories(searchPath).TryGetValue(library, out dir))
                         continue;
+
+                    if (ManifestFile.Exists(dir.FullName))
+                    {
+                        result.Add(dir);
+                        continue;
+                    }
 
                     var versions = dir.GetDirectories();
                     Array.Sort(versions, (left, right) => VersionRange.Compare(right.Name, left.Name));


### PR DESCRIPTION
This makes "uno config -l" list all libraries again, missed in fa61353.