### PR TITLE
android: upgrade to Gradle 8.2 (beta-3.0)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - ps: |
       if ($env:TARGET -eq "android") {
-        Invoke-Expression "npm install android-build-tools@1.x -g"
+        Invoke-Expression "npm install android-build-tools@2.x -g"
       }
   - ps: |
       if ($env:TARGET -eq "native") {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,22 +46,20 @@ which might have unintended side-effects.
 
 ### Android
 
-To support building Android apps, we need to know where your [Android SDKs](https://developer.android.com/studio/index.html)
-are installed. Running `npm install -g android-build-tools@1.x` will set this up automatically, or you can
+To support building Android apps, we need to know where your [Android SDK](https://developer.android.com/studio/index.html)
+is installed. Running `npm install android-build-tools@2.x -g` will set this up automatically, or you can
 specify other locations as demonstrated below.
 
 ### Windows
 
 ```javascript
-android.ndk: `%LOCALAPPDATA%\Android\sdk\ndk-bundle`
 android.sdk: `%LOCALAPPDATA%\Android\sdk`
-java.jdk: `%PROGRAMFILES%\Java\jdk1.8.0_40`
+java.jdk: `%PROGRAMFILES%\Java\jdk17`
 ```
 
 ### macOS
 
 ```javascript
-android.ndk: ~/Library/Android/sdk/ndk-bundle
 android.sdk: ~/Library/Android/sdk
 ```
 

--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -20,7 +20,7 @@
     <Set JDK.Directory="@(Config.Java.JDK:Path || Config.Java.JDK.Directory:Path || JAVA_HOME:Env)" />
     <Set NDK.PlatformVersion="@(Project.Android.NDK.PlatformVersion || Config.Android.NDK.PlatformVersion || '16')" />
     <Set NDK.Version="@(Project.Android.NDK.Version || Config.Android.NDK.Version || '21.4.7075529')" />
-    <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '30.0.3')" />
+    <Set SDK.BuildToolsVersion="@(Project.Android.SDK.BuildToolsVersion || Config.Android.SDK.BuildToolsVersion || '33.0.1')" />
     <Set SDK.CompileVersion="@(Project.Android.SDK.CompileVersion || Config.Android.SDK.CompileVersion || '33')" />
     <Set SDK.Directory="@(Config.Android.SDK:Path || Config.Android.SDK.Directory:Path || ANDROID_SDK:Env)" />
     <Set SDK.MinVersion="@(Project.Android.SDK.MinVersion || Config.Android.SDK.MinVersion || '19')" />

--- a/lib/UnoCore/android/app/build.gradle
+++ b/lib/UnoCore/android/app/build.gradle
@@ -42,10 +42,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion = @(SDK.CompileVersion)
-    buildToolsVersion = '@(SDK.BuildToolsVersion)'
-
+    compileSdkVersion @(SDK.CompileVersion)
+    buildToolsVersion '@(SDK.BuildToolsVersion)'
     ndkVersion '@(NDK.Version)'
+
+    namespace '@(Activity.Package)'
 
     defaultConfig {
 #if !@(LIBRARY:Defined)

--- a/lib/UnoCore/android/build.bat
+++ b/lib/UnoCore/android/build.bat
@@ -9,7 +9,7 @@ echo ERROR: Could not locate the Android SDK. >&2
 echo. >&2
 echo This dependency can be acquired by installing 'android-build-tools': >&2
 echo. >&2
-echo     npm install android-build-tools@1.x -g >&2
+echo     npm install android-build-tools@2.x -g >&2
 echo. >&2
 echo After installing, pass --force to make sure the new configuration is picked up. >&2
 echo. >&2

--- a/lib/UnoCore/android/build.sh
+++ b/lib/UnoCore/android/build.sh
@@ -9,7 +9,7 @@ echo "ERROR: Could not locate the Android SDK." >&2
 echo "" >&2
 echo "This dependency can be acquired by installing 'android-build-tools':" >&2
 echo "" >&2
-echo "    npm install android-build-tools@1.x -g" >&2
+echo "    npm install android-build-tools@2.x -g" >&2
 echo "" >&2
 echo "After installing, pass --force to make sure the new configuration is picked up." >&2
 echo "" >&2

--- a/lib/UnoCore/android/dependencies.uxl
+++ b/lib/UnoCore/android/dependencies.uxl
@@ -6,7 +6,7 @@
     <Require Gradle.BuildScript.Repository="mavenCentral()" />
     <Require Gradle.Repository="maven { url 'https://maven.google.com' }" />
 
-    <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:7.4.2" />
+    <Require Gradle.Dependency.ClassPath="com.android.tools.build:gradle:8.1.0" />
     <Require Gradle.Dependency.Implementation="androidx.appcompat:appcompat:1.4.2" />
     <Require Gradle.Dependency.Implementation="com.google.android.material:material:1.6.1" />
 

--- a/lib/UnoCore/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/UnoCore/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
Requires JDK 17. Run `npm install android-build-tools@2.x -g` to update your configuration after installing JDK 17.

* gradle-plugin -> 8.1.0
* gradle-wrapper -> 8.2
* build-tools -> 33.0.1
* add namespace in build.gradle
* update configuration.md