### PR TITLE
Bump min version of Android and iOS and upgrade Kotlin and Swift version

### DIFF
--- a/lib/UnoCore/android/android.uxl
+++ b/lib/UnoCore/android/android.uxl
@@ -21,10 +21,10 @@
     <set ndk.platformVersion="@(project.android.ndk.platformVersion || config.android.ndk.platformVersion || '16')" />
     <set ndk.version="@(project.android.ndk.version || config.android.ndk.version || '21.4.7075529')" />
     <set sdk.buildToolsVersion="@(project.android.sdk.buildToolsVersion || config.android.sdk.buildToolsVersion || '33.0.1')" />
-    <set sdk.compileVersion="@(project.android.sdk.compileVersion || config.android.sdk.compileVersion || '33')" />
+    <set sdk.compileVersion="@(project.android.sdk.compileVersion || config.android.sdk.compileVersion || '34')" />
     <set sdk.directory="@(config.android.sdk:path || config.android.sdk.directory:path || ANDROID_SDK:env)" />
-    <set sdk.minVersion="@(project.android.sdk.minVersion || config.android.sdk.minVersion || '19')" />
-    <set sdk.targetVersion="@(project.android.sdk.targetVersion || config.android.sdk.targetVersion || '33')" />
+    <set sdk.minVersion="@(project.android.sdk.minVersion || config.android.sdk.minVersion || '21')" />
+    <set sdk.targetVersion="@(project.android.sdk.targetVersion || config.android.sdk.targetVersion || '34')" />
 
     <!-- Build properties -->
 
@@ -55,6 +55,7 @@
     <declare element="gradle.dependency.debugImplementation" />
     <declare element="gradle.dependency.releaseImplementation" />
     <declare element="gradle.dependency.nativeImplementation" />
+    <declare element="gradle.android.end" />
     <declare element="gradle.buildFile.end" />
     <declare element="gradle.repository" />
     <declare element="gradle.buildScript.repository" />

--- a/lib/UnoCore/android/app/build.gradle
+++ b/lib/UnoCore/android/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.@(LIBRARY:defined:test('library', 'application'))'
 #if @(KOTLIN:defined)
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 #endif
 
 configurations { native_implementation }
@@ -42,8 +41,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion @(sdk.compileVersion)
-    buildToolsVersion '@(sdk.buildToolsVersion)'
+    compileSdk @(sdk.compileVersion)
     ndkVersion '@(ndk.version)'
 
     namespace '@(activity.package)'
@@ -52,8 +50,8 @@ android {
 #if !@(LIBRARY:defined)
         applicationId = '@(activity.package)'
 #endif
-        minSdkVersion @(sdk.minVersion)
-        targetSdkVersion @(sdk.targetVersion)
+        minSdk @(sdk.minVersion)
+        targetSdk @(sdk.targetVersion)
         versionCode = @(project.android.versionCode)
         versionName = '@(project.android.versionName)'
         multiDexEnabled @(project.android.multiDexEnabled:isSet:test(@(project.android.multiDexEnabled:bool),true))
@@ -151,6 +149,18 @@ android {
     lintOptions {
         checkReleaseBuilds = false
     }
+
+#if @(KOTLIN:defined)
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+#endif
+
+    @(gradle.android.end:join('\n'))
 }
 
 @(gradle.buildFile.end:join('\n'))

--- a/lib/UnoCore/android/dependencies.uxl
+++ b/lib/UnoCore/android/dependencies.uxl
@@ -6,13 +6,12 @@
     <require gradle.buildScript.repository="mavenCentral()" />
     <require gradle.repository="maven { url 'https://maven.google.com' }" />
 
-    <require gradle.dependency.classPath="com.android.tools.build:gradle:8.1.0" />
+    <require gradle.dependency.classPath="com.android.tools.build:gradle:8.1.4" />
     <require gradle.dependency.implementation="androidx.appcompat:appcompat:1.4.2" />
     <require gradle.dependency.implementation="com.google.android.material:material:1.6.1" />
 
     <!-- Kotlin support. -->
-    <require condition="KOTLIN" gradle.dependency.implementation="androidx.core:core-ktx:+" />
-    <require condition="KOTLIN" gradle.dependency.implementation="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70" />
-    <require condition="KOTLIN" gradle.dependency.classPath="org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70" />
+    <require condition="KOTLIN" gradle.dependency.implementation="androidx.core:core-ktx:1.10.1" />
+    <require condition="KOTLIN" gradle.dependency.classPath="org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25" />
 
 </extensions>

--- a/lib/UnoCore/android/gradle.properties
+++ b/lib/UnoCore/android/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx2048m
 @(Gradle.Properties:Join('\n'))

--- a/lib/UnoCore/ios/@(project.name).xcodeproj/project.pbxproj
+++ b/lib/UnoCore/ios/@(project.name).xcodeproj/project.pbxproj
@@ -518,7 +518,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = @(bundleIdentifier);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = @(project.ios.swiftVersion || "3.0");
+				SWIFT_VERSION = @(project.ios.swiftVersion || "5.0");
 			};
 			name = Debug;
 		};
@@ -567,7 +567,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = @(bundleIdentifier);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = @(project.ios.swiftVersion || "3.0");
+				SWIFT_VERSION = @(project.ios.swiftVersion || "5.0");
 #if @(LIBRARY:defined)
 				WRAPPER_EXTENSION = framework;
 #else

--- a/src/tool/project/PropertyDefinitions.cs
+++ b/src/tool/project/PropertyDefinitions.cs
@@ -58,7 +58,7 @@ namespace Uno.ProjectFormat
             {"ios.statusBarHidden", PropertyType.Bool, "!$(mobile.showStatusbar)"},
             {"ios.statusBarStyle", PropertyType.String, "Default"},
             {"ios.defines", PropertyType.String},
-            {"ios.deploymentTarget", PropertyType.String, "11.0"},
+            {"ios.deploymentTarget", PropertyType.String, "13.0"},
             {"ios.developmentTeam", PropertyType.String},
             {"ios.icons.iphone_20_2x", PropertyType.Path, "$(icon)"},
             {"ios.icons.iphone_20_3x", PropertyType.Path, "$(icon)"},


### PR DESCRIPTION
#### Android:

This commit bump minimum Android SDK now 21 and target SDK 34, and also upgrade Gradle version to 8.1.4 and more Kotlin Supports. 

#### iOS:

This commit bump minimum iOS version to 13 and Swift version to 5.